### PR TITLE
feat: Take slice rather than owned Vec as input arg

### DIFF
--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -220,7 +220,7 @@ fn callback(state_ptr: *const InnerCell<CallFutureState<Vec<u8>>>) {
 pub fn call_raw(
     id: Principal,
     method: &str,
-    args_raw: Vec<u8>,
+    args_raw: &[u8],
     payment: u64,
 ) -> impl Future<Output = CallResult<Vec<u8>>> {
     let callee = id.as_slice();
@@ -266,7 +266,7 @@ pub async fn call<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     args: T,
 ) -> CallResult<R> {
     let args_raw = encode_args(args).expect("Failed to encode arguments.");
-    let bytes = call_raw(id, method, args_raw, 0).await?;
+    let bytes = call_raw(id, method, &args_raw, 0).await?;
     decode_args(&bytes).map_err(|err| trap(&format!("{:?}", err)))
 }
 
@@ -278,7 +278,7 @@ pub async fn call_with_payment<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a
     cycles: u64,
 ) -> CallResult<R> {
     let args_raw = encode_args(args).expect("Failed to encode arguments.");
-    let bytes = call_raw(id, method, args_raw, cycles).await?;
+    let bytes = call_raw(id, method, &args_raw, cycles).await?;
     decode_args(&bytes).map_err(|err| trap(&format!("{:?}", err)))
 }
 


### PR DESCRIPTION
This allows people to use `call_raw` without ever having to clone the bytes.