### PR TITLE
Update multiply-dependency.adoc

### DIFF
--- a/docs/modules/rust-guide/pages/multiply-dependency.adoc
+++ b/docs/modules/rust-guide/pages/multiply-dependency.adoc
@@ -218,7 +218,7 @@ The next step is to write a Rust program that imports the {native} canister and 
 +
 [source,bash]
 ----
-include::example$mul-deps/deps-main.rs[]
+include::example$mul-deps/main.rs[]
 ----
 . Save your changes and close the `+src/rust_deps/src/lib.rs+` file to continue.
 


### PR DESCRIPTION
On the https://sdk.dfinity.org/docs/rust-guide/multiply-dependency.html site when follolwing the documentation it shows the #[update] instead of #[query] and throws an error that there is no query read function available in the rust_deps canister