### PR TITLE
refactor: deprecate block_on in favour of the new spawn function

### DIFF
--- a/src/ic-cdk-macros/src/export.rs
+++ b/src/ic-cdk-macros/src/export.rs
@@ -190,7 +190,7 @@ fn dfn_macro(
 
             #guard
 
-            ic_cdk::block_on(async {
+            ic_cdk::spawn(async {
                 #arg_decode
                 let result = #function_call;
                 #return_encode

--- a/src/ic-cdk/src/futures.rs
+++ b/src/ic-cdk/src/futures.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::Context;
 
 /// Must be called on every top-level future corresponding to a method call of a
 /// canister by the IC.
@@ -18,7 +18,7 @@ use std::task::{Context, Poll};
 /// API requires us to pass one thin pointer, while a a pointer to a `dyn Trait`
 /// can only be fat. So we create one additional thin pointer, pointing to the
 /// fat pointer and pass it instead.
-pub fn block_on<F: 'static + Future<Output = ()>>(future: F) {
+pub fn spawn<F: 'static + Future<Output = ()>>(future: F) {
     let future_ptr = Box::into_raw(Box::new(future));
     let future_ptr_ptr: *mut *mut dyn Future<Output = ()> = Box::into_raw(Box::new(future_ptr));
     let mut pinned_future = unsafe { Pin::new_unchecked(&mut *future_ptr) };

--- a/src/ic-cdk/src/lib.rs
+++ b/src/ic-cdk/src/lib.rs
@@ -25,8 +25,18 @@ pub fn setup() {
 }
 
 /// Block on a promise in a WASM-friendly way (no multithreading!).
+#[deprecated(
+    since = "0.3.1",
+    note = "Please use the spawn() function instead, it does the same thing but is more appropriately named"
+)]
 pub fn block_on<F: 'static + std::future::Future<Output = ()>>(future: F) {
-    futures::block_on(future);
+    futures::spawn(future);
+}
+
+/// Spawn an asynchronous task that drives the provided future to
+/// completion.
+pub fn spawn<F: 'static + std::future::Future<Output = ()>>(future: F) {
+    futures::spawn(future);
 }
 
 /// Format and then print the formatted message


### PR DESCRIPTION
This PR provides the functionality of block_on under a better name,
"spawn".  The block_on function is marked as deprecated in favour of the
newly added function.