### PR TITLE
feat: implement proper range queries for certified map

### DIFF
--- a/src/ic-certified-map/CHANGELOG.md
+++ b/src/ic-certified-map/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- RbTree::value_range() method to get a witness for a range of keys with values.
+
 ### Changed
+- RbTree::key_range() method returns tighter key bounds which reduces the size of witnesses.
 - Updated the version of candid from `0.6.19` to `0.7.1` ([#72](https://github.com/dfinity/cdk-rs/pull/72)).
 - Hash tree leaves can now hold both references and values ([#121](https://github.com/dfinity/cdk-rs/issues/121)).
   This is a BREAKING CHANGE, some clients might need to slightly change and recompile their code.

--- a/src/ic-certified-map/src/rbtree.rs
+++ b/src/ic-certified-map/src/rbtree.rs
@@ -300,14 +300,7 @@ impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> RbTree<K, V> {
     ///
     /// If the key is not in the map, returns a proof of absence.
     pub fn witness<'a>(&'a self, key: &[u8]) -> HashTree<'a> {
-        if let Some(t) = self.lookup_and_build_witness(key, |v| v.as_hash_tree()) {
-            return t;
-        }
-        self.range_witness(
-            self.lower_bound(key),
-            self.upper_bound(key),
-            Node::witness_tree,
-        )
+        self.nested_witness(key, |v| v.as_hash_tree())
     }
 
     /// Like `witness`, but gives the caller more control over the
@@ -499,7 +492,7 @@ impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> RbTree<K, V> {
                         (_, KeyBound::Exact(_)) => f(n),
                         _ => Node::witness_tree(n),
                     },
-                    go((*n).right, lo, hi, f),
+                    Node::right_hash_tree(n),
                 ),
                 (_, Equal) => three_way_fork(
                     go((*n).left, lo, hi, f),

--- a/src/ic-certified-map/src/rbtree.rs
+++ b/src/ic-certified-map/src/rbtree.rs
@@ -24,7 +24,11 @@ impl Color {
 }
 
 pub trait AsHashTree {
+    /// Returns the root hash of the tree without constructing it.
+    /// Must be equivalent to `as_hash_tree().reconstruct()`.
     fn root_hash(&self) -> Hash;
+
+    /// Constructs a hash tree corresponding to the data.
     fn as_hash_tree(&self) -> HashTree<'_>;
 }
 
@@ -56,8 +60,24 @@ impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> AsHashTree for RbTree<K,
             unsafe { (*self.root).subtree_hash }
         }
     }
+
     fn as_hash_tree(&self) -> HashTree<'_> {
-        unsafe { Node::full_data_tree(self.root) }
+        unsafe { Node::full_witness_tree(self.root, Node::data_tree) }
+    }
+}
+
+#[derive(PartialEq, Debug, Clone, Copy)]
+enum KeyBound<'a> {
+    Exact(&'a [u8]),
+    Neighbor(&'a [u8]),
+}
+
+impl<'a> AsRef<[u8]> for KeyBound<'a> {
+    fn as_ref(&self) -> &'a [u8] {
+        match self {
+            KeyBound::Exact(key) => key,
+            KeyBound::Neighbor(key) => key,
+        }
     }
 }
 
@@ -65,7 +85,7 @@ impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> AsHashTree for RbTree<K,
 // 2. Children of a red node are black.
 // 3. Every path from a node goes through the same number of black
 //    nodes.
-pub struct Node<K, V> {
+struct Node<K, V> {
     key: K,
     value: V,
     left: *mut Node<K, V>,
@@ -139,31 +159,23 @@ impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> Node<K, V> {
         labeled((*n).key.as_ref(), f(&(*n).value))
     }
 
-    unsafe fn full_data_tree<'a>(n: *mut Self) -> HashTree<'a> {
-        if n.is_null() {
-            return Empty;
-        }
-        three_way_fork(
-            Self::full_data_tree((*n).left),
-            Self::data_tree(n),
-            Self::full_data_tree((*n).right),
-        )
-    }
-
     unsafe fn witness_tree<'a>(n: *mut Self) -> HashTree<'a> {
         debug_assert!(!n.is_null());
         let value_hash = (*n).value.root_hash();
         labeled((*n).key.as_ref(), Pruned(value_hash))
     }
 
-    unsafe fn full_witness_tree<'a>(n: *mut Self) -> HashTree<'a> {
+    unsafe fn full_witness_tree<'a>(
+        n: *mut Self,
+        f: unsafe fn(*mut Self) -> HashTree<'a>,
+    ) -> HashTree<'a> {
         if n.is_null() {
             return Empty;
         }
         three_way_fork(
-            Self::full_witness_tree((*n).left),
-            Self::witness_tree(n),
-            Self::full_witness_tree((*n).right),
+            Self::full_witness_tree((*n).left, f),
+            f(n),
+            Self::full_witness_tree((*n).right, f),
         )
     }
 
@@ -239,6 +251,7 @@ impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> RbTree<K, V> {
         }
     }
 
+    /// Updates the value corresponding to the specified key.
     pub fn modify(&mut self, key: &[u8], f: impl FnOnce(&mut V)) {
         unsafe fn go<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static>(
             mut h: *mut Node<K, V>,
@@ -269,24 +282,37 @@ impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> RbTree<K, V> {
 
     fn range_witness<'a>(
         &'a self,
-        left: Option<&'a [u8]>,
-        right: Option<&'a [u8]>,
+        left: Option<KeyBound<'a>>,
+        right: Option<KeyBound<'a>>,
+        f: unsafe fn(*mut Node<K, V>) -> HashTree<'a>,
     ) -> HashTree<'a> {
         match (left, right) {
-            (None, None) => Empty,
-            (Some(l), None) => self.witness_range_above(l),
-            (None, Some(r)) => self.witness_range_below(r),
-            (Some(l), Some(r)) => self.witness_range_exclusive(l, r),
+            (None, None) => unsafe { Node::full_witness_tree(self.root, f) },
+            (Some(l), None) => self.witness_range_above(l, f),
+            (None, Some(r)) => self.witness_range_below(r, f),
+            (Some(l), Some(r)) => self.witness_range_between(l, r, f),
         }
     }
 
+    /// Constructs a hash tree that acts as a proof that there is a
+    /// entry with the specified key in this map.  The proof also
+    /// contains the value in question.
+    ///
+    /// If the key is not in the map, returns a proof of absence.
     pub fn witness<'a>(&'a self, key: &[u8]) -> HashTree<'a> {
         if let Some(t) = self.lookup_and_build_witness(key, |v| v.as_hash_tree()) {
             return t;
         }
-        self.range_witness(self.left_neighbor(key), self.right_neighbor(key))
+        self.range_witness(
+            self.lower_bound(key),
+            self.upper_bound(key),
+            Node::witness_tree,
+        )
     }
 
+    /// Like `witness`, but gives the caller more control over the
+    /// construction of the value witness.  This method is useful for
+    /// constructing witnesses for nested certified maps.
     pub fn nested_witness<'a>(
         &'a self,
         key: &[u8],
@@ -295,24 +321,52 @@ impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> RbTree<K, V> {
         if let Some(t) = self.lookup_and_build_witness(key, f) {
             return t;
         }
-        self.range_witness(self.left_neighbor(key), self.right_neighbor(key))
-    }
-
-    pub fn keys(&self) -> HashTree<'_> {
-        unsafe { Node::full_witness_tree(self.root) }
-    }
-
-    pub fn key_range(&self, first: &[u8], last: &[u8]) -> HashTree<'_> {
-        self.range_witness(self.left_neighbor(first), self.right_neighbor(last))
-    }
-
-    pub fn keys_with_prefix(&self, prefix: &[u8]) -> HashTree<'_> {
         self.range_witness(
-            self.left_neighbor(prefix),
-            self.right_prefix_neighbor(prefix),
+            self.lower_bound(key),
+            self.upper_bound(key),
+            Node::witness_tree,
         )
     }
 
+    /// Returns a witness enumerating all the keys in this map.  The
+    /// resulting tree doesn't include values, they are replaced with
+    /// "Pruned" nodes.
+    pub fn keys(&self) -> HashTree<'_> {
+        unsafe { Node::full_witness_tree(self.root, Node::witness_tree) }
+    }
+
+    /// Returns a witness for the keys in the specified range.  The
+    /// resulting tree doesn't include values, they are replaced with
+    /// "Pruned" nodes.
+    pub fn key_range(&self, first: &[u8], last: &[u8]) -> HashTree<'_> {
+        self.range_witness(
+            self.lower_bound(first),
+            self.upper_bound(last),
+            Node::witness_tree,
+        )
+    }
+
+    /// Returns a witness for the key-value pairs in the specified range.
+    /// The resulting tree contains both keys and values.
+    pub fn value_range(&self, first: &[u8], last: &[u8]) -> HashTree<'_> {
+        self.range_witness(
+            self.lower_bound(first),
+            self.upper_bound(last),
+            Node::data_tree,
+        )
+    }
+
+    /// Returns a witness that enumerates all the keys starting with
+    /// the specified prefix.
+    pub fn keys_with_prefix(&self, prefix: &[u8]) -> HashTree<'_> {
+        self.range_witness(
+            self.lower_bound(prefix),
+            self.right_prefix_neighbor(prefix),
+            Node::witness_tree,
+        )
+    }
+
+    /// Enumerates all the key-value pairs in the tree.
     pub fn for_each<'a, F>(&'a self, mut f: F)
     where
         F: 'a + FnMut(&'a [u8], &'a V),
@@ -338,140 +392,184 @@ impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> RbTree<K, V> {
         unsafe { visit(self.root, &mut f) }
     }
 
-    fn witness_range_above<'a>(&'a self, lo: &[u8]) -> HashTree<'a> {
+    fn witness_range_above<'a>(
+        &'a self,
+        lo: KeyBound<'a>,
+        f: unsafe fn(*mut Node<K, V>) -> HashTree<'a>,
+    ) -> HashTree<'a> {
         unsafe fn go<'a, K: 'static + AsRef<[u8]>, V: AsHashTree + 'static>(
             n: *mut Node<K, V>,
-            lo: &[u8],
+            lo: KeyBound<'a>,
+            f: unsafe fn(*mut Node<K, V>) -> HashTree<'a>,
         ) -> HashTree<'a> {
             if n.is_null() {
                 return Empty;
             }
-            match (*n).key.as_ref().cmp(lo) {
+            match (*n).key.as_ref().cmp(lo.as_ref()) {
                 Equal => three_way_fork(
                     Node::left_hash_tree(n),
-                    Node::witness_tree(n),
-                    Node::full_witness_tree((*n).right),
+                    match lo {
+                        KeyBound::Exact(_) => f(n),
+                        KeyBound::Neighbor(_) => Node::witness_tree(n),
+                    },
+                    Node::full_witness_tree((*n).right, f),
                 ),
                 Less => three_way_fork(
                     Node::left_hash_tree(n),
                     Pruned(Node::data_hash(n)),
-                    go((*n).right, lo),
+                    go((*n).right, lo, f),
                 ),
                 Greater => three_way_fork(
-                    go((*n).left, lo),
-                    Node::witness_tree(n),
-                    Node::full_witness_tree((*n).right),
+                    go((*n).left, lo, f),
+                    f(n),
+                    Node::full_witness_tree((*n).right, f),
                 ),
             }
         }
-        unsafe { go(self.root, lo) }
+        unsafe { go(self.root, lo, f) }
     }
 
-    fn witness_range_below<'a>(&'a self, hi: &[u8]) -> HashTree<'a> {
+    fn witness_range_below<'a>(
+        &'a self,
+        hi: KeyBound<'a>,
+        f: unsafe fn(*mut Node<K, V>) -> HashTree<'a>,
+    ) -> HashTree<'a> {
         unsafe fn go<'a, K: 'static + AsRef<[u8]>, V: AsHashTree + 'static>(
             n: *mut Node<K, V>,
-            hi: &[u8],
+            hi: KeyBound<'a>,
+            f: unsafe fn(*mut Node<K, V>) -> HashTree<'a>,
         ) -> HashTree<'a> {
             if n.is_null() {
                 return Empty;
             }
-            match (*n).key.as_ref().cmp(hi) {
+            match (*n).key.as_ref().cmp(hi.as_ref()) {
                 Equal => three_way_fork(
-                    Node::full_witness_tree((*n).left),
-                    Node::witness_tree(n),
+                    Node::full_witness_tree((*n).left, f),
+                    match hi {
+                        KeyBound::Exact(_) => f(n),
+                        KeyBound::Neighbor(_) => Node::witness_tree(n),
+                    },
                     Node::right_hash_tree(n),
                 ),
                 Greater => three_way_fork(
-                    go((*n).left, hi),
+                    go((*n).left, hi, f),
                     Pruned(Node::data_hash(n)),
                     Node::right_hash_tree(n),
                 ),
                 Less => three_way_fork(
-                    Node::full_witness_tree((*n).left),
-                    Node::witness_tree(n),
-                    go((*n).right, hi),
+                    Node::full_witness_tree((*n).left, f),
+                    f(n),
+                    go((*n).right, hi, f),
                 ),
             }
         }
-        unsafe { go(self.root, hi) }
+        unsafe { go(self.root, hi, f) }
     }
 
-    fn witness_range_exclusive<'a>(&'a self, lo: &[u8], hi: &[u8]) -> HashTree<'a> {
-        debug_assert!(lo <= hi, "lo = {:?} > hi = {:?}", lo, hi);
+    fn witness_range_between<'a>(
+        &'a self,
+        lo: KeyBound<'a>,
+        hi: KeyBound<'a>,
+        f: unsafe fn(*mut Node<K, V>) -> HashTree<'a>,
+    ) -> HashTree<'a> {
+        debug_assert!(
+            lo.as_ref() <= hi.as_ref(),
+            "lo = {:?} > hi = {:?}",
+            lo.as_ref(),
+            hi.as_ref()
+        );
         unsafe fn go<'a, K: 'static + AsRef<[u8]>, V: AsHashTree + 'static>(
             n: *mut Node<K, V>,
-            lo: &[u8],
-            hi: &[u8],
+            lo: KeyBound<'a>,
+            hi: KeyBound<'a>,
+            f: unsafe fn(*mut Node<K, V>) -> HashTree<'a>,
         ) -> HashTree<'a> {
             if n.is_null() {
                 return Empty;
             }
             let k = (*n).key.as_ref();
-            match (lo.cmp(k), k.cmp(hi)) {
-                (Less, Less) => three_way_fork(
-                    go((*n).left, lo, hi),
-                    Node::witness_tree(n),
-                    go((*n).right, lo, hi),
+            match (lo.as_ref().cmp(k), k.cmp(hi.as_ref())) {
+                (Less, Less) => {
+                    three_way_fork(go((*n).left, lo, hi, f), f(n), go((*n).right, lo, hi, f))
+                }
+                (Equal, Equal) => three_way_fork(
+                    Node::left_hash_tree(n),
+                    match (lo, hi) {
+                        (KeyBound::Exact(_), _) => f(n),
+                        (_, KeyBound::Exact(_)) => f(n),
+                        _ => Node::witness_tree(n),
+                    },
+                    go((*n).right, lo, hi, f),
+                ),
+                (_, Equal) => three_way_fork(
+                    go((*n).left, lo, hi, f),
+                    match hi {
+                        KeyBound::Exact(_) => f(n),
+                        KeyBound::Neighbor(_) => Node::witness_tree(n),
+                    },
+                    Node::right_hash_tree(n),
                 ),
                 (Equal, _) => three_way_fork(
                     Node::left_hash_tree(n),
-                    Node::witness_tree(n),
-                    go((*n).right, lo, hi),
-                ),
-                (_, Equal) => three_way_fork(
-                    go((*n).left, lo, hi),
-                    Node::witness_tree(n),
-                    Node::right_hash_tree(n),
+                    match lo {
+                        KeyBound::Exact(_) => f(n),
+                        KeyBound::Neighbor(_) => Node::witness_tree(n),
+                    },
+                    go((*n).right, lo, hi, f),
                 ),
                 (Less, Greater) => three_way_fork(
-                    go((*n).left, lo, hi),
+                    go((*n).left, lo, hi, f),
                     Pruned(Node::data_hash(n)),
                     Node::right_hash_tree(n),
                 ),
                 (Greater, Less) => three_way_fork(
                     Node::left_hash_tree(n),
                     Pruned(Node::data_hash(n)),
-                    go((*n).right, lo, hi),
+                    go((*n).right, lo, hi, f),
                 ),
                 _ => Pruned((*n).subtree_hash),
             }
         }
-        unsafe { go(self.root, lo, hi) }
+        unsafe { go(self.root, lo, hi, f) }
     }
 
-    fn left_neighbor<'a>(&'a self, key: &[u8]) -> Option<&'a [u8]> {
+    fn lower_bound<'a>(&'a self, key: &[u8]) -> Option<KeyBound<'a>> {
         unsafe fn go<'a, K: 'static + AsRef<[u8]>, V>(
             n: *mut Node<K, V>,
             key: &[u8],
-        ) -> Option<&'a [u8]> {
+        ) -> Option<KeyBound<'a>> {
             if n.is_null() {
                 return None;
             }
-            match (*n).key.as_ref().cmp(key) {
-                Less => go((*n).right, key).or_else(|| Some((*n).key.as_ref())),
-                Greater | Equal => go((*n).left, key),
+            let node_key = (*n).key.as_ref();
+            match node_key.cmp(key) {
+                Less => go((*n).right, key).or_else(|| Some(KeyBound::Neighbor(node_key))),
+                Equal => Some(KeyBound::Exact(node_key)),
+                Greater => go((*n).left, key),
             }
         }
         unsafe { go(self.root, key) }
     }
 
-    fn right_neighbor<'a>(&'a self, key: &[u8]) -> Option<&'a [u8]> {
+    fn upper_bound<'a>(&'a self, key: &[u8]) -> Option<KeyBound<'a>> {
         unsafe fn go<'a, K: 'static + AsRef<[u8]>, V>(
             n: *mut Node<K, V>,
             key: &[u8],
-        ) -> Option<&'a [u8]> {
+        ) -> Option<KeyBound<'a>> {
             if n.is_null() {
                 return None;
             }
-            match (*n).key.as_ref().cmp(key) {
-                Greater => go((*n).left, key).or_else(|| Some((*n).key.as_ref())),
-                Less | Equal => go((*n).right, key),
+            let node_key = (*n).key.as_ref();
+            match node_key.cmp(key) {
+                Less => go((*n).right, key),
+                Equal => Some(KeyBound::Exact(node_key)),
+                Greater => go((*n).left, key).or_else(|| Some(KeyBound::Neighbor(node_key))),
             }
         }
         unsafe { go(self.root, key) }
     }
 
-    fn right_prefix_neighbor<'a>(&'a self, prefix: &[u8]) -> Option<&'a [u8]> {
+    fn right_prefix_neighbor<'a>(&'a self, prefix: &[u8]) -> Option<KeyBound<'a>> {
         fn is_prefix_of(p: &[u8], x: &[u8]) -> bool {
             if p.len() > x.len() {
                 return false;
@@ -481,14 +579,14 @@ impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> RbTree<K, V> {
         unsafe fn go<'a, K: 'static + AsRef<[u8]>, V>(
             n: *mut Node<K, V>,
             prefix: &[u8],
-        ) -> Option<&'a [u8]> {
+        ) -> Option<KeyBound<'a>> {
             if n.is_null() {
                 return None;
             }
             let node_key = (*n).key.as_ref();
             match node_key.cmp(prefix) {
                 Greater if is_prefix_of(prefix, node_key) => go((*n).right, prefix),
-                Greater => go((*n).left, prefix).or(Some(node_key)),
+                Greater => go((*n).left, prefix).or(Some(KeyBound::Neighbor(node_key))),
                 Less | Equal => go((*n).right, prefix),
             }
         }
@@ -535,6 +633,7 @@ impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> RbTree<K, V> {
         unsafe { go(self.root, key, f) }
     }
 
+    /// Inserts a key-value entry into the map.
     pub fn insert(&mut self, key: K, value: V) {
         unsafe fn go<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static>(
             mut h: *mut Node<K, V>,
@@ -578,6 +677,7 @@ impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> RbTree<K, V> {
         }
     }
 
+    /// Removes the specified key from the map.
     pub fn delete(&mut self, key: &[u8]) {
         unsafe fn move_red_left<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static>(
             mut h: *mut Node<K, V>,
@@ -726,6 +826,7 @@ unsafe fn balance<K: AsRef<[u8]> + 'static, V: AsHashTree + 'static>(
     }
     h
 }
+
 /// Make a left-leaning link lean to the right.
 unsafe fn rotate_right<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static>(
     h: *mut Node<K, V>,

--- a/src/ic-certified-map/src/rbtree.rs
+++ b/src/ic-certified-map/src/rbtree.rs
@@ -543,7 +543,7 @@ impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> RbTree<K, V> {
             }
             let node_key = (*n).key.as_ref();
             match node_key.cmp(key) {
-                Less => go((*n).right, key).or_else(|| Some(KeyBound::Neighbor(node_key))),
+                Less => go((*n).right, key).or(Some(KeyBound::Neighbor(node_key))),
                 Equal => Some(KeyBound::Exact(node_key)),
                 Greater => go((*n).left, key),
             }
@@ -563,7 +563,7 @@ impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> RbTree<K, V> {
             match node_key.cmp(key) {
                 Less => go((*n).right, key),
                 Equal => Some(KeyBound::Exact(node_key)),
-                Greater => go((*n).left, key).or_else(|| Some(KeyBound::Neighbor(node_key))),
+                Greater => go((*n).left, key).or(Some(KeyBound::Neighbor(node_key))),
             }
         }
         unsafe { go(self.root, key) }


### PR DESCRIPTION
This change implements key-value range queries for the certified map
and fixes the handling of key range queries.

Before this change, the key range queries always included key
neighbors into the witness, even if the actual key bound is present in
the tree.

For example, if the tree contains keys '0'..'9', key_range('1', '8')
would produce a witness with keys '0'..'9' instead of just '1'..'8'
with everything else pruned.

This made it hard/impossible to use this map in some applications,
e.g., for registry certification.