### PR TITLE
fix: provide a default feature for candid/cdk

### DIFF
--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -16,10 +16,14 @@ include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 proc-macro = true
 
 [dependencies]
-candid = { version = "0.6.17", features = ["cdk"] }
+candid = "0.6.19"
 ic-cdk = { path = "../ic-cdk", version = "0.2" }
 syn = { version = "1.0.58", features = ["fold", "full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 serde_tokenstream = "0.1.0"
 serde = "1.0.111"
+
+[features]
+default = ["redirect"]
+redirect = ["candid/cdk"]

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -13,10 +13,12 @@ keywords = ["internet-computer", "types", "dfinity", "canister", "cdk"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
-candid = { version = "0.6.17", features = ["cdk"] }
+candid = "0.6.19"
 cfg-if = "0.1.10"
 ic-types = "0.1.1"
 serde = "1.0.110"
 
 [features]
+default = ["redirect"]
+redirect = ["candid/cdk"]
 experimental = []


### PR DESCRIPTION
Developers can opt-out candid/cdk feature with `default-features = false`