### PR TITLE
chore: update candid to 0.6.17

### DIFF
--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 proc-macro = true
 
 [dependencies]
-candid = { version = "0.6.12", features = ["cdk"] }
+candid = { version = "0.6.17", features = ["cdk"] }
 ic-cdk = { path = "../ic-cdk", version = "0.2" }
 syn = { version = "1.0.58", features = ["fold", "full"] }
 quote = "1.0"

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["internet-computer", "types", "dfinity", "canister", "cdk"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
-candid = { version = "0.6.12", features = ["cdk"] }
+candid = { version = "0.6.17", features = ["cdk"] }
 cfg-if = "0.1.10"
 ic-types = "0.1.1"
 serde = "1.0.110"


### PR DESCRIPTION
Update candid to 0.6.17 which supports more efficient serialization/de-serialization of `Vec<u8>`