### PR TITLE
fix: `import` no longer compel user to depend on candid

### DIFF
--- a/examples/asset_storage/src/asset_storage_rs/Cargo.toml
+++ b/examples/asset_storage/src/asset_storage_rs/Cargo.toml
@@ -13,4 +13,3 @@ crate-type = ["cdylib"]
 [dependencies]
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.3" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.3" }
-serde = "1.0.111"

--- a/examples/build.sh
+++ b/examples/build.sh
@@ -7,7 +7,7 @@ root="$(dirname "$0")/.."
 example_root="$(dirname "$0")/$name"
 
 # This script builds an example project (passed as $1) and then run the ic-cdk-optimizer on it.
-cargo +nightly-2021-09-20 build --manifest-path="$example_root/Cargo.toml" \
+cargo build --manifest-path="$example_root/Cargo.toml" \
     --target wasm32-unknown-unknown \
     --release \
     --package "$package"

--- a/examples/build.sh
+++ b/examples/build.sh
@@ -7,7 +7,7 @@ root="$(dirname "$0")/.."
 example_root="$(dirname "$0")/$name"
 
 # This script builds an example project (passed as $1) and then run the ic-cdk-optimizer on it.
-cargo build --manifest-path="$example_root/Cargo.toml" \
+cargo +nightly-2021-09-20 build --manifest-path="$example_root/Cargo.toml" \
     --target wasm32-unknown-unknown \
     --release \
     --package "$package"

--- a/examples/profile/src/profile_inter_rs/Cargo.toml
+++ b/examples/profile/src/profile_inter_rs/Cargo.toml
@@ -13,4 +13,3 @@ crate-type = ["cdylib"]
 [dependencies]
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.3" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.3" }
-serde = "1.0.111"

--- a/examples/profile/src/profile_inter_rs/lib.rs
+++ b/examples/profile/src/profile_inter_rs/lib.rs
@@ -1,5 +1,5 @@
 use ic_cdk_macros::*;
-use ic_cdk::export::candid;
+// use ic_cdk::export::candid;
 
 #[import(canister = "profile_rs")]
 struct ProfileCanister;

--- a/examples/profile/src/profile_inter_rs/lib.rs
+++ b/examples/profile/src/profile_inter_rs/lib.rs
@@ -1,5 +1,4 @@
 use ic_cdk_macros::*;
-// use ic_cdk::export::candid;
 
 #[import(canister = "profile_rs")]
 struct ProfileCanister;

--- a/examples/profile/tests/basic.bats
+++ b/examples/profile/tests/basic.bats
@@ -1,0 +1,35 @@
+# Executed before each test.
+setup() {
+  cd examples/profile
+  # Make sure the directory is clean.
+  dfx start --clean --background --host "127.0.0.1:0"
+  local webserver_port=$(cat .dfx/webserver-port)
+  cp dfx.json dfx.json.bk
+  cat <<<$(jq .networks.local.bind=\"127.0.0.1:${webserver_port}\" dfx.json) >dfx.json
+}
+
+# executed after each test
+teardown() {
+  dfx stop
+  mv dfx.json.bk dfx.json
+}
+
+@test "Can get, update, search (profile_rs)" {
+  dfx deploy
+
+  run dfx canister call profile_rs getSelf
+  [ "$output" == '(record { name = ""; description = ""; keywords = vec {} })' ]
+  dfx canister call profile_rs update 'record {"name"= "abc"; "description"="123"; "keywords"= vec {} }'
+  run dfx canister call profile_rs get abc
+  [ "$output" == '(record { name = "abc"; description = "123"; keywords = vec {} })' ]
+  run dfx canister call profile_rs search ab
+  [ "$output" == '(opt record { name = "abc"; description = "123"; keywords = vec {} })' ]
+
+  run dfx canister call profile_inter_rs getSelf
+  [ "$output" == '(record { name = ""; description = ""; keywords = vec {} })' ]
+  dfx canister call profile_inter_rs update 'record {"name"= "def"; "description"="456"; "keywords"= vec {} }'
+  run dfx canister call profile_inter_rs get def
+  [ "$output" == '(record { name = "def"; description = "456"; keywords = vec {} })' ]
+  run dfx canister call profile_inter_rs search de
+  [ "$output" == '(opt record { name = "def"; description = "456"; keywords = vec {} })' ]
+}

--- a/src/ic-cdk-macros/src/import.rs
+++ b/src/ic-cdk-macros/src/import.rs
@@ -146,7 +146,8 @@ impl candid::codegen::rust::RustBindings for RustLanguageBinding {
             .join(" , ");
         Ok(format!(
             r#"
-                #[derive(Clone, Debug, Default, ic_cdk::export::candid::CandidType, serde::Deserialize)]
+                #[derive(Clone, Debug, Default, ic_cdk::export::candid::CandidType, ic_cdk::export::serde::Deserialize)]
+                #[serde(crate = "ic_cdk::export::serde")]
                 pub struct {} {{ {} }}
             "#,
             id, all_fields

--- a/src/ic-cdk-macros/src/import.rs
+++ b/src/ic-cdk-macros/src/import.rs
@@ -146,7 +146,7 @@ impl candid::codegen::rust::RustBindings for RustLanguageBinding {
             .join(" , ");
         Ok(format!(
             r#"
-                #[derive(Clone, Debug, Default, candid::CandidType, serde::Deserialize)]
+                #[derive(Clone, Debug, Default, ic_cdk::export::candid::CandidType, serde::Deserialize)]
                 pub struct {} {{ {} }}
             "#,
             id, all_fields

--- a/src/ic-cdk-macros/src/import.rs
+++ b/src/ic-cdk-macros/src/import.rs
@@ -144,6 +144,8 @@ impl candid::codegen::rust::RustBindings for RustLanguageBinding {
             .map(|(name, ty)| format!("pub {} : {}", name, ty))
             .collect::<Vec<String>>()
             .join(" , ");
+        // The following #[serde(crate = ...)] line was from https://github.com/serde-rs/serde/issues/1465#issuecomment-800686252
+        // It is necessary when use re-exported serde
         Ok(format!(
             r#"
                 #[derive(Clone, Debug, Default, ic_cdk::export::candid::CandidType, ic_cdk::export::serde::Deserialize)]

--- a/src/ic-cdk-macros/src/lib.rs
+++ b/src/ic-cdk-macros/src/lib.rs
@@ -74,6 +74,14 @@ pub fn inspect_message(attr: TokenStream, item: TokenStream) -> TokenStream {
     handle_debug_and_errors(export::ic_inspect_message, "ic_inspect_message", attr, item)
 }
 
+/// Import data type from another canister as a struct.
+///
+/// # Examples
+///
+/// ```no_run
+/// #[import(canister = "another_canister")]
+/// struct DataTypeThere;
+/// ```
 #[proc_macro_attribute]
 pub fn import(attr: TokenStream, item: TokenStream) -> TokenStream {
     handle_debug_and_errors(import::ic_import, "ic_import", attr, item)

--- a/src/ic-cdk/src/lib.rs
+++ b/src/ic-cdk/src/lib.rs
@@ -11,6 +11,7 @@ static mut DONE: bool = false;
 pub mod export {
     pub use candid;
     pub use candid::types::ic_types::Principal;
+    pub use serde;
 }
 
 /// Setup the stdlib hooks.


### PR DESCRIPTION
The proc macro `import` generated code which contains `#[derive(..., candid::CandidType, serde::Deserialize)]`. That line compelled the user of `ic-cdk-macros` to either:
* add `candid` to their `Cargo.toml`
* have an extra line in the file using `[import]`: `use ic_cdk::export::candid;`

This PR lift such restriction by specifying the `candid` module in `ic_cdk::export`.
Similarly, `serde` is re-exported in `ic-cdk`.

