### PR TITLE
feat: Add stdin param and auto-select output file

### DIFF
--- a/src/ic-cdk-optimizer/CHANGELOG.md
+++ b/src/ic-cdk-optimizer/CHANGELOG.md
@@ -5,8 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Specifying `-` as the input or output argument refers to stdin or stdout respectively (#230)
+
 ### Changed
 - Update clap to 3.1 (#209)
+- The output argument defaults to the input argument if unspecified (#230)
 
 ## [0.3.4] - 2022-02-07
 ### Fixed

--- a/src/ic-cdk-optimizer/src/main.rs
+++ b/src/ic-cdk-optimizer/src/main.rs
@@ -1,26 +1,27 @@
 use clap::Parser;
 use humansize::{file_size_opts, FileSize};
-use std::io::Read;
-use std::path::PathBuf;
+use std::io::{Read, Write};
+use std::path::{PathBuf, Path};
 
 mod passes;
 
 #[derive(Parser, Debug)]
 #[clap(version)]
 struct CommandLineOpts {
-    /// Input file to optimize. By default will use STDIN.
-    input: Option<PathBuf>,
+    /// Input file to optimize. By default, or if "-", will use STDIN.
+    #[clap(default_value("-"))]
+    input: PathBuf,
 
-    /// Output file. Required.
+    /// Output file. If unset, the original file will be overwritten. If "-", or if unset and the original was passed via STDIN, the result will go to STDOUT.
     #[clap(short, long)]
-    output: PathBuf,
+    output: Option<PathBuf>,
 }
 
 fn main() {
     let passes = passes::create();
     let opts = CommandLineOpts::parse();
-    let content = if let Some(i) = opts.input {
-        std::fs::read(&i).expect("Could not read the file.")
+    let content = if opts.input != Path::new("-") {
+        std::fs::read(&opts.input).expect("Could not read the file.")
     } else {
         let mut buff = Vec::new();
         std::io::stdin()
@@ -59,6 +60,10 @@ fn main() {
         wasm_back.len().file_size(file_size_opts::BINARY).unwrap(),
         (1.0 - ((wasm_back.len() as f64) / (original_wasm_size as f64))) * 100.0
     );
-
-    std::fs::write(opts.output, wasm_back).expect("Could not write output file.");
+    let outfile = opts.output.unwrap_or(opts.input);
+    if outfile == Path::new("-") {
+        std::io::stdout().write_all(&wasm_back).expect("Could not write output.");
+    } else {
+        std::fs::write(outfile, wasm_back).expect("Could not write output file.");
+    }
 }

--- a/src/ic-cdk-optimizer/src/main.rs
+++ b/src/ic-cdk-optimizer/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use humansize::{file_size_opts, FileSize};
 use std::io::{Read, Write};
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 
 mod passes;
 
@@ -62,7 +62,9 @@ fn main() {
     );
     let outfile = opts.output.unwrap_or(opts.input);
     if outfile == Path::new("-") {
-        std::io::stdout().write_all(&wasm_back).expect("Could not write output.");
+        std::io::stdout()
+            .write_all(&wasm_back)
+            .expect("Could not write output.");
     } else {
         std::fs::write(outfile, wasm_back).expect("Could not write output file.");
     }


### PR DESCRIPTION
Currently, the optimizer will only select stdin if no file is specified, which takes special effort to script around, and does not support stdout. This adds `-` input and output 'paths', which explicitly read from stdin and write to stdout respectively, following unix command conentions.

The interface also requires an output parameter, even though its primary usage is to overwrite the original file. This changes that so the output, if unspecified, will default to the input.