### PR TITLE
chore: set syn package's patch version

### DIFF
--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 [dependencies]
 candid = { version = "0.6.8", features = ["cdk"] }
 ic-cdk = { path = "../ic-cdk", version = "0.2" }
-syn = { version = "1.0", features = ["fold", "full"] }
+syn = { version = "1.0.58", features = ["fold", "full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 serde_tokenstream = "0.1.0"

--- a/src/ic-cdk-macros/src/export.rs
+++ b/src/ic-cdk-macros/src/export.rs
@@ -2,8 +2,8 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use serde::Deserialize;
 use serde_tokenstream::from_tokenstream;
+use std::fmt::Formatter;
 use std::sync::atomic::{AtomicBool, Ordering};
-use syn::export::Formatter;
 use syn::Error;
 use syn::{spanned::Spanned, FnArg, ItemFn, Pat, PatIdent, PatType, ReturnType, Signature, Type};
 

--- a/src/ic-cdk/src/api/stable.rs
+++ b/src/ic-cdk/src/api/stable.rs
@@ -115,7 +115,7 @@ impl Default for StableReader {
 }
 
 impl StableReader {
-    pub fn read(&mut self, buf: &mut [u8]) -> Result<usize, ()> {
+    pub fn read(&mut self, buf: &mut [u8]) -> Result<usize, StableMemoryError> {
         stable_read(self.offset as u32, buf);
         self.offset += buf.len();
         Ok(buf.len())

--- a/src/ic-cdk/src/api/stable.rs
+++ b/src/ic-cdk/src/api/stable.rs
@@ -15,7 +15,7 @@ pub struct StableMemoryError();
 pub fn stable_grow(new_pages: u32) -> Result<u32, StableMemoryError> {
     unsafe {
         match super::ic0::stable_grow(new_pages as i32) {
-            -1 => Err(()),
+            -1 => Err(StableMemoryError()),
             x => Ok(x as u32),
         }
     }
@@ -70,7 +70,7 @@ impl Default for StableWriter {
 
 impl StableWriter {
     /// Attempt to grow the memory by adding new pages.
-    pub fn grow(&mut self, added_pages: u32) -> Result<(), ()> {
+    pub fn grow(&mut self, added_pages: u32) -> Result<(), StableMemoryError> {
         let old_page_count = stable_grow(added_pages)?;
         self.capacity = old_page_count + added_pages;
         Ok(())
@@ -78,7 +78,7 @@ impl StableWriter {
 
     /// Write a byte slice to the buffer. The only condition where this will
     /// error out is if it cannot grow the memory.
-    pub fn write(&mut self, buf: &[u8]) -> Result<usize, ()> {
+    pub fn write(&mut self, buf: &[u8]) -> Result<usize, StableMemoryError> {
         if self.offset + buf.len() > ((self.capacity as usize) << 16) {
             self.grow((buf.len() >> 16) as u32 + 1)?;
         }

--- a/src/ic-cdk/src/api/stable.rs
+++ b/src/ic-cdk/src/api/stable.rs
@@ -4,13 +4,15 @@ pub fn stable_size() -> u32 {
     unsafe { super::ic0::stable_size() as u32 }
 }
 
+pub struct StableMemoryError();
+
 /// Attempt to grow the stable memory by `new_pages` (added pages).
 /// Returns an error if it wasn't possible. Otherwise, returns the previous
 /// size that was reserved.
 ///
 /// ## Notes
 /// Pages are 64KiB in WASM.
-pub fn stable_grow(new_pages: u32) -> Result<u32, ()> {
+pub fn stable_grow(new_pages: u32) -> Result<u32, StableMemoryError> {
     unsafe {
         match super::ic0::stable_grow(new_pages as i32) {
             -1 => Err(()),


### PR DESCRIPTION
It broke when they removed the export module from root, but we don't need it.
