### PR TITLE
docs: Add a step to install wasm32-unknown-unknown

### DIFF
--- a/docs/modules/rust-guide/pages/rust-quickstart.adoc
+++ b/docs/modules/rust-guide/pages/rust-quickstart.adoc
@@ -296,6 +296,11 @@ After you connect to the {LEE} running in your development environment, you can 
 To register, build, and deploy:
 
 . Check that you are still in root directory for your project directory, if needed.
+. Make sure you have `wasm32-unknown-unknown` installed by running the command:
++
+[source,bash]
+rustup target add wasm32-unknown-unknown
++
 . Register, build, and deploy the canisters specified in the `+dfx.json+` file by running the following command:
 +
 [source,bash]


### PR DESCRIPTION
In the step Register, build, and deploy your project it's possible to fail because wasm32-unknown-unknown component isn't installed. Added a step 2 to handle that