### PR TITLE
Docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,26 @@
+name: Docker build
+
+on:
+  push:
+    branches:
+      - main
+      - docker
+  pull_request:
+
+jobs:
+  builder:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      # We use buildx and its GitHub Actions caching support `type=gha`. For
+      # more information, see
+      # https://github.com/docker/build-push-action/issues/539
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build base Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Use this with
+#
+# docker build . -t nns-dapp
+# container_id=$(docker create nns-dapp no-op)
+# docker cp $container_id:nns-dapp.wasm nns-dapp.wasm
+# docker rm --volumes $container_id
+
+# This is the "builder", i.e. the base image used later to build the final
+# code.
+FROM ubuntu:20.04 as builder
+SHELL ["bash", "-c"]
+
+
+ENV TZ=UTC
+
+ENV RUST_BACKTRACE=full
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+    apt -yq update && \
+    apt -yqq install --no-install-recommends curl ca-certificates \
+        build-essential pkg-config libssl-dev llvm-dev liblmdb-dev clang cmake \
+        git jq
+
+# Install Rust and Cargo in /opt
+ENV RUSTUP_HOME=/opt/rustup \
+    CARGO_HOME=/opt/cargo \
+    PATH=/opt/cargo/bin:$PATH
+
+# ARG rust_version=1.58.1
+ARG rust_version=1.55
+RUN curl --fail https://sh.rustup.rs -sSf \
+        | sh -s -- -y --default-toolchain ${rust_version}-x86_64-unknown-linux-gnu --no-modify-path && \
+    rustup default ${rust_version}-x86_64-unknown-linux-gnu && \
+    rustup target add wasm32-unknown-unknown
+
+ENV PATH=/cargo/bin:$PATH
+
+# Install IC CDK optimizer
+RUN cargo install --version 0.3.4 ic-cdk-optimizer

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,1 @@
+DOCKER_BUILDKIT=1 docker build --platform=linux/amd64 .

--- a/empty/Dockerfile
+++ b/empty/Dockerfile
@@ -35,8 +35,5 @@ RUN curl --fail https://sh.rustup.rs -sSf \
 
 ENV PATH=/cargo/bin:$PATH
 
-
-COPY . build
-WORKDIR build
-RUN rm -fr target
-RUN cargo build
+# Install IC CDK optimizer
+RUN cargo install --version 0.3.4 ic-cdk-optimizer

--- a/empty/docker-build.sh
+++ b/empty/docker-build.sh
@@ -1,0 +1,1 @@
+DOCKER_BUILDKIT=1 docker build --platform=linux/amd64 .


### PR DESCRIPTION
# Motivation
There are build errors when the nns-dapp is built in docker on M1 macs.  The error happens in wabt-rs, in ic-cdk.  The same error happens on intel macs, although it _sometimes_ succeeds.

# Changes
Two dockerfiles:
* One in the dir "empty" that does `cargo install ic-cdk-optimizer`
* One in the root dir that does `cargo build`
Both fail.  Need to figure out why.

Note: A similar cargo build docker run succeeds in wabt-rs so there is something going wrong in the interplay between these two repos.