### PR TITLE
Fix clap's semver beta.4 disaster

### DIFF
--- a/src/ic-cdk-optimizer/Cargo.toml
+++ b/src/ic-cdk-optimizer/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
 binaryen = "0.12.0"
-clap = "3.0.0-beta.1"
+clap = "3.0.0-beta.4"
 humansize = "1.1.0"
 tempfile = "3.1.0"
 wabt = "0.10.0"

--- a/src/ic-cdk-optimizer/src/main.rs
+++ b/src/ic-cdk-optimizer/src/main.rs
@@ -28,7 +28,9 @@ fn main() {
     }
 
     let matches = app.get_matches();
-    let opts = <CommandLineOpts as FromArgMatches>::from_arg_matches(&matches);
+    let opts = (<CommandLineOpts as FromArgMatches>::from_arg_matches(&matches)
+        as Option<CommandLineOpts>)
+        .unwrap();
 
     let content = if let Some(i) = opts.input {
         std::fs::read(&i).expect("Could not read the file.")


### PR DESCRIPTION
Clap did update their APIs during beta, so `cdk-optimizer` does not build anymore.

This PR fixes it.

Please merge ASAP, I'm blocked.