### PR TITLE
feat: Trap in setup panic hook

### DIFF
--- a/src/ic-cdk/src/printer.rs
+++ b/src/ic-cdk/src/printer.rs
@@ -18,6 +18,7 @@ pub fn set_panic_hook() {
 
         let err_info = format!("Panicked at '{}', {}:{}:{}", msg, file, line, col);
         api::print(&err_info);
+        api::trap(&err_info);
     }));
 }
 


### PR DESCRIPTION
This PR enhances the custom panic hook to `trap` on top of printing the error. The reason for doing this is that it results in a better error message that gets back to the user. Instead of a generic "trapped: unreachable" we will get a more useful "trapped explicitly: error message".