### PR TITLE
chore: Add rust-toolchain.toml and point to 1.55.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.55.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Sync this file and the CI configuration.