### PR TITLE
feat: Allow configuring export macros to not reply

### DIFF
--- a/docs/modules/rust-guide/examples/profile-tutorial/profile.rs
+++ b/docs/modules/rust-guide/examples/profile-tutorial/profile.rs
@@ -1,6 +1,6 @@
 use ic_cdk::storage;
 use ic_cdk::{
-    call::{self, Empty},
+    call::{self, ManualReply},
     export::{
         candid::{CandidType, Deserialize},
         Principal,
@@ -52,25 +52,21 @@ fn update(profile: Profile) {
 }
 
 #[query(reply = true)]
-fn search(text: String) -> Empty<Option<Profile>> {
+fn search(text: String) -> ManualReply<Option<Profile>> {
     let text = text.to_lowercase();
     let profile_store = storage::get::<ProfileStore>();
 
-    let mut profile = None;
     for (_, p) in profile_store.iter() {
         if p.name.to_lowercase().contains(&text) || p.description.to_lowercase().contains(&text) {
-            profile = Some(p);
-            break;
+            return ManualReply::one(Some(p));
         }
 
         for x in p.keywords.iter() {
             if x.to_lowercase() == text {
-                profile = Some(p);
-                break;
+                return ManualReply::one(Some(p));
             }
         }
     }
 
-    call::reply(profile);
-    Empty::empty()
+    ManualReply::one(None::<Profile>)
 }

--- a/docs/modules/rust-guide/examples/profile-tutorial/profile.rs
+++ b/docs/modules/rust-guide/examples/profile-tutorial/profile.rs
@@ -51,7 +51,7 @@ fn update(profile: Profile) {
     profile_store.insert(principal_id, profile);
 }
 
-#[query(reply = true)]
+#[query(manual_reply = true)]
 fn search(text: String) -> ManualReply<Option<Profile>> {
     let text = text.to_lowercase();
     let profile_store = storage::get::<ProfileStore>();

--- a/docs/modules/rust-guide/examples/profile-tutorial/profile.rs
+++ b/docs/modules/rust-guide/examples/profile-tutorial/profile.rs
@@ -1,11 +1,11 @@
+use ic_cdk::storage;
 use ic_cdk::{
+    call::{self, Empty},
     export::{
         candid::{CandidType, Deserialize},
         Principal,
     },
-    call::{self, Empty},
 };
-use ic_cdk::storage;
 use ic_cdk_macros::*;
 use std::collections::BTreeMap;
 

--- a/examples/asset_storage/src/asset_storage_rs/lib.rs
+++ b/examples/asset_storage/src/asset_storage_rs/lib.rs
@@ -36,7 +36,7 @@ fn retrieve(path: String) -> Empty<Vec<u8>> {
     let store = storage::get::<Store>();
 
     match store.get(&path) {
-        Some(content) => call::reply(content),
+        Some(content) => call::reply((content,)),
         None => panic!("Path {} not found.", path),
     }
     Empty::empty()

--- a/examples/asset_storage/src/asset_storage_rs/lib.rs
+++ b/examples/asset_storage/src/asset_storage_rs/lib.rs
@@ -1,4 +1,8 @@
-use ic_cdk::{storage, export::Principal, api::call::{self, Empty}};
+use ic_cdk::{
+    api::call::{self, Empty},
+    export::Principal,
+    storage,
+};
 use ic_cdk_macros::*;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -28,7 +32,7 @@ fn store(path: String, contents: Vec<u8>) {
 }
 
 #[query(reply = true)]
-fn retrieve(path: String) -> Empty<Vec<u8> {
+fn retrieve(path: String) -> Empty<Vec<u8>> {
     let store = storage::get::<Store>();
 
     match store.get(&path) {

--- a/examples/asset_storage/src/asset_storage_rs/lib.rs
+++ b/examples/asset_storage/src/asset_storage_rs/lib.rs
@@ -1,4 +1,4 @@
-use ic_cdk::{storage, export::Principal};
+use ic_cdk::{storage, export::Principal, api::call::{self, Empty}};
 use ic_cdk_macros::*;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -27,14 +27,15 @@ fn store(path: String, contents: Vec<u8>) {
     store.insert(path, contents);
 }
 
-#[query]
-fn retrieve(path: String) -> &'static Vec<u8> {
+#[query(reply = true)]
+fn retrieve(path: String) -> Empty<Vec<u8> {
     let store = storage::get::<Store>();
 
     match store.get(&path) {
-        Some(content) => content,
+        Some(content) => call::reply(content),
         None => panic!("Path {} not found.", path),
     }
+    Empty::empty()
 }
 
 #[update(guard = "is_user")]

--- a/examples/asset_storage/src/asset_storage_rs/lib.rs
+++ b/examples/asset_storage/src/asset_storage_rs/lib.rs
@@ -31,7 +31,7 @@ fn store(path: String, contents: Vec<u8>) {
     store.insert(path, contents);
 }
 
-#[query(reply = true)]
+#[query(manual_reply = true)]
 fn retrieve(path: String) -> ManualReply<Vec<u8>> {
     let store = storage::get::<Store>();
 

--- a/examples/asset_storage/src/asset_storage_rs/lib.rs
+++ b/examples/asset_storage/src/asset_storage_rs/lib.rs
@@ -1,5 +1,5 @@
 use ic_cdk::{
-    api::call::{self, Empty},
+    api::call::{self, ManualReply},
     export::Principal,
     storage,
 };
@@ -32,14 +32,13 @@ fn store(path: String, contents: Vec<u8>) {
 }
 
 #[query(reply = true)]
-fn retrieve(path: String) -> Empty<Vec<u8>> {
+fn retrieve(path: String) -> ManualReply<Vec<u8>> {
     let store = storage::get::<Store>();
 
     match store.get(&path) {
-        Some(content) => call::reply((content,)),
+        Some(content) => ManualReply::one(content),
         None => panic!("Path {} not found.", path),
     }
-    Empty::empty()
 }
 
 #[update(guard = "is_user")]

--- a/examples/counter/src/counter_rs/lib.rs
+++ b/examples/counter/src/counter_rs/lib.rs
@@ -23,7 +23,7 @@ fn inc() -> () {
     }
 }
 
-#[query(reply = true)]
+#[query(manual_reply = true)]
 fn read() -> ManualReply<candid::Nat> {
     unsafe { ManualReply::one(COUNTER.as_mut().unwrap()) }
 }

--- a/examples/counter/src/counter_rs/lib.rs
+++ b/examples/counter/src/counter_rs/lib.rs
@@ -1,5 +1,5 @@
 use ic_cdk::{
-    api::call::{self, Empty},
+    api::call::{self, ManualReply},
     export::{candid, Principal},
 };
 use ic_cdk_macros::*;
@@ -24,9 +24,8 @@ fn inc() -> () {
 }
 
 #[query(reply = true)]
-fn read() -> Empty<candid::Nat> {
-    unsafe { call::reply((COUNTER.as_mut().unwrap(),)) };
-    Empty::empty()
+fn read() -> ManualReply<candid::Nat> {
+    unsafe { ManualReply::one(COUNTER.as_mut().unwrap()) }
 }
 
 #[update]

--- a/examples/counter/src/counter_rs/lib.rs
+++ b/examples/counter/src/counter_rs/lib.rs
@@ -25,7 +25,7 @@ fn inc() -> () {
 
 #[query(reply = true)]
 fn read() -> Empty<candid::Nat> {
-    unsafe { call::reply(&COUNTER.as_mut().unwrap()) };
+    unsafe { call::reply((COUNTER.as_mut().unwrap(),)) };
     Empty::empty()
 }
 

--- a/examples/counter/src/counter_rs/lib.rs
+++ b/examples/counter/src/counter_rs/lib.rs
@@ -1,5 +1,8 @@
+use ic_cdk::{
+    api::call::{self, Empty},
+    export::{candid, Principal},
+};
 use ic_cdk_macros::*;
-use ic_cdk::{export::{candid, Principal}, api::call::{self, Empty}};
 
 static mut COUNTER: Option<candid::Nat> = None;
 static mut OWNER: Option<Principal> = None;

--- a/examples/counter/src/counter_rs/lib.rs
+++ b/examples/counter/src/counter_rs/lib.rs
@@ -1,5 +1,5 @@
 use ic_cdk_macros::*;
-use ic_cdk::export::{candid, Principal};
+use ic_cdk::{export::{candid, Principal}, api::call::{self, Empty}};
 
 static mut COUNTER: Option<candid::Nat> = None;
 static mut OWNER: Option<Principal> = None;
@@ -20,9 +20,10 @@ fn inc() -> () {
     }
 }
 
-#[query]
-fn read() -> candid::Nat {
-    unsafe { COUNTER.as_mut().unwrap().clone() }
+#[query(reply = true)]
+fn read() -> Empty<candid::Nat> {
+    unsafe { call::reply(&COUNTER.as_mut().unwrap()) };
+    Empty::empty()
 }
 
 #[update]

--- a/examples/profile/src/profile_rs/lib.rs
+++ b/examples/profile/src/profile_rs/lib.rs
@@ -1,6 +1,6 @@
 use ic_cdk::storage;
 use ic_cdk::{
-    api::call::{self, Empty},
+    api::call::{self, ManualReply},
     export::{
         candid::{CandidType, Deserialize},
         Principal,
@@ -52,25 +52,21 @@ fn update(profile: Profile) {
 }
 
 #[query(reply = true)]
-fn search(text: String) -> Empty<Option<Profile>> {
+fn search(text: String) -> ManualReply<Option<Profile>> {
     let text = text.to_lowercase();
     let profile_store = storage::get::<ProfileStore>();
 
-    let mut profile = None;
-    'outer: for (_, p) in profile_store.iter() {
+    for (_, p) in profile_store.iter() {
         if p.name.to_lowercase().contains(&text) || p.description.to_lowercase().contains(&text) {
-            profile = Some(p);
-            break 'outer;
+            return ManualReply::one(Some(p));
         }
 
         for x in p.keywords.iter() {
             if x.to_lowercase() == text {
-                profile = Some(p);
-                break 'outer;
+                return ManualReply::one(Some(p));
             }
         }
     }
 
-    call::reply((profile,));
-    Empty::empty()
+    ManualReply::one(None::<Profile>)
 }

--- a/examples/profile/src/profile_rs/lib.rs
+++ b/examples/profile/src/profile_rs/lib.rs
@@ -1,6 +1,9 @@
-use ic_cdk::export::{
-    candid::{CandidType, Deserialize},
-    Principal,
+use ic_cdk::{
+    export::{
+        candid::{CandidType, Deserialize},
+        Principal,
+    },
+    call::{self, Empty},
 };
 use ic_cdk::storage;
 use ic_cdk_macros::*;
@@ -48,22 +51,26 @@ fn update(profile: Profile) {
     profile_store.insert(principal_id, profile);
 }
 
-#[query]
-fn search(text: String) -> Option<&'static Profile> {
+#[query(reply = true)]
+fn search(text: String) -> Empty<Option<Profile>> {
     let text = text.to_lowercase();
     let profile_store = storage::get::<ProfileStore>();
 
+    let mut profile = None;
     for (_, p) in profile_store.iter() {
         if p.name.to_lowercase().contains(&text) || p.description.to_lowercase().contains(&text) {
-            return Some(p);
+            profile = Some(p);
+            break;
         }
 
         for x in p.keywords.iter() {
             if x.to_lowercase() == text {
-                return Some(p);
+                profile = Some(p);
+                break;
             }
         }
     }
 
-    None
+    call::reply(profile);
+    Empty::empty()
 }

--- a/examples/profile/src/profile_rs/lib.rs
+++ b/examples/profile/src/profile_rs/lib.rs
@@ -1,6 +1,6 @@
 use ic_cdk::storage;
 use ic_cdk::{
-    call::{self, Empty},
+    api::call::{self, Empty},
     export::{
         candid::{CandidType, Deserialize},
         Principal,
@@ -57,20 +57,20 @@ fn search(text: String) -> Empty<Option<Profile>> {
     let profile_store = storage::get::<ProfileStore>();
 
     let mut profile = None;
-    for (_, p) in profile_store.iter() {
+    'outer: for (_, p) in profile_store.iter() {
         if p.name.to_lowercase().contains(&text) || p.description.to_lowercase().contains(&text) {
             profile = Some(p);
-            break;
+            break 'outer;
         }
 
         for x in p.keywords.iter() {
             if x.to_lowercase() == text {
                 profile = Some(p);
-                break;
+                break 'outer;
             }
         }
     }
 
-    call::reply(profile);
+    call::reply((profile,));
     Empty::empty()
 }

--- a/examples/profile/src/profile_rs/lib.rs
+++ b/examples/profile/src/profile_rs/lib.rs
@@ -51,7 +51,7 @@ fn update(profile: Profile) {
     profile_store.insert(principal_id, profile);
 }
 
-#[query(reply = true)]
+#[query(manual_reply = true)]
 fn search(text: String) -> ManualReply<Option<Profile>> {
     let text = text.to_lowercase();
     let profile_store = storage::get::<ProfileStore>();

--- a/examples/profile/src/profile_rs/lib.rs
+++ b/examples/profile/src/profile_rs/lib.rs
@@ -1,11 +1,11 @@
+use ic_cdk::storage;
 use ic_cdk::{
+    call::{self, Empty},
     export::{
         candid::{CandidType, Deserialize},
         Principal,
     },
-    call::{self, Empty},
 };
-use ic_cdk::storage;
 use ic_cdk_macros::*;
 use std::collections::BTreeMap;
 

--- a/src/ic-cdk-macros/src/export.rs
+++ b/src/ic-cdk-macros/src/export.rs
@@ -10,6 +10,8 @@ use syn::{spanned::Spanned, FnArg, ItemFn, Pat, PatIdent, PatType, ReturnType, S
 struct ExportAttributes {
     pub name: Option<String>,
     pub guard: Option<String>,
+    #[serde(default)]
+    pub reply: bool,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -152,7 +154,7 @@ fn dfn_macro(
 
     let arg_count = arg_tuple.len();
 
-    let return_encode = if method.is_lifecycle() {
+    let return_encode = if method.is_lifecycle() || attrs.reply {
         quote! {}
     } else {
         match return_length {

--- a/src/ic-cdk-macros/src/export.rs
+++ b/src/ic-cdk-macros/src/export.rs
@@ -11,7 +11,7 @@ struct ExportAttributes {
     pub name: Option<String>,
     pub guard: Option<String>,
     #[serde(default)]
-    pub reply: bool,
+    pub manual_reply: bool,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -154,7 +154,7 @@ fn dfn_macro(
 
     let arg_count = arg_tuple.len();
 
-    let return_encode = if method.is_lifecycle() || attrs.reply {
+    let return_encode = if method.is_lifecycle() || attrs.manual_reply {
         quote! {}
     } else {
         match return_length {

--- a/src/ic-cdk-macros/src/lib.rs
+++ b/src/ic-cdk-macros/src/lib.rs
@@ -90,21 +90,23 @@ where
 /// }
 /// ```
 ///
-/// If you would rather call the `reply` function than return a value, you
-/// will need to set `reply` to `true` so that the canister does not trap.
+/// If you would rather call the [`call::reply`] function than return a value,
+/// you will need to set `manual_reply` to `true` so that the canister does not
+/// trap.
 ///
 /// ```rust
 /// # fn calculate_result() {}
 /// # type MyResult = ();
 /// # use ic_cdk_macros::query;
-/// use ic_cdk::api::call::{self, Empty};
-/// #[query(reply = true)]
-/// fn query_function() -> Empty<MyResult> {
+/// use ic_cdk::api::call::{self, ManualReply};
+/// #[query(manual_reply = true)]
+/// fn query_function() -> ManualReply<MyResult> {
 ///     let result = calculate_result();
-///     call::reply(result); // instead of `return result;`
-///     Empty::empty()
+///     ManualReply::one(result)
 /// }
 /// ```
+/// 
+/// [`reply`]: ic_cdk::api::call::reply
 #[proc_macro_attribute]
 pub fn query(attr: TokenStream, item: TokenStream) -> TokenStream {
     handle_debug_and_errors(export::ic_query, "ic_query", attr, item)
@@ -137,21 +139,23 @@ pub fn query(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// If you would rather call the `reply` function than return a value, you
-/// will need to set `reply` to `true` so that the canister does not trap.
+/// If you would rather call the [`call::reply`] function than return a value,
+/// you will need to set `manual_reply` to `true` so that the canister does not
+/// trap.
 ///
 /// ```rust
 /// # fn calculate_result() {}
 /// # type MyResult = ();
 /// # use ic_cdk_macros::update;
-/// use ic_cdk::api::call::{self, Empty};
-/// #[update(reply = true)]
-/// fn update_function() -> Empty<MyResult> {
+/// use ic_cdk::api::call::{self, ManualReply};
+/// #[update(manual_reply = true)]
+/// fn update_function() -> ManualReply<MyResult> {
 ///     let result = calculate_result();
-///     call::reply(result); // instead of `return result;`
-///     Empty::empty()
+///     ManualReply::one(result)
 /// }
 /// ```
+///
+/// [`reply`]: ic_cdk::api::call::reply
 #[proc_macro_attribute]
 pub fn update(attr: TokenStream, item: TokenStream) -> TokenStream {
     handle_debug_and_errors(export::ic_update, "ic_update", attr, item)

--- a/src/ic-cdk-macros/src/lib.rs
+++ b/src/ic-cdk-macros/src/lib.rs
@@ -105,7 +105,7 @@ where
 ///     ManualReply::one(result)
 /// }
 /// ```
-/// 
+///
 /// [`reply`]: ic_cdk::api::call::reply
 #[proc_macro_attribute]
 pub fn query(attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/src/ic-cdk-macros/src/lib.rs
+++ b/src/ic-cdk-macros/src/lib.rs
@@ -89,6 +89,22 @@ where
 /// # unimplemented!()
 /// }
 /// ```
+///
+/// If you would rather call the `reply` function than return a value, you
+/// will need to set `reply` to `false` so that the canister does not trap.
+///
+/// ```rust
+/// # fn calculate_result() {}
+/// # type MyResult = ();
+/// # use ic_cdk_macros::query;
+/// use ic_cdk::api::call::{self, Empty};
+/// #[query(reply = false)]
+/// fn query_function() -> Empty<MyResult> {
+///     let result = calculate_result();
+///     call::reply(result); // instead of `return result;`
+///     Empty::empty()
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn query(attr: TokenStream, item: TokenStream) -> TokenStream {
     handle_debug_and_errors(export::ic_query, "ic_query", attr, item)
@@ -118,6 +134,22 @@ pub fn query(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// fn update_function() {
 ///     // ...
 /// # unimplemented!()
+/// }
+/// ```
+///
+/// If you would rather call the `reply` function than return a value, you
+/// will need to set `reply` to `false` so that the canister does not trap.
+///
+/// ```rust
+/// # fn calculate_result() {}
+/// # type MyResult = ();
+/// # use ic_cdk_macros::update;
+/// use ic_cdk::api::call::{self, Empty};
+/// #[update(reply = false)]
+/// fn update_function() -> Empty<MyResult> {
+///     let result = calculate_result();
+///     call::reply(result); // instead of `return result;`
+///     Empty::empty()
 /// }
 /// ```
 #[proc_macro_attribute]

--- a/src/ic-cdk-macros/src/lib.rs
+++ b/src/ic-cdk-macros/src/lib.rs
@@ -91,14 +91,14 @@ where
 /// ```
 ///
 /// If you would rather call the `reply` function than return a value, you
-/// will need to set `reply` to `false` so that the canister does not trap.
+/// will need to set `reply` to `true` so that the canister does not trap.
 ///
 /// ```rust
 /// # fn calculate_result() {}
 /// # type MyResult = ();
 /// # use ic_cdk_macros::query;
 /// use ic_cdk::api::call::{self, Empty};
-/// #[query(reply = false)]
+/// #[query(reply = true)]
 /// fn query_function() -> Empty<MyResult> {
 ///     let result = calculate_result();
 ///     call::reply(result); // instead of `return result;`
@@ -138,14 +138,14 @@ pub fn query(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// ```
 ///
 /// If you would rather call the `reply` function than return a value, you
-/// will need to set `reply` to `false` so that the canister does not trap.
+/// will need to set `reply` to `true` so that the canister does not trap.
 ///
 /// ```rust
 /// # fn calculate_result() {}
 /// # type MyResult = ();
 /// # use ic_cdk_macros::update;
 /// use ic_cdk::api::call::{self, Empty};
-/// #[update(reply = false)]
+/// #[update(reply = true)]
 /// fn update_function() -> Empty<MyResult> {
 ///     let result = calculate_result();
 ///     call::reply(result); // instead of `return result;`

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -2,8 +2,10 @@
 use crate::api::{ic0, trap};
 use crate::export::Principal;
 use candid::utils::{ArgumentDecoder, ArgumentEncoder};
-use candid::{decode_args, encode_args, write_args};
+use candid::{decode_args, encode_args, write_args, CandidType};
+use serde::ser::Error;
 use std::future::Future;
+use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll, Waker};
 
@@ -394,4 +396,34 @@ pub fn method_name() -> String {
         ic0::msg_method_name_copy(bytes.as_mut_ptr() as i32, 0, len as i32);
     }
     String::from_utf8_lossy(&bytes).to_string()
+}
+
+/// Pretends to have the Candid type `T`, but unconditionally errors when serialized.
+/// Useful primarily as metadata when using `#[query(reply = false)]`,
+/// so an accurate Candid file can still be generated.
+#[derive(Debug, Copy, Clone, Default)]
+pub struct Empty<T: ?Sized>(PhantomData<T>);
+
+impl<T: ?Sized> Empty<T> {
+    /// Constructs a new `Empty`.
+    #[allow(clippy::self_named_constructors)]
+    pub const fn empty() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T> CandidType for Empty<T>
+where
+    T: CandidType + ?Sized,
+{
+    fn _ty() -> candid::types::Type {
+        T::_ty()
+    }
+    /// Unconditionally errors.
+    fn idl_serialize<S>(&self, _: S) -> Result<(), S::Error>
+    where
+        S: candid::types::Serializer,
+    {
+        Err(S::Error::custom("`Empty` cannot be serialized"))
+    }
 }

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -398,21 +398,41 @@ pub fn method_name() -> String {
     String::from_utf8_lossy(&bytes).to_string()
 }
 
-/// Pretends to have the Candid type `T`, but unconditionally errors when serialized.
-/// Useful primarily as metadata when using `#[query(reply = false)]`,
+/// Pretends to have the Candid type `T`, but unconditionally errors
+/// when serialized.
+/// 
+/// Usable, but not required, as metadata when using `#[query(reply = false)]`,
 /// so an accurate Candid file can still be generated.
 #[derive(Debug, Copy, Clone, Default)]
-pub struct Empty<T: ?Sized>(PhantomData<T>);
+pub struct ManualReply<T: ?Sized>(PhantomData<T>);
 
-impl<T: ?Sized> Empty<T> {
-    /// Constructs a new `Empty`.
+impl<T: ?Sized> ManualReply<T> {
+    /// Constructs a new `ManualReply`.
     #[allow(clippy::self_named_constructors)]
     pub const fn empty() -> Self {
         Self(PhantomData)
     }
+    /// Replies with the given value and returns a new `ManualReply`,
+    /// for a useful reply-then-return shortcut.
+    pub fn all<U>(value: U) -> Self
+    where
+        U: ArgumentEncoder,
+    {
+        reply(value);
+        Self::empty()
+    }
+    /// Replies with a one-element tuple around the given value and returns
+    /// a new `ManualReply`, for a useful reply-then-return shortcut.
+    pub fn one<U>(value: U) -> Self
+    where
+        U: CandidType,
+    {
+        reply((value,));
+        Self::empty()
+    }
 }
 
-impl<T> CandidType for Empty<T>
+impl<T> CandidType for ManualReply<T>
 where
     T: CandidType + ?Sized,
 {

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -400,7 +400,7 @@ pub fn method_name() -> String {
 
 /// Pretends to have the Candid type `T`, but unconditionally errors
 /// when serialized.
-/// 
+///
 /// Usable, but not required, as metadata when using `#[query(reply = false)]`,
 /// so an accurate Candid file can still be generated.
 #[derive(Debug, Copy, Clone, Default)]


### PR DESCRIPTION
Adds a `reply` field to `ic_cdk_macros`'s export macros, which controls whether `ic0.msg_reply` is called by the macro. If it is not, the canister function must (and therefore can) call that function itself. 

Also adds an `Empty` type to `ic_cdk::api::call`, for annotating not-physically-returning functions with the type they semantically return, for use with the former feature.