### PR TITLE
feat: Implement remaining 128-bit functions

### DIFF
--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Update canister calling API for 128-bit cycles (#228)
+
 ### Changed
 - Take slice rather than owned Vec as input arg (#217)
 - Remove non-stable storage API (#215)

--- a/src/ic-cdk/src/api.rs
+++ b/src/ic-cdk/src/api.rs
@@ -1,6 +1,6 @@
 //! System API and low level functions for it.
 use crate::export::Principal;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 
 pub mod call;
 pub mod stable;
@@ -55,10 +55,9 @@ pub fn canister_balance() -> u64 {
 
 /// Get the amount of funds available in the canister.
 pub fn canister_balance128() -> u128 {
-    let size = 16;
-    let mut buf = vec![0u8; size];
-    unsafe { ic0::canister_cycle_balance128(buf.as_mut_ptr() as i32) }
-    u128::from_le_bytes(buf.try_into().unwrap())
+    let mut recv = 0u128;
+    unsafe { ic0::canister_cycle_balance128(&mut recv as *mut u128 as i32) }
+    recv
 }
 
 /// Sets the certified data of this canister.


### PR DESCRIPTION
Implements user-facing versions of `ic0.msg_cycles_available128`, `ic0.msg_cycles_refunded128`, `ic0.msg_cycles_accept128`, and  `ic0.call_cycles_add128`.

Also adjusts `canister_balance128` to use a u128 as the buffer instead of `vec![0u8; 16]`.