### PR TITLE
chore: publish ic-ledger-types v0.1.1

### DIFF
--- a/src/ic-ledger-types/CHANGELOG.md
+++ b/src/ic-ledger-types/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2022-02-04
+### Changed
+* Upgrade `ic-cdk` to v0.4.0.
+
 ## [0.1.0] - 2021-11-11
 ### Added
 * Initial release of the library.

--- a/src/ic-ledger-types/Cargo.toml
+++ b/src/ic-ledger-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-ledger-types"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Types for interacting with the ICP ledger canister."


### PR DESCRIPTION
use `ic-cdk` v0.4.0