### PR TITLE
feat: remove wee_alloc as the global allocation in CDK

### DIFF
--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -17,7 +17,6 @@ candid = { version = "0.6.17", features = ["cdk"] }
 cfg-if = "0.1.10"
 ic-types = "0.1.1"
 serde = "1.0.110"
-wee_alloc = { version = "0.4.5" }
 
 [features]
 experimental = []

--- a/src/ic-cdk/src/lib.rs
+++ b/src/ic-cdk/src/lib.rs
@@ -1,7 +1,3 @@
-// Use `wee_alloc` as the global allocator.
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 pub mod api;
 mod futures;
 mod printer;


### PR DESCRIPTION
The CDK is now BYOA. We'll need to publish this under a new minor version.