### PR TITLE
refactor: deprecate block_on in favour of the new spawn function

### DIFF
--- a/src/ic-cdk-macros/src/export.rs
+++ b/src/ic-cdk-macros/src/export.rs
@@ -193,7 +193,7 @@ fn dfn_macro(
 
             #guard
 
-            ic_cdk::block_on(async {
+            ic_cdk::spawn(async {
                 #arg_decode
                 let result = #function_call;
                 #return_encode

--- a/src/ic-cdk-macros/src/export.rs
+++ b/src/ic-cdk-macros/src/export.rs
@@ -306,7 +306,7 @@ mod test {
             #[export_name = "canister_query query"]
             fn #fn_name() {
                 ic_cdk::setup();
-                ic_cdk::block_on(async {
+                ic_cdk::spawn(async {
                     let () = ic_cdk::api::call::arg_data();
                     let result = query();
                     ic_cdk::api::call::reply(())
@@ -343,7 +343,7 @@ mod test {
             #[export_name = "canister_query query"]
             fn #fn_name() {
                 ic_cdk::setup();
-                ic_cdk::block_on(async {
+                ic_cdk::spawn(async {
                     let () = ic_cdk::api::call::arg_data();
                     let result = query();
                     ic_cdk::api::call::reply((result,))
@@ -380,7 +380,7 @@ mod test {
             #[export_name = "canister_query query"]
             fn #fn_name() {
                 ic_cdk::setup();
-                ic_cdk::block_on(async {
+                ic_cdk::spawn(async {
                     let () = ic_cdk::api::call::arg_data();
                     let result = query();
                     ic_cdk::api::call::reply(result)
@@ -417,7 +417,7 @@ mod test {
             #[export_name = "canister_query query"]
             fn #fn_name() {
                 ic_cdk::setup();
-                ic_cdk::block_on(async {
+                ic_cdk::spawn(async {
                     let (a, ) = ic_cdk::api::call::arg_data();
                     let result = query(a);
                     ic_cdk::api::call::reply(())
@@ -454,7 +454,7 @@ mod test {
             #[export_name = "canister_query query"]
             fn #fn_name() {
                 ic_cdk::setup();
-                ic_cdk::block_on(async {
+                ic_cdk::spawn(async {
                     let (a, b, ) = ic_cdk::api::call::arg_data();
                     let result = query(a, b);
                     ic_cdk::api::call::reply(())
@@ -491,7 +491,7 @@ mod test {
             #[export_name = "canister_query query"]
             fn #fn_name() {
                 ic_cdk::setup();
-                ic_cdk::block_on(async {
+                ic_cdk::spawn(async {
                     let (a, b, ) = ic_cdk::api::call::arg_data();
                     let result = query(a, b);
                     ic_cdk::api::call::reply((result,))
@@ -528,7 +528,7 @@ mod test {
             #[export_name = "canister_query custom_query"]
             fn #fn_name() {
                 ic_cdk::setup();
-                ic_cdk::block_on(async {
+                ic_cdk::spawn(async {
                     let () = ic_cdk::api::call::arg_data();
                     let result = query();
                     ic_cdk::api::call::reply(())

--- a/src/ic-cdk/src/futures.rs
+++ b/src/ic-cdk/src/futures.rs
@@ -18,7 +18,7 @@ use std::task::Context;
 /// API requires us to pass one thin pointer, while a a pointer to a `dyn Trait`
 /// can only be fat. So we create one additional thin pointer, pointing to the
 /// fat pointer and pass it instead.
-pub fn block_on<F: 'static + Future<Output = ()>>(future: F) {
+pub fn spawn<F: 'static + Future<Output = ()>>(future: F) {
     let future_ptr = Box::into_raw(Box::new(future));
     let future_ptr_ptr: *mut *mut dyn Future<Output = ()> = Box::into_raw(Box::new(future_ptr));
     let mut pinned_future = unsafe { Pin::new_unchecked(&mut *future_ptr) };

--- a/src/ic-cdk/src/lib.rs
+++ b/src/ic-cdk/src/lib.rs
@@ -36,7 +36,7 @@ pub fn setup() {
 
 /// See documentation for [spawn].
 #[deprecated(
-    since = "0.3.1",
+    since = "0.3.4",
     note = "Use the spawn() function instead, it does the same thing but is more appropriately named."
 )]
 pub fn block_on<F: 'static + std::future::Future<Output = ()>>(future: F) {

--- a/src/ic-cdk/src/lib.rs
+++ b/src/ic-cdk/src/lib.rs
@@ -34,9 +34,19 @@ pub fn setup() {
     printer::hook()
 }
 
-/// Block on a promise in a WASM-friendly way (no multithreading!).
+/// See documentation for [spawn].
+#[deprecated(
+    since = "0.3.1",
+    note = "Use the spawn() function instead, it does the same thing but is more appropriately named."
+)]
 pub fn block_on<F: 'static + std::future::Future<Output = ()>>(future: F) {
-    futures::block_on(future);
+    futures::spawn(future);
+}
+
+/// Spawn an asynchronous task that drives the provided future to
+/// completion.
+pub fn spawn<F: 'static + std::future::Future<Output = ()>>(future: F) {
+    futures::spawn(future);
 }
 
 /// Format and then print the formatted message


### PR DESCRIPTION
This PR provides the functionality of `block_on` under a better name,
`spawn`. The `block_on` function is marked as deprecated in favour of
`spawn`.

Closes #7 and #174.