### PR TITLE
chore: Remove default features

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ In Cargo.toml:
 crate-type = ["cdylib"]
 
 [dependencies]
-ic-cdk = "0.3"
-ic-cdk-macros = "0.3"
+candid = "0.7.4" # this is required if you want to use the `#[import]` macro
+ic-cdk = "0.4"
+ic-cdk-macros = "0.4"
 ```
 
 Then in your rust source code:

--- a/docs/modules/rust-guide/pages/rust-profile.adoc
+++ b/docs/modules/rust-guide/pages/rust-profile.adoc
@@ -101,8 +101,8 @@ To replace the default program:
 [source,toml]
 ----
 [dependencies]
-ic-cdk = "0.3"
-ic-cdk-macros = "0.3"
+ic-cdk = "0.4"
+ic-cdk-macros = "0.4"
 serde = "1.0"
 ----
 +

--- a/docs/modules/rust-guide/pages/rust-quickstart.adoc
+++ b/docs/modules/rust-guide/pages/rust-quickstart.adoc
@@ -136,8 +136,8 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-ic-cdk = "0.3"
-ic-cdk-macros = "0.3"
+ic-cdk = "0.4"
+ic-cdk-macros = "0.4"
 ----
 
 Notice the `+crate-type = ["cdylib"]+` line which is necessary to compile this rust program into WebAssembly module.

--- a/examples/asset_storage/src/asset_storage_rs/Cargo.toml
+++ b/examples/asset_storage/src/asset_storage_rs/Cargo.toml
@@ -11,5 +11,5 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-ic-cdk = { path = "../../../../src/ic-cdk", version = "0.3" }
-ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.3" }
+ic-cdk = { path = "../../../../src/ic-cdk", version = "0.4" }
+ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.4" }

--- a/examples/chess/src/chess_rs/Cargo.toml
+++ b/examples/chess/src/chess_rs/Cargo.toml
@@ -11,6 +11,7 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
+candid = "0.7.4"
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.3" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.3" }
 serde = "1.0.111"

--- a/examples/chess/src/chess_rs/Cargo.toml
+++ b/examples/chess/src/chess_rs/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 candid = "0.7.4"
-ic-cdk = { path = "../../../../src/ic-cdk", version = "0.3" }
-ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.3" }
+ic-cdk = { path = "../../../../src/ic-cdk", version = "0.4" }
+ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.4" }
 serde = "1.0.111"
 pleco = "0.5.0"

--- a/examples/counter/src/counter_rs/Cargo.toml
+++ b/examples/counter/src/counter_rs/Cargo.toml
@@ -12,6 +12,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 candid = "0.7.4"
-ic-cdk = { path = "../../../../src/ic-cdk", version = "0.3" }
-ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.3" }
+ic-cdk = { path = "../../../../src/ic-cdk", version = "0.4" }
+ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.4" }
 lazy_static = "1.4.0"

--- a/examples/counter/src/counter_rs/Cargo.toml
+++ b/examples/counter/src/counter_rs/Cargo.toml
@@ -11,6 +11,7 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
+candid = "0.7.4"
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.3" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.3" }
 lazy_static = "1.4.0"

--- a/examples/counter/src/inter2_rs/Cargo.toml
+++ b/examples/counter/src/inter2_rs/Cargo.toml
@@ -11,5 +11,6 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
+candid = "0.7.4"
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.3" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.3" }

--- a/examples/counter/src/inter2_rs/Cargo.toml
+++ b/examples/counter/src/inter2_rs/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 candid = "0.7.4"
-ic-cdk = { path = "../../../../src/ic-cdk", version = "0.3" }
-ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.3" }
+ic-cdk = { path = "../../../../src/ic-cdk", version = "0.4" }
+ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.4" }

--- a/examples/counter/src/inter_rs/Cargo.toml
+++ b/examples/counter/src/inter_rs/Cargo.toml
@@ -11,5 +11,6 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
+candid = "0.7.4"
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.3" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.3" }

--- a/examples/counter/src/inter_rs/Cargo.toml
+++ b/examples/counter/src/inter_rs/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 candid = "0.7.4"
-ic-cdk = { path = "../../../../src/ic-cdk", version = "0.3" }
-ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.3" }
+ic-cdk = { path = "../../../../src/ic-cdk", version = "0.4" }
+ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.4" }

--- a/examples/print/src/print_rs/Cargo.toml
+++ b/examples/print/src/print_rs/Cargo.toml
@@ -11,6 +11,6 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-ic-cdk = { path = "../../../../src/ic-cdk", version = "0.3" }
-ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.3" }
+ic-cdk = { path = "../../../../src/ic-cdk", version = "0.4" }
+ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.4" }
 

--- a/examples/profile/src/profile_inter_rs/Cargo.toml
+++ b/examples/profile/src/profile_inter_rs/Cargo.toml
@@ -11,5 +11,6 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
+candid = "0.7.4"
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.3" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.3" }

--- a/examples/profile/src/profile_inter_rs/Cargo.toml
+++ b/examples/profile/src/profile_inter_rs/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 candid = "0.7.4"
-ic-cdk = { path = "../../../../src/ic-cdk", version = "0.3" }
-ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.3" }
+ic-cdk = { path = "../../../../src/ic-cdk", version = "0.4" }
+ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.4" }

--- a/examples/profile/src/profile_rs/Cargo.toml
+++ b/examples/profile/src/profile_rs/Cargo.toml
@@ -11,6 +11,7 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
+candid = "0.7.4"
 ic-cdk = { path = "../../../../src/ic-cdk", version = "0.3" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.3" }
 serde = "1.0.111"

--- a/examples/profile/src/profile_rs/Cargo.toml
+++ b/examples/profile/src/profile_rs/Cargo.toml
@@ -12,6 +12,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 candid = "0.7.4"
-ic-cdk = { path = "../../../../src/ic-cdk", version = "0.3" }
-ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.3" }
+ic-cdk = { path = "../../../../src/ic-cdk", version = "0.4" }
+ic-cdk-macros = { path = "../../../../src/ic-cdk-macros", version = "0.4" }
 serde = "1.0.111"

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -26,7 +26,3 @@ serde = "1.0.111"
 
 [dev-dependencies]
 trybuild = "1.0"
-
-[features]
-default = ["redirect"]
-redirect = ["candid/cdk"]

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-macros"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Canister Developer Kit macros."
@@ -17,7 +17,7 @@ proc-macro = true
 
 [dependencies]
 candid = "0.7.4"
-ic-cdk = { path = "../ic-cdk", version = "0.3" }
+ic-cdk = { path = "../ic-cdk", version = "0.4" }
 syn = { version = "1.0.58", features = ["fold", "full"] }
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Canister Developer Kit for the Internet Computer."

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -18,6 +18,4 @@ cfg-if = "1.0.0"
 serde = "1.0.110"
 
 [features]
-default = ["redirect"]
-redirect = ["candid/cdk"]
 experimental = []

--- a/src/ic-ledger-types/Cargo.toml
+++ b/src/ic-ledger-types/Cargo.toml
@@ -15,6 +15,7 @@ include = ["src", "Cargo.toml", "CHANGELOG.md", "LICENSE", "README.md"]
 
 [dependencies]
 ic-cdk = { path = "../ic-cdk", version = "0.3" }
+candid = "0.7.4"
 crc32fast = "1.2.0"
 hex = "0.4"
 serde = "1"

--- a/src/ic-ledger-types/Cargo.toml
+++ b/src/ic-ledger-types/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src", "Cargo.toml", "CHANGELOG.md", "LICENSE", "README.md"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ic-cdk = { path = "../ic-cdk", version = "0.3" }
+ic-cdk = { path = "../ic-cdk", version = "0.4" }
 candid = "0.7.4"
 crc32fast = "1.2.0"
 hex = "0.4"


### PR DESCRIPTION
This PR removes the default features from `ic-cdk` and `ic-cdk-macros` which in turn enable the `cdk` feature in `candid`.

### Motivation

The default features are tricky because they end up getting enabled in situations where you don't want them to, e.g. if you have a dependency which in turn depends on candid but without enabling this feature, then you end up with code that doesn't compile (because there are two crates pulling the same one, once with the feature on and once without). This results in not being able to use `ic-cdk` and `ic-cdk-macros` with e.g. parts of the `ic` repository which makes certain things, that should be easy quite, hard to implement in your canister. 

Even worse, if you try to disable default features when importing `ic-cdk` and `ic-cdk-macros`, you actually still end up enabling the default features because `ic-cdk-macros` depends on `ic-cdk` with default features on. So, even if you are trying to be extra careful and disable default features everywhere in your dependencies, you are still stuck with them.

### Proposed solution

The proposed solution is to remove the default features from `ic-cdk` and `ic-cdk-macros`. This results in having to add `candid` as an explicit dependency in your projects (see some of the examples which are fixed in this patch) but this doesn't seem to be a big burden given the headaches that one saves.