### PR TITLE
docs: Add warning to `stable_write` explaining scenario in which it panics

### DIFF
--- a/src/ic-cdk/src/api/stable.rs
+++ b/src/ic-cdk/src/api/stable.rs
@@ -60,6 +60,9 @@ pub fn stable64_grow(new_pages: u64) -> Result<u64, StableMemoryError> {
 }
 
 /// Writes data to the stable memory location specified by an offset.
+///
+/// Warning - this will panic if `offset + buf.len()` exceeds the current size of stable memory.
+/// Use `stable_grow` to request more stable memory if needed.
 pub fn stable_write(offset: u32, buf: &[u8]) {
     unsafe {
         super::ic0::stable_write(offset as i32, buf.as_ptr() as i32, buf.len() as i32);


### PR DESCRIPTION
# Description

Adds a warning to the `stable_write` method so that developers are made aware of the scenario in which it panics.
We were burnt by this in OpenChat and we'd like to ensure no other devs fall into the same trap.