### PR TITLE
ci: use pull_request_target for workflows that need it

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,6 +1,6 @@
 name: Check PR title
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
       - next
-  pull_request:
+  pull_request_target:
 name: Publish Cargo docs
 jobs:
   publish:


### PR DESCRIPTION
See https://github.com/dfinity/agent-rs/pull/52

The conventional commits workflow needs a secret with write access in order to be able to update the commit status.  Using pull_request_target achieves this, which is fine since this step doesn't need the branch contents anyway.

The netlify step also needs write access in order to comment on the PR.  Using pull_request_target rather than pull_request means that docs from the base branch will be uploaded rather than from the PR branch.  This is also what is done in agent-rs, and I think it's wrong there (too), but in the interest of having PRs from forks be able to pass at all, I am making them consistent.