### PR TITLE
chore: Change the version label  to latest

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,2 +1,2 @@
 name: docs
-version: 'master'
+version: 'latest'


### PR DESCRIPTION
To be more PC and "accurate" changing the label for the docs bucket from "master" to "latest"