### PR TITLE
chore: remove candid crate from examples

### DIFF
--- a/examples/chess/src/chess_rs/Cargo.toml
+++ b/examples/chess/src/chess_rs/Cargo.toml
@@ -13,6 +13,5 @@ crate-type = ["cdylib"]
 [dependencies]
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.1.0" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.1.0" }
-candid = "0.6.2"
 serde = "1.0.111"
 pleco = "0.5.0"

--- a/examples/chess/src/chess_rs/Cargo.toml
+++ b/examples/chess/src/chess_rs/Cargo.toml
@@ -13,5 +13,6 @@ crate-type = ["cdylib"]
 [dependencies]
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.1.0" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.1.0" }
+candid = "0.6.2"
 serde = "1.0.111"
 pleco = "0.5.0"

--- a/examples/chess/src/chess_rs/lib.rs
+++ b/examples/chess/src/chess_rs/lib.rs
@@ -1,4 +1,4 @@
-use candid::CandidType;
+use ic_cdk::candid::CandidType;
 use ic_cdk::storage;
 use ic_cdk_macros::*;
 use pleco::tools::Searcher;

--- a/examples/chess/src/chess_rs/lib.rs
+++ b/examples/chess/src/chess_rs/lib.rs
@@ -1,4 +1,4 @@
-use ic_cdk::candid::CandidType;
+use ic_cdk::export::candid::CandidType;
 use ic_cdk::storage;
 use ic_cdk_macros::*;
 use pleco::tools::Searcher;

--- a/examples/counter/src/counter_rs/Cargo.toml
+++ b/examples/counter/src/counter_rs/Cargo.toml
@@ -14,5 +14,4 @@ crate-type = ["cdylib"]
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.1.0" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.1.0" }
 ic-types = "0.1.1"
-candid = "0.6.2"
 lazy_static = "1.4.0"

--- a/examples/counter/src/counter_rs/Cargo.toml
+++ b/examples/counter/src/counter_rs/Cargo.toml
@@ -14,4 +14,5 @@ crate-type = ["cdylib"]
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.1.0" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.1.0" }
 ic-types = "0.1.1"
+candid = "0.6.2"
 lazy_static = "1.4.0"

--- a/examples/counter/src/counter_rs/lib.rs
+++ b/examples/counter/src/counter_rs/lib.rs
@@ -1,5 +1,6 @@
 use ic_cdk_macros::*;
 use ic_types::Principal;
+use ic_cdk::candid;
 
 static mut COUNTER: Option<candid::Nat> = None;
 static mut OWNER: Option<Principal> = None;

--- a/examples/counter/src/counter_rs/lib.rs
+++ b/examples/counter/src/counter_rs/lib.rs
@@ -1,6 +1,5 @@
 use ic_cdk_macros::*;
-use ic_types::Principal;
-use ic_cdk::candid;
+use ic_cdk::export::{candid, Principal};
 
 static mut COUNTER: Option<candid::Nat> = None;
 static mut OWNER: Option<Principal> = None;

--- a/examples/counter/src/inter2_rs/Cargo.toml
+++ b/examples/counter/src/inter2_rs/Cargo.toml
@@ -13,4 +13,3 @@ crate-type = ["cdylib"]
 [dependencies]
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.1.0" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.1.0" }
-candid = "0.6.2"

--- a/examples/counter/src/inter2_rs/Cargo.toml
+++ b/examples/counter/src/inter2_rs/Cargo.toml
@@ -13,3 +13,4 @@ crate-type = ["cdylib"]
 [dependencies]
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.1.0" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.1.0" }
+candid = "0.6.2"

--- a/examples/counter/src/inter2_rs/lib.rs
+++ b/examples/counter/src/inter2_rs/lib.rs
@@ -1,5 +1,5 @@
 use ic_cdk_macros::*;
-use ic_cdk::candid;
+use ic_cdk::export::candid;
 
 #[import(canister = "inter_mo")]
 struct CounterCanister;

--- a/examples/counter/src/inter2_rs/lib.rs
+++ b/examples/counter/src/inter2_rs/lib.rs
@@ -1,4 +1,5 @@
 use ic_cdk_macros::*;
+use ic_cdk::candid;
 
 #[import(canister = "inter_mo")]
 struct CounterCanister;

--- a/examples/counter/src/inter_rs/Cargo.toml
+++ b/examples/counter/src/inter_rs/Cargo.toml
@@ -13,4 +13,4 @@ crate-type = ["cdylib"]
 [dependencies]
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.1.0" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.1.0" }
-candid = "0.6.2"
+

--- a/examples/counter/src/inter_rs/Cargo.toml
+++ b/examples/counter/src/inter_rs/Cargo.toml
@@ -13,4 +13,4 @@ crate-type = ["cdylib"]
 [dependencies]
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.1.0" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.1.0" }
-
+candid = "0.6.2"

--- a/examples/counter/src/inter_rs/lib.rs
+++ b/examples/counter/src/inter_rs/lib.rs
@@ -1,4 +1,5 @@
 use ic_cdk_macros::*;
+use ic_cdk::candid;
 
 #[import(canister = "counter_mo")]
 struct CounterCanister;

--- a/examples/counter/src/inter_rs/lib.rs
+++ b/examples/counter/src/inter_rs/lib.rs
@@ -1,5 +1,5 @@
 use ic_cdk_macros::*;
-use ic_cdk::candid;
+use ic_cdk::export::candid;
 
 #[import(canister = "counter_mo")]
 struct CounterCanister;

--- a/examples/print/src/print_rs/Cargo.toml
+++ b/examples/print/src/print_rs/Cargo.toml
@@ -13,5 +13,4 @@ crate-type = ["cdylib"]
 [dependencies]
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.1.0" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.1.0" }
-candid = "0.6.2"
-serde = "1.0.111"
+

--- a/examples/print/src/print_rs/Cargo.toml
+++ b/examples/print/src/print_rs/Cargo.toml
@@ -13,4 +13,5 @@ crate-type = ["cdylib"]
 [dependencies]
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.1.0" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.1.0" }
-
+candid = "0.6.2"
+serde = "1.0.111"

--- a/examples/profile/src/profile_inter_rs/Cargo.toml
+++ b/examples/profile/src/profile_inter_rs/Cargo.toml
@@ -13,5 +13,4 @@ crate-type = ["cdylib"]
 [dependencies]
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.1.0" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.1.0" }
-candid = "0.6.2"
 serde = "1.0.111"

--- a/examples/profile/src/profile_inter_rs/Cargo.toml
+++ b/examples/profile/src/profile_inter_rs/Cargo.toml
@@ -13,4 +13,5 @@ crate-type = ["cdylib"]
 [dependencies]
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.1.0" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.1.0" }
+candid = "0.6.2"
 serde = "1.0.111"

--- a/examples/profile/src/profile_rs/Cargo.toml
+++ b/examples/profile/src/profile_rs/Cargo.toml
@@ -14,5 +14,4 @@ crate-type = ["cdylib"]
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.1.0" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.1.0" }
 ic-types = "0.1.1"
-candid = "0.6.2"
 serde = "1.0.111"

--- a/examples/profile/src/profile_rs/Cargo.toml
+++ b/examples/profile/src/profile_rs/Cargo.toml
@@ -14,4 +14,5 @@ crate-type = ["cdylib"]
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.1.0" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.1.0" }
 ic-types = "0.1.1"
+candid = "0.6.2"
 serde = "1.0.111"

--- a/examples/profile/src/profile_rs/lib.rs
+++ b/examples/profile/src/profile_rs/lib.rs
@@ -1,8 +1,6 @@
-use ic_cdk::candid::CandidType;
+use ic_cdk::export::{candid::{CandidType, Deserialize}, Principal};
 use ic_cdk::storage;
 use ic_cdk_macros::*;
-use ic_types::Principal;
-use serde::Deserialize;
 use std::collections::BTreeMap;
 
 type IdStore = BTreeMap<String, Principal>;

--- a/examples/profile/src/profile_rs/lib.rs
+++ b/examples/profile/src/profile_rs/lib.rs
@@ -1,4 +1,4 @@
-use candid::CandidType;
+use ic_cdk::candid::CandidType;
 use ic_cdk::storage;
 use ic_cdk_macros::*;
 use ic_types::Principal;

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 proc-macro = true
 
 [dependencies]
-candid = { git = "https://github.com/dfinity/candid.git", branch = "derive-rename", version = "0.6.7", features = ["cdk"] }
+candid = "0.6.2"
 ic-cdk = { path = "../ic-cdk", version = "0.1" }
 syn = { version = "1.0", features = ["fold", "full"] }
 quote = "1.0"

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 proc-macro = true
 
 [dependencies]
-candid = { git = "https://github.com/dfinity/candid.git", branch = "derive-rename", version = "0.6.7", features = ["cdk"] }
+candid = { version = "0.6.8", features = ["cdk"] }
 ic-cdk = { path = "../ic-cdk", version = "0.1" }
 syn = { version = "1.0", features = ["fold", "full"] }
 quote = "1.0"

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 proc-macro = true
 
 [dependencies]
-candid = "0.6.2"
+candid = { git = "https://github.com/dfinity/candid.git", branch = "derive-rename", version = "0.6.7", features = ["cdk"] }
 ic-cdk = { path = "../ic-cdk", version = "0.1" }
 syn = { version = "1.0", features = ["fold", "full"] }
 quote = "1.0"

--- a/src/ic-cdk-macros/src/export.rs
+++ b/src/ic-cdk-macros/src/export.rs
@@ -24,10 +24,10 @@ enum MethodType {
 
 impl MethodType {
     pub fn is_lifecycle(&self) -> bool {
-        match self {
-            MethodType::Init | MethodType::PreUpgrade | MethodType::PostUpgrade => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            MethodType::Init | MethodType::PreUpgrade | MethodType::PostUpgrade
+        )
     }
 }
 

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["internet-computer", "types", "dfinity", "canister", "cdk"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
-candid = { git = "https://github.com/dfinity/candid.git", branch = "derive-rename", version = "0.6.7", features = ["cdk"] }
+candid = "0.6.2"
 cfg-if = "0.1.10"
 ic-types = "0.1.1"
 serde = "1.0.110"

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["internet-computer", "types", "dfinity", "canister", "cdk"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
-candid = "0.6.2"
+candid = { git = "https://github.com/dfinity/candid.git", branch = "derive-rename", version = "0.6.7", features = ["cdk"] }
 cfg-if = "0.1.10"
 ic-types = "0.1.1"
 serde = "1.0.110"

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["internet-computer", "types", "dfinity", "canister", "cdk"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
-candid = { git = "https://github.com/dfinity/candid.git", branch = "derive-rename", version = "0.6.7", features = ["cdk"] }
+candid = { version = "0.6.8", features = ["cdk"] }
 cfg-if = "0.1.10"
 ic-types = "0.1.1"
 serde = "1.0.110"

--- a/src/ic-cdk/src/lib.rs
+++ b/src/ic-cdk/src/lib.rs
@@ -13,9 +13,9 @@ pub use api::{caller, id, print, trap};
 static mut DONE: bool = false;
 
 pub mod export {
+    pub use candid;
     pub use ic_types::Principal;
 }
-pub use candid;
 
 /// Setup the stdlib hooks.
 pub fn setup() {

--- a/src/ic-cdk/src/lib.rs
+++ b/src/ic-cdk/src/lib.rs
@@ -15,6 +15,7 @@ static mut DONE: bool = false;
 pub mod export {
     pub use ic_types::Principal;
 }
+pub use candid;
 
 /// Setup the stdlib hooks.
 pub fn setup() {

--- a/src/ic-cdk/src/lib.rs
+++ b/src/ic-cdk/src/lib.rs
@@ -15,7 +15,6 @@ static mut DONE: bool = false;
 pub mod export {
     pub use ic_types::Principal;
 }
-pub use candid;
 
 /// Setup the stdlib hooks.
 pub fn setup() {


### PR DESCRIPTION
Export candid from `ic_cdk::candid`, and user projects are encouraged to use this alias for candid. This avoids problems when the candid version is different on the user project from the one used in CDK.