### PR TITLE
feat: update system API for 128 bit cycles

### DIFF
--- a/src/ic-cdk/src/api.rs
+++ b/src/ic-cdk/src/api.rs
@@ -1,6 +1,6 @@
 //! System API and low level functions for it.
 use crate::export::Principal;
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 
 pub mod call;
 pub mod stable;
@@ -51,6 +51,14 @@ pub fn id() -> Principal {
 /// Get the amount of funds available in the canister.
 pub fn canister_balance() -> u64 {
     unsafe { ic0::canister_cycle_balance() as u64 }
+}
+
+/// Get the amount of funds available in the canister.
+pub fn canister_balance128() -> u128 {
+    let size = 16;
+    let mut buf = vec![0u8; size];
+    unsafe { ic0::canister_cycle_balance128(buf.as_mut_ptr() as i32) }
+    u128::from_le_bytes(buf.try_into().unwrap())
 }
 
 /// Sets the certified data of this canister.

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -346,31 +346,11 @@ pub fn msg_cycles_available() -> u64 {
     unsafe { ic0::msg_cycles_available() as u64 }
 }
 
-/// Similar to [`msg_cycles_available`] but returns in 128-bit.
-///
-/// *Note*: Cycles are represented by 128-bit values.
-/// The amount of cycles transferred can be obtained by
-/// combining the return values: high * 264 + low.
-pub fn msg_cycles_available128() -> (u64, u64) {
-    let (high, low) = unsafe { ic0::msg_cycles_available128() };
-    (high as u64, low as u64)
-}
-
 /// Returns the amount of cycles that came back with the response as a refund.
 ///
 /// The refund has already been added to the canister balance automatically.
 pub fn msg_cycles_refunded() -> u64 {
     unsafe { ic0::msg_cycles_refunded() as u64 }
-}
-
-/// Similar to [`msg_cycles_refunded`] but returns in 128-bit.
-///
-/// *Note*: Cycles are represented by 128-bit values.
-/// The amount of cycles transferred can be obtained by
-/// combining the return values: high * 264 + low.
-pub fn msg_cycles_refunded128() -> (u64, u64) {
-    let (high, low) = unsafe { ic0::msg_cycles_refunded128() };
-    (high as u64, low as u64)
 }
 
 /// Moves cycles from the call to the canister balance.
@@ -379,14 +359,6 @@ pub fn msg_cycles_refunded128() -> (u64, u64) {
 pub fn msg_cycles_accept(max_amount: u64) -> u64 {
     // TODO: should we assert the u64 input is within the range of i64?
     unsafe { ic0::msg_cycles_accept(max_amount as i64) as u64 }
-}
-
-/// Similar to [`msg_cycles_accept`] but the inputs and returns are in 128-bit.
-pub fn msg_cycles_accept128(max_amount_high: u64, max_amount_low: u64) -> (u64, u64) {
-    // TODO: should we assert the u64 input is within the range of i64?
-    let (amount_high, amount_low) =
-        unsafe { ic0::msg_cycles_accept128(max_amount_high as i64, max_amount_low as i64) };
-    (amount_high as u64, amount_low as u64)
 }
 
 /// Returns the argument data as bytes.

--- a/src/ic-cdk/src/api/ic0.rs
+++ b/src/ic-cdk/src/api/ic0.rs
@@ -89,17 +89,17 @@ ic0_module! {
     ic0.msg_reject : (src : i32, size : i32) -> ();                             // U Q Ry Rt
 
     ic0.msg_cycles_available : () -> i64;                                       // U Rt Ry
-    ic0.msg_cycles_available128 : () -> (high : i64, low : i64);                // U Rt Ry
+    ic0.msg_cycles_available128 : (dst : i32) -> ();                            // U Rt Ry
     ic0.msg_cycles_refunded : () -> i64;                                        // Rt Ry
-    ic0.msg_cycles_refunded128 : () -> (high : i64, low: i64);                  // Rt Ry
+    ic0.msg_cycles_refunded128 : (dst : i32) -> ();                             // Rt Ry
     ic0.msg_cycles_accept : ( max_amount : i64) -> ( amount : i64 );            // U Rt Ry
-    ic0.msg_cycles_accept128 : ( max_amount_high : i64, max_amount_low: i64)
-                       -> ( amount_high : i64, amount_low: i64 );               // U Rt Ry
+    ic0.msg_cycles_accept128 : ( max_amount_high : i64, max_amount_low: i64, dst : i32)
+                       -> ();                                                   // U Rt Ry
 
     ic0.canister_self_size : () -> i32;                                         // *
     ic0.canister_self_copy : (dst : i32, offset : i32, size : i32) -> ();       // *
     ic0.canister_cycle_balance : () -> i64;                                     // *
-    ic0.canister_cycle_balance128 : () -> (high : i64, low : i64);              // *
+    ic0.canister_cycle_balance128 : (dst : i32) -> ();                          // *
     ic0.canister_status : () -> i32;                                            // *
 
     ic0.msg_method_name_size : () -> i32;                                       // F


### PR DESCRIPTION
Following up on our discussion regarding the multivalue target feature support, we have decided to update the experimental System Api and not rely on this feature anymore. 

This MR updates the SystemAPI according to the Public Spec: https://github.com/dfinity-lab/ic-ref/pull/381.
