### PR TITLE
feat: add support for 'heartbeat' and 'inspect_message'

### DIFF
--- a/src/ic-cdk-macros/src/export.rs
+++ b/src/ic-cdk-macros/src/export.rs
@@ -20,13 +20,15 @@ enum MethodType {
     PostUpgrade,
     Update,
     Query,
+    Heartbeat,
+    InspectMessage
 }
 
 impl MethodType {
     pub fn is_lifecycle(&self) -> bool {
         matches!(
             self,
-            MethodType::Init | MethodType::PreUpgrade | MethodType::PostUpgrade
+            MethodType::Init | MethodType::PreUpgrade | MethodType::PostUpgrade | MethodType::Heartbeat | MethodType::InspectMessage
         )
     }
 }
@@ -39,6 +41,8 @@ impl std::fmt::Display for MethodType {
             MethodType::PostUpgrade => f.write_str("canister_post_upgrade"),
             MethodType::Query => f.write_str("canister_query"),
             MethodType::Update => f.write_str("canister_update"),
+            MethodType::Heartbeat => f.write_str("canister_heartbeat"),
+            MethodType::InspectMessage => f.write_str("canister_inspect_message"),
         }
     }
 }
@@ -111,16 +115,11 @@ fn dfn_macro(
         },
     };
 
-    match method {
-        MethodType::Init | MethodType::PreUpgrade | MethodType::PostUpgrade
-            if return_length > 0 =>
-        {
-            return Err(Error::new(
-                Span::call_site(),
-                format!("#[{}] function cannot have a return value.", method),
-            ));
-        }
-        _ => {}
+    if method.is_lifecycle() && return_length > 0 {
+        return Err(Error::new(
+            Span::call_site(),
+            format!("#[{}] function cannot have a return value.", method),
+        ));
     }
 
     let (arg_tuple, _): (Vec<Ident>, Vec<Box<Type>>) =
@@ -284,6 +283,48 @@ pub(crate) fn ic_post_upgrade(
 
     dfn_macro(
         MethodType::PostUpgrade,
+        TokenStream::from(attr),
+        TokenStream::from(item),
+    )
+    .map(proc_macro::TokenStream::from)
+}
+
+static HAS_HEARTBEAT: AtomicBool = AtomicBool::new(false);
+
+pub(crate) fn ic_heartbeat(
+    attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> Result<proc_macro::TokenStream, Error> {
+    if HAS_HEARTBEAT.swap(true, Ordering::SeqCst) {
+        return Err(Error::new(
+            Span::call_site(),
+            "Heartbeat function already declared.",
+        ));
+    }
+
+    dfn_macro(
+        MethodType::Heartbeat,
+        TokenStream::from(attr),
+        TokenStream::from(item),
+    )
+    .map(proc_macro::TokenStream::from)
+}
+
+static HAS_INSPECT_MESSAGE: AtomicBool = AtomicBool::new(false);
+
+pub(crate) fn ic_inspect_message(
+    attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> Result<proc_macro::TokenStream, Error> {
+    if HAS_INSPECT_MESSAGE.swap(true, Ordering::SeqCst) {
+        return Err(Error::new(
+            Span::call_site(),
+            "Inspect-message function already declared.",
+        ));
+    }
+
+    dfn_macro(
+        MethodType::InspectMessage,
         TokenStream::from(attr),
         TokenStream::from(item),
     )

--- a/src/ic-cdk-macros/src/export.rs
+++ b/src/ic-cdk-macros/src/export.rs
@@ -21,14 +21,18 @@ enum MethodType {
     Update,
     Query,
     Heartbeat,
-    InspectMessage
+    InspectMessage,
 }
 
 impl MethodType {
     pub fn is_lifecycle(&self) -> bool {
         matches!(
             self,
-            MethodType::Init | MethodType::PreUpgrade | MethodType::PostUpgrade | MethodType::Heartbeat | MethodType::InspectMessage
+            MethodType::Init
+                | MethodType::PreUpgrade
+                | MethodType::PostUpgrade
+                | MethodType::Heartbeat
+                | MethodType::InspectMessage
         )
     }
 }

--- a/src/ic-cdk-macros/src/lib.rs
+++ b/src/ic-cdk-macros/src/lib.rs
@@ -65,6 +65,16 @@ pub fn post_upgrade(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
+pub fn heartbeat(attr: TokenStream, item: TokenStream) -> TokenStream {
+    handle_debug_and_errors(export::ic_heartbeat, "ic_heartbeat", attr, item)
+}
+
+#[proc_macro_attribute]
+pub fn inspect_message(attr: TokenStream, item: TokenStream) -> TokenStream {
+    handle_debug_and_errors(export::ic_inspect_message, "ic_inspect_message", attr, item)
+}
+
+#[proc_macro_attribute]
 pub fn import(attr: TokenStream, item: TokenStream) -> TokenStream {
     handle_debug_and_errors(import::ic_import, "ic_import", attr, item)
 }

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -362,3 +362,7 @@ pub fn arg_data<R: for<'a> ArgumentDecoder<'a>>() -> R {
         Ok(r) => r,
     }
 }
+
+pub fn accept_message() {
+    unsafe { ic0::accept_message(); }
+}

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -368,3 +368,12 @@ pub fn accept_message() {
         ic0::accept_message();
     }
 }
+
+pub fn method_name() -> String {
+    let len: u32 = unsafe { ic0::msg_method_name_size() as u32 };
+    let mut bytes = vec![0; len as usize];
+    unsafe {
+        ic0::msg_method_name_copy(bytes.as_mut_ptr() as i32, 0, len as i32);
+    }
+    String::from_utf8_lossy(&bytes).to_string()
+}

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -364,5 +364,7 @@ pub fn arg_data<R: for<'a> ArgumentDecoder<'a>>() -> R {
 }
 
 pub fn accept_message() {
-    unsafe { ic0::accept_message(); }
+    unsafe {
+        ic0::accept_message();
+    }
 }

--- a/src/ic-cdk/src/api/ic0.rs
+++ b/src/ic-cdk/src/api/ic0.rs
@@ -57,11 +57,24 @@ macro_rules! ic0_module {
 
 // This is a private module that can only be used internally in this file.
 // Copy-paste the spec section of the API here.
+/*
+The comment after each function lists from where these functions may be invoked:
+I: from canister_init or canister_post_upgrade
+G: from canister_pre_upgrade
+U: from canister_update
+Q: from canister_query …
+Ry: from a reply callback
+Rt: from a reject callback
+C: from a cleanup callback
+s: the (start) module initialization function
+F: from canister_inspect_message
+* = I G U Q Ry Rt C F (NB: Not (start))
+*/
 ic0_module! {
-    ic0.msg_arg_data_size : () -> i32;                                          // I U Q Ry
-    ic0.msg_arg_data_copy : (dst : i32, offset : i32, size : i32) -> ();        // I U Q Ry
-    ic0.msg_caller_size : () -> i32;                                            // I G U Q
-    ic0.msg_caller_copy : (dst : i32, offset: i32, size : i32) -> ();           // I G U Q
+    ic0.msg_arg_data_size : () -> i32;                                          // I U Q Ry F
+    ic0.msg_arg_data_copy : (dst : i32, offset : i32, size : i32) -> ();        // I U Q Ry F
+    ic0.msg_caller_size : () -> i32;                                            // I G U Q F
+    ic0.msg_caller_copy : (dst : i32, offset: i32, size : i32) -> ();           // I G U Q F
     ic0.msg_reject_code : () -> i32;                                            // Ry Rt
     ic0.msg_reject_msg_size : () -> i32;                                        // Rt
     ic0.msg_reject_msg_copy : (dst : i32, offset : i32, size : i32) -> ();      // Rt
@@ -79,16 +92,21 @@ ic0_module! {
     ic0.canister_cycle_balance : () -> i64;                                     // *
     ic0.canister_status : () -> i32;                                            // *
 
+    ic0.msg_method_name_size : () -> i32;                                       // F
+    ic0.msg_method_name_copy : (dst : i32, offset : i32, size : i32) -> ();     // F
+    ic0.accept_message : () -> ();                                              // F
+
     ic0.call_new :                                                              // U Ry Rt
-    ( callee_src  : i32,
-      callee_size : i32,
-      name_src : i32,
-      name_size : i32,
-      reply_fun : i32,
-      reply_env : i32,
-      reject_fun : i32,
-      reject_env : i32
-    ) -> ();
+      ( callee_src  : i32,
+        callee_size : i32,
+        name_src : i32,
+        name_size : i32,
+        reply_fun : i32,
+        reply_env : i32,
+        reject_fun : i32,
+        reject_env : i32
+      ) -> ();
+    ic0.call_on_cleanup : (fun : i32, env : i32) -> ();                         // U Ry Rt
     ic0.call_data_append : (src : i32, size : i32) -> ();                       // U Ry Rt
     ic0.call_cycles_add : ( amount : i64 ) -> ();                               // U Ry Rt
     ic0.call_perform : () -> ( err_code : i32 );                                // U Ry Rt
@@ -98,10 +116,10 @@ ic0_module! {
     ic0.stable_write : (offset : i32, src : i32, size : i32) -> ();             // *
     ic0.stable_read : (dst : i32, offset : i32, size : i32) -> ();              // *
 
-    ic0.certified_data_set : (src: i32, size: i32) -> ();                        // I G U Ry Rt
-    ic0.data_certificate_present : () -> i32;                                    // Q
-    ic0.data_certificate_size : () -> i32;                                       // Q
-    ic0.data_certificate_copy : (dst: i32, offset: i32, size: i32) -> ();        // Q
+    ic0.certified_data_set : (src: i32, size: i32) -> ();                       // I G U Ry Rt
+    ic0.data_certificate_present : () -> i32;                                   // *
+    ic0.data_certificate_size : () -> i32;                                      // *
+    ic0.data_certificate_copy : (dst: i32, offset: i32, size: i32) -> ();       // *
 
     ic0.time : () -> (timestamp : i64);                                         // *
 


### PR DESCRIPTION
This adds 2 new attributes 'heartbeat' and 'inspect_message' and also exposes 2 additional ic0 methods 'accept_message' and 'method_name' which are required when using 'inspect_message'.