### PR TITLE
feat: expose canister certification API

### DIFF
--- a/src/ic-cdk/src/api.rs
+++ b/src/ic-cdk/src/api.rs
@@ -51,3 +51,42 @@ pub fn id() -> Principal {
 pub fn canister_balance() -> i64 {
     unsafe { ic0::canister_cycle_balance() }
 }
+
+/// Sets the certified data of this canister.
+///
+/// Canisters can store up to 32 bytes of data that is certified by
+/// the system on a regular basis.  One can call [data_certificate]
+/// function from a query call to get a certificate authenticating the
+/// value set by calling this function.
+///
+/// This function can only be called from the following contexts:
+///  * "canister_init", "canister_pre_upgrade" and "canister_post_upgrade"
+///    hooks.
+///  * "canister_update" calls.
+///  * reply or reject callbacks.
+///
+/// # Panics
+///
+/// * This function traps if data.len() > 32.
+/// * This function traps if it's called from an illegal context
+///   (e.g., from a query call).
+pub fn set_certified_data(data: &[u8]) {
+    unsafe { ic0::certified_data_set(data.as_ptr() as i32, data.len() as i32) }
+}
+
+/// When called from a query call, returns the data certificate authenticating
+/// certified_data set by this canister.
+///
+/// Returns None if called not from a query call.
+pub fn data_certificate() -> Option<Vec<u8>> {
+    if unsafe { ic0::data_certificate_present() } == 0 {
+        return None;
+    }
+
+    let n = unsafe { ic0::data_certificate_size() };
+    let mut buf = vec![0u8; n as usize];
+    unsafe {
+        ic0::data_certificate_copy(buf.as_mut_ptr() as i32, 0i32, n);
+    }
+    Some(buf)
+}


### PR DESCRIPTION
This change adds minimalistic certification API based on the function
that were already exported in the ic0 module.

* set_certified_data can only be called from initialization
  hooks/callbacks/update calls. It copies the data to the system for
  subsequent certification that happens asynchronously.

* data_certificate can only be called from query calls. It requests a
  certificate authenticating the previously set data from the system.