### PR TITLE
fix: Run inter-canister calls without awaiting

### DIFF
--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Do not call done() in stable_restore() (#216) 
 - Remove out-of-bounds vulnerability (#208)
+- Run inter-canister calls without awaiting (#233)
 
 ## [0.4.0] - 2022-01-26
 ### Changed

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -291,38 +291,47 @@ fn call_raw_internal(
 }
 
 /// Performs an asynchronous call to another canister via ic0.
-pub async fn call<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
+pub fn call<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     id: Principal,
     method: &str,
     args: T,
-) -> CallResult<R> {
+) -> impl Future<Output = CallResult<R>> {
     let args_raw = encode_args(args).expect("Failed to encode arguments.");
-    let bytes = call_raw(id, method, &args_raw, 0).await?;
-    decode_args(&bytes).map_err(|err| trap(&format!("{:?}", err)))
+    let fut = call_raw(id, method, &args_raw, 0);
+    async {
+        let bytes = fut.await?;
+        decode_args(&bytes).map_err(|err| trap(&format!("{:?}", err)))
+    }
 }
 
 /// Performs an asynchronous call to another canister and pay cycles at the same time.
-pub async fn call_with_payment<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
+pub fn call_with_payment<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     id: Principal,
     method: &str,
     args: T,
     cycles: u64,
-) -> CallResult<R> {
+) -> impl Future<Output = CallResult<R>> {
     let args_raw = encode_args(args).expect("Failed to encode arguments.");
-    let bytes = call_raw(id, method, &args_raw, cycles).await?;
-    decode_args(&bytes).map_err(|err| trap(&format!("{:?}", err)))
+    let fut = call_raw(id, method, &args_raw, cycles);
+    async {
+        let bytes = fut.await?;
+        decode_args(&bytes).map_err(|err| trap(&format!("{:?}", err)))
+    }
 }
 
 /// Performs an asynchronous call to another canister and pay cycles at the same time.
-pub async fn call_with_payment128<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
+pub fn call_with_payment128<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     id: Principal,
     method: &str,
     args: T,
     cycles: u128,
-) -> CallResult<R> {
+) -> impl Future<Output = CallResult<R>> {
     let args_raw = encode_args(args).expect("Failed to encode arguments.");
-    let bytes = call_raw128(id, method, &args_raw, cycles).await?;
-    decode_args(&bytes).map_err(|err| trap(&format!("{:?}", err)))
+    let fut = call_raw128(id, method, &args_raw, cycles);
+    async {
+        let bytes = fut.await?;
+        decode_args(&bytes).map_err(|err| trap(&format!("{:?}", err)))
+    }
 }
 
 /// Returns a result that maps over the call


### PR DESCRIPTION
Rust futures do nothing unless polled. This means that currently, call_raw will call the function whether it's awaited or not (since it is a manual future), but call/call_with_payment only actually make the call if awaited (since it is an `async fn`). This changes the implementation to have consistent behavior across the three function flavors (the caller can still disable this behavior by wrapping it in their own async block). As a bonus this no longer lifetimes the resulting future to the canister method name.