### PR TITLE
feat: add support for inspect_message api

### DIFF
--- a/src/ic-cdk-macros/src/lib.rs
+++ b/src/ic-cdk-macros/src/lib.rs
@@ -65,6 +65,11 @@ pub fn post_upgrade(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
+pub fn inspect_message(attr: TokenStream, item: TokenStream) -> TokenStream {
+    handle_debug_and_errors(export::ic_inspect_message, "ic_inspect_message", attr, item)
+}
+
+#[proc_macro_attribute]
 pub fn import(attr: TokenStream, item: TokenStream) -> TokenStream {
     handle_debug_and_errors(import::ic_import, "ic_import", attr, item)
 }

--- a/src/ic-cdk/src/api.rs
+++ b/src/ic-cdk/src/api.rs
@@ -90,3 +90,34 @@ pub fn data_certificate() -> Option<Vec<u8>> {
     }
     Some(buf)
 }
+
+/// Returns the name of the method to be invoked if the message being
+/// inspected is accepted.  This function can only be called in the
+/// context of inspect_message method.
+///
+/// # Traps
+///
+/// This function traps if it's called not in the context of
+/// inspect_message method.
+pub fn method_name() -> String {
+    let n = unsafe { ic0::msg_method_name_size() };
+    let mut buf = String::with_capacity(n as usize);
+    unsafe {
+        ic0::msg_method_name_copy(buf.as_mut_ptr() as i32, 0i32, n);
+        buf.as_mut_vec().set_len(n as usize);
+    }
+    buf
+}
+
+/// Accepts the message being inspected.  This function can only be
+/// called in the context of inspect_message method.
+///
+/// # Traps
+///
+/// This function traps if
+///
+///   1. it's called more than once.
+///   2. it's called outside of inspect_message method.
+pub fn accept_message() {
+    unsafe { ic0::accept_message() }
+}

--- a/src/ic-cdk/src/api/ic0.rs
+++ b/src/ic-cdk/src/api/ic0.rs
@@ -58,10 +58,10 @@ macro_rules! ic0_module {
 // This is a private module that can only be used internally in this file.
 // Copy-paste the spec section of the API here.
 ic0_module! {
-    ic0.msg_arg_data_size : () -> i32;                                          // I U Q Ry
-    ic0.msg_arg_data_copy : (dst : i32, offset : i32, size : i32) -> ();        // I U Q Ry
-    ic0.msg_caller_size : () -> i32;                                            // I G U Q
-    ic0.msg_caller_copy : (dst : i32, offset: i32, size : i32) -> ();           // I G U Q
+    ic0.msg_arg_data_size : () -> i32;                                          // I U Q Ry F
+    ic0.msg_arg_data_copy : (dst : i32, offset : i32, size : i32) -> ();        // I U Q Ry F
+    ic0.msg_caller_size : () -> i32;                                            // I G U Q F
+    ic0.msg_caller_copy : (dst : i32, offset: i32, size : i32) -> ();           // I G U Q F
     ic0.msg_reject_code : () -> i32;                                            // Ry Rt
     ic0.msg_reject_msg_size : () -> i32;                                        // Rt
     ic0.msg_reject_msg_copy : (dst : i32, offset : i32, size : i32) -> ();      // Rt
@@ -79,6 +79,10 @@ ic0_module! {
     ic0.canister_cycle_balance : () -> i64;                                     // *
     ic0.canister_status : () -> i32;                                            // *
 
+    ic0.msg_method_name_size : () -> i32;                                       // F
+    ic0.msg_method_name_copy : (dst : i32, offset : i32, size : i32) -> ();     // F
+    ic0.accept_message : () -> ();                                              // F
+
     ic0.call_new :                                                              // U Ry Rt
     ( callee_src  : i32,
       callee_size : i32,
@@ -89,6 +93,7 @@ ic0_module! {
       reject_fun : i32,
       reject_env : i32
     ) -> ();
+    ic0.call_on_cleanup : (fun : i32, env : i32) -> ();                         // U Ry Rt
     ic0.call_data_append : (src : i32, size : i32) -> ();                       // U Ry Rt
     ic0.call_cycles_add : ( amount : i64 ) -> ();                               // U Ry Rt
     ic0.call_perform : () -> ( err_code : i32 );                                // U Ry Rt
@@ -98,10 +103,10 @@ ic0_module! {
     ic0.stable_write : (offset : i32, src : i32, size : i32) -> ();             // *
     ic0.stable_read : (dst : i32, offset : i32, size : i32) -> ();              // *
 
-    ic0.certified_data_set : (src: i32, size: i32) -> ();                        // I G U Ry Rt
-    ic0.data_certificate_present : () -> i32;                                    // Q
-    ic0.data_certificate_size : () -> i32;                                       // Q
-    ic0.data_certificate_copy : (dst: i32, offset: i32, size: i32) -> ();        // Q
+    ic0.certified_data_set : (src: i32, size: i32) -> ();                       // I G U Ry Rt
+    ic0.data_certificate_present : () -> i32;                                   // *
+    ic0.data_certificate_size : () -> i32;                                      // *
+    ic0.data_certificate_copy : (dst: i32, offset: i32, size: i32) -> ();       // *
 
     ic0.time : () -> (timestamp : i64);                                         // *
 

--- a/src/ic-cdk/src/futures.rs
+++ b/src/ic-cdk/src/futures.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::Context;
 
 /// Must be called on every top-level future corresponding to a method call of a
 /// canister by the IC.


### PR DESCRIPTION
This change

  1. Introduces a new macro (`inspect_message`) that registers
     a function that will be invoked for each ingress message.

  2. Updates the IC0 module to the latest version to get access to new
     functions.

  3. Adds 2 new api functions that can only be invoked in the context
     of a inspect_message method:

     * method_name() returns the name of the method being called.
     * accept_message() accepts the message being inspected.

See [1] for more details on how message inspection works.

I tested the new functionality by adding inspect_message to the assets
canister example, inspecting the generated Wasm and interacting with
the canister using DFX.  We really need some infra to test new CDK
features.

[1]: https://sdk.dfinity.org/docs/interface-spec/index.html#system-api-inspect-message