### PR TITLE
fix: deleted `Profile_2` to `Profile`

### DIFF
--- a/examples/profile/src/profile_inter_rs/lib.rs
+++ b/examples/profile/src/profile_inter_rs/lib.rs
@@ -4,21 +4,21 @@ use ic_cdk_macros::*;
 struct ProfileCanister;
 
 #[update(name = "getSelf")]
-async fn get_self() -> Box<Profile_2> {
+async fn get_self() -> Box<Profile> {
     ProfileCanister::getSelf().await.0
 }
 
 #[update]
-async fn get(name: String) -> Box<Profile_2> {
+async fn get(name: String) -> Box<Profile> {
     ProfileCanister::get(name).await.0
 }
 
 #[update]
 async fn update(profile: Profile) {
-    ProfileCanister::update(profile).await
+    ProfileCanister::update(Box::new(profile)).await
 }
 
 #[update]
-async fn search(text: String) -> Option<Box<Profile_2>> {
+async fn search(text: String) -> Option<Box<Profile>> {
     ProfileCanister::search(text).await.0
 }

--- a/examples/profile/src/profile_inter_rs/profile.did
+++ b/examples/profile/src/profile_inter_rs/profile.did
@@ -1,13 +1,12 @@
-type Profile_2 = record {
+type Profile = record {
     "name": text;
     "description": text;
     "keywords": vec text;
 };
-type Profile = Profile_2;
 
 service : {
-    "getSelf": () -> (Profile_2);
-    "get": (text) -> (Profile_2);
-    "update": (Profile_2) -> ();
-    "search": (text) -> (opt Profile_2);
+    "getSelf": () -> (Profile);
+    "get": (text) -> (Profile);
+    "update": (Profile) -> ();
+    "search": (text) -> (opt Profile);
 }

--- a/examples/profile/src/profile_rs/lib.rs
+++ b/examples/profile/src/profile_rs/lib.rs
@@ -1,4 +1,7 @@
-use ic_cdk::export::{candid::{CandidType, Deserialize}, Principal};
+use ic_cdk::export::{
+    candid::{CandidType, Deserialize},
+    Principal,
+};
 use ic_cdk::storage;
 use ic_cdk_macros::*;
 use std::collections::BTreeMap;

--- a/examples/profile/src/profile_rs/profile.did
+++ b/examples/profile/src/profile_rs/profile.did
@@ -1,13 +1,12 @@
-type Profile_2 = record {
+type Profile = record {
     "name": text;
     "description": text;
     "keywords": vec text;
 };
-type Profile = Profile_2;
 
 service : {
-    "getSelf": () -> (Profile_2) query;
-    "get": (text) -> (Profile_2) query;
-    "update": (Profile_2) -> ();
-    "search": (text) -> (opt Profile_2) query;
+    "getSelf": () -> (Profile) query;
+    "get": (text) -> (Profile) query;
+    "update": (Profile) -> ();
+    "search": (text) -> (opt Profile) query;
 }


### PR DESCRIPTION
The `rust_profile` tutorial is a bit hard to trace without a
description of why we should:

```
type Profile = Profile_2
```

The tutorial still works without this line with refactoring `Profile_2` to `Profile`.

Please let me know if there are other intentions. (I'm very much interested to see when there is a case)