### PR TITLE
Docs: Fix typo

### DIFF
--- a/docs/modules/rust-guide/pages/rust-quickstart.adoc
+++ b/docs/modules/rust-guide/pages/rust-quickstart.adoc
@@ -119,7 +119,7 @@ For example:
 +
 [source, json]
 ----
-"candid": "src/rust_hello/src/rust_hello.did",
+"candid": "src/rust_hello/rust_hello.did",
 ----
 . Add a `+canisters.rust_hello.wasm+` key and specify the location of the compiled WebAssembly file to use for the canister.
 +


### PR DESCRIPTION
Changes value of canisters.rust_hello.candid key in step 5 from "src/rust_hello/src/rust_hello.did" to "src/rust_hello/rust_hello.did" so it matches the example configuration file in step 8.