### PR TITLE
fix: do not call done() in stable_restore()

### DIFF
--- a/src/ic-cdk/src/storage.rs
+++ b/src/ic-cdk/src/storage.rs
@@ -23,8 +23,5 @@ where
     let mut de =
         candid::de::IDLDeserialize::new(bytes.as_slice()).map_err(|e| format!("{:?}", e))?;
     let res = candid::utils::ArgumentDecoder::decode(&mut de).map_err(|e| format!("{:?}", e))?;
-    // The idea here is to ignore an error that comes from Candid, because we have trailing
-    // bytes.
-    let _ = de.done();
     Ok(res)
 }


### PR DESCRIPTION
This change removes the call to decoder.done() in stable_restore().

Rationale:

 * done() almost always returns an error because the input is likely
   to contain trailing zero bytes.

 * Calling done() has no effect on the return value.

 * The error that done() constructs contains the dump of the whole state,
   which causes the decoder to allocate huge amounts of memory.
   All of these allocations are unnecessary because stable_restore()
   throws away the error right away.

Fixes #212.