### PR TITLE
chore: Update Rust to 1.58.1

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - build: linux-stable
             os: ubuntu-latest
-            rust: 1.55.0
+            rust: 1.58.1
             dfx: 0.8.1
 
     steps:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [ 1.55.0 ]
+        rust: [ 1.58.1 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [ 1.55.0 ]
+        rust: [ 1.58.1 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,13 @@ jobs:
         include:
           - build: linux-stable
             os: ubuntu-latest
-            rust: 1.55.0
+            rust: 1.58.1
           - build: macos-stable
             os: macos-latest
-            rust: 1.55.0
+            rust: 1.58.1
           - build: windows-stable
             os: windows-latest
-            rust: 1.55.0
+            rust: 1.58.1
 
     steps:
       - uses: actions/checkout@v2

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.55.0"
+channel = "1.58.1"
 components = ["rustfmt", "clippy"]

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["api-bindings", "data-structures", "no-std", "development-tools::f
 keywords = ["internet-computer", "types", "dfinity", "canister", "cdk"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 repository = "https://github.com/dfinity/cdk-rs"
+rust-version = "1.58.1"
 
 [lib]
 proc-macro = true

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ic-cdk-macros"
 version = "0.5.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
-edition = "2018"
+edition = "2021"
 description = "Canister Developer Kit macros."
 homepage = "https://docs.rs/ic-cdk-macros"
 documentation = "https://docs.rs/ic-cdk-macros"

--- a/src/ic-cdk-macros/src/export.rs
+++ b/src/ic-cdk-macros/src/export.rs
@@ -131,10 +131,7 @@ fn dfn_macro(
         get_args(method, signature)?.iter().cloned().unzip();
     let name = &signature.ident;
 
-    let outer_function_ident = Ident::new(
-        &format!("{}_{}_", name.to_string(), crate::id()),
-        Span::call_site(),
-    );
+    let outer_function_ident = Ident::new(&format!("{}_{}_", name, crate::id()), Span::call_site());
 
     let export_name = if method.is_lifecycle() {
         format!("canister_{}", method)

--- a/src/ic-cdk-macros/src/import.rs
+++ b/src/ic-cdk-macros/src/import.rs
@@ -127,7 +127,7 @@ impl candid::codegen::rust::RustBindings for RustLanguageBinding {
             arguments = arguments_list,
             body = body,
             return_type = if returns.is_empty() {
-                format!("")
+                String::new()
             } else {
                 format!("-> ({},)", returns.to_vec().join(","))
             }

--- a/src/ic-cdk-macros/src/lib.rs
+++ b/src/ic-cdk-macros/src/lib.rs
@@ -233,6 +233,7 @@ pub fn update(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ```rust
 /// # use ic_cdk_macros::*;
+/// # use candid::*;
 ///
 /// #[derive(Clone, Debug, CandidType, Deserialize)]
 /// struct InitArg {

--- a/src/ic-cdk-macros/tests/compile_fail/only_function.stderr
+++ b/src/ic-cdk-macros/tests/compile_fail/only_function.stderr
@@ -1,5 +1,5 @@
 error: #[query] must be above a function.
-expected `fn`
+       expected `fn`
  --> tests/compile_fail/only_function.rs:4:1
   |
 4 | struct S;

--- a/src/ic-cdk-optimizer/Cargo.toml
+++ b/src/ic-cdk-optimizer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ic-cdk-optimizer"
 version = "0.3.4"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
-edition = "2018"
+edition = "2021"
 description = "WASM Optimizer for the IC CDK (experimental)."
 homepage = "https://docs.rs/ic-cdk-optimizer"
 documentation = "https://docs.rs/ic-cdk-optimizer"

--- a/src/ic-cdk-optimizer/Cargo.toml
+++ b/src/ic-cdk-optimizer/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["api-bindings", "data-structures", "no-std", "command-line-utiliti
 keywords = ["internet-computer", "dfinity", "canister", "cli", "optimizer"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 repository = "https://github.com/dfinity/cdk-rs"
+rust-version = "1.58.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["api-bindings", "data-structures", "no-std", "development-tools::f
 keywords = ["internet-computer", "types", "dfinity", "canister", "cdk"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 repository = "https://github.com/dfinity/cdk-rs"
+rust-version = "1.58.1"
 
 [dependencies]
 candid = "0.7.4"

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ic-cdk"
 version = "0.5.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
-edition = "2018"
+edition = "2021"
 description = "Canister Developer Kit for the Internet Computer."
 homepage = "https://docs.rs/ic-cdk"
 documentation = "https://docs.rs/ic-cdk"

--- a/src/ic-cdk/src/api/stable.rs
+++ b/src/ic-cdk/src/api/stable.rs
@@ -94,11 +94,9 @@ pub fn stable_bytes() -> Vec<u8> {
     let size = (stable_size() as usize) << 16;
     let mut vec = Vec::with_capacity(size);
     unsafe {
+        super::ic0::stable_read(vec.as_ptr() as i32, 0, size as i32);
         vec.set_len(size);
     }
-
-    stable_read(0, vec.as_mut_slice());
-
     vec
 }
 

--- a/src/ic-certified-assets/Cargo.toml
+++ b/src/ic-certified-assets/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 keywords = ["internet-computer", "dfinity"]
 categories = ["wasm", "filesystem", "data-structures"]
 repository = "https://github.com/dfinity/cdk-rs"
+rust-version = "1.58.1"
 
 [dependencies]
 base64 = "0.13"

--- a/src/ic-certified-assets/Cargo.toml
+++ b/src/ic-certified-assets/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ic-certified-assets"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Rust support for asset certification."
 license = "Apache-2.0"

--- a/src/ic-certified-map/Cargo.toml
+++ b/src/ic-certified-map/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["data-structures", "cryptography", "cryptography::cryptocurrencies
 keywords = ["internet-computer", "types", "dfinity", "map"]
 include = ["src", "Cargo.toml", "CHANGELOG.md", "LICENSE", "README.md"]
 repository = "https://github.com/dfinity/cdk-rs"
+rust-version = "1.58.1"
 
 [dependencies]
 serde = "1"

--- a/src/ic-certified-map/Cargo.toml
+++ b/src/ic-certified-map/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ic-certified-map"
 version = "0.3.0"
-edition = "2018"
+edition = "2021"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Merkleized map data structure."
 homepage = "https://docs.rs/ic-certified-map"

--- a/src/ic-ledger-types/Cargo.toml
+++ b/src/ic-ledger-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ic-ledger-types"
 version = "0.1.1"
-edition = "2018"
+edition = "2021"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Types for interacting with the ICP ledger canister."
 homepage = "https://docs.rs/ic-ledger-types"

--- a/src/ic-ledger-types/Cargo.toml
+++ b/src/ic-ledger-types/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["internet-computer", "ledger"]
 categories = ["cryptography::cryptocurrencies", "data-structures"]
 include = ["src", "Cargo.toml", "CHANGELOG.md", "LICENSE", "README.md"]
 repository = "https://github.com/dfinity/cdk-rs"
+rust-version = "1.58.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This updates the CI and toolchain file to 1.58.1, adds the new MSRV key to Cargo.toml, and sets the crate editions to 2021 edition. It also fixes an instance of UB identified by 1.58 clippy.