### PR TITLE
docs: fix attribute of read()

### DIFF
--- a/docs/modules/rust-guide/examples/mul-deps/deps-main.rs
+++ b/docs/modules/rust-guide/examples/mul-deps/deps-main.rs
@@ -4,7 +4,7 @@ use ic_cdk::export::candid;
 #[import(canister = "multiply_deps")]
 struct CounterCanister;
 
-#[update]
+#[query]
 async fn read() -> candid::Nat {
     CounterCanister::read().await.0
 }

--- a/docs/modules/rust-guide/examples/mul-deps/mul-deps-dfx.json
+++ b/docs/modules/rust-guide/examples/mul-deps/mul-deps-dfx.json
@@ -5,8 +5,8 @@
       "type": "motoko"
     },
     "rust_deps": {
-      "build": "cargo build --target wasm32-unknown-unknown --package  rust_deps --release",
-      "candid": "src/rust_deps/deps.did",
+      "build": "cargo build --target wasm32-unknown-unknown --package rust_deps --release",
+      "candid": "src/rust_deps/src/deps.did",
       "wasm": "target/wasm32-unknown-unknown/release/rust_deps.wasm",
       "type": "custom",
       "dependencies": [


### PR DESCRIPTION
Switched the attribute of read() to query as it is otherwise inconsistent with the suggested candid file.