### PR TITLE
chore: ic-cdk-optimizer: pin to clap-3.0.0-beta.2

### DIFF
--- a/src/ic-cdk-optimizer/Cargo.toml
+++ b/src/ic-cdk-optimizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-optimizer"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "WASM Optimizer for the IC CDK (experimental)."
@@ -16,7 +16,8 @@ include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
 binaryen = "0.12.0"
-clap = "3.0.0-beta.1"
+clap = "=3.0.0-beta.2"
+clap_derive = "=3.0.0-beta.2"
 humansize = "1.1.0"
 tempfile = "3.1.0"
 wabt = "0.10.0"


### PR DESCRIPTION
beta.4 introduced errors like these:

error[E0658]: arbitrary expressions in key-value attributes are unstable
 --> /Users/ericswanson/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.0.0-beta.4/src/lib.rs:8:10
  |
8 | #![doc = include_str!("../README.md")]
  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: see issue #78835 <https://github.com/rust-lang/rust/issues/78835> for more information

error[E0658]: use of unstable library feature 'osstring_ascii'
   --> /Users/ericswanson/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.0.0-beta.4/src/parse/matches/matched_arg.rs:130:19
    |
130 |                 v.eq_ignore_ascii_case(val)
    |                   ^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #70516 <https://github.com/rust-lang/rust/issues/70516> for more information