### PR TITLE
feat: Add `grow_then_write_stable_bytes` helper method

### DIFF
--- a/src/ic-cdk/src/api/stable.rs
+++ b/src/ic-cdk/src/api/stable.rs
@@ -4,7 +4,9 @@
 //! for a in-depth explanation of stable memory.
 use std::{error, fmt, io};
 
-/// Gets current size of the stable memory.
+const WASM_PAGE_SIZE_IN_BYTES: u64 = 64 * 1024;
+
+/// Gets current size of the stable memory (in WASM pages).
 pub fn stable_size() -> u32 {
     unsafe { super::ic0::stable_size() as u32 }
 }
@@ -100,6 +102,22 @@ pub fn stable_bytes() -> Vec<u8> {
     vec
 }
 
+/// Ensures the stable memory size is large enough to perform the write, then writes data to the
+/// stable memory location specified by an offset.
+pub fn grow_then_write_stable_bytes(offset: u64, bytes: &[u8]) -> Result<(), StableMemoryError> {
+    let bytes_required = offset + bytes.len() as u64;
+    let pages_required = (bytes_required + WASM_PAGE_SIZE_IN_BYTES - 1) / WASM_PAGE_SIZE_IN_BYTES;
+    let current_pages = stable64_size();
+    let additional_pages_required = pages_required.saturating_sub(current_pages);
+
+    if additional_pages_required > 0 {
+        stable64_grow(additional_pages_required)?;
+    }
+
+    stable64_write(offset, bytes);
+    Ok(())
+}
+
 /// A writer to the stable memory.
 ///
 /// Will attempt to grow the memory as it writes,
@@ -136,11 +154,7 @@ impl StableWriter {
     /// The only condition where this will
     /// error out is if it cannot grow the memory.
     pub fn write(&mut self, buf: &[u8]) -> Result<usize, StableMemoryError> {
-        if self.offset + buf.len() > ((self.capacity as usize) << 16) {
-            self.grow((buf.len() >> 16) as u32 + 1)?;
-        }
-
-        stable_write(self.offset as u32, buf);
+        grow_then_write_stable_bytes(self.offset as u64, buf)?;
         self.offset += buf.len();
         Ok(buf.len())
     }

--- a/src/ic-cdk/src/api/stable.rs
+++ b/src/ic-cdk/src/api/stable.rs
@@ -4,7 +4,7 @@
 //! for a in-depth explanation of stable memory.
 use std::{error, fmt, io};
 
-const WASM_PAGE_SIZE_IN_BYTES: u64 = 64 * 1024;
+const WASM_PAGE_SIZE_IN_BYTES: u64 = 64 * 1024; // 64KB
 
 /// Gets current size of the stable memory (in WASM pages).
 pub fn stable_size() -> u32 {


### PR DESCRIPTION
# Description

Adds a new helper method, `grow_then_write_stable_bytes`, which simplifies writing bytes to stable memory by first growing the stable memory size if needed.

Also fixes a small bug where `StableWriter` was requesting more memory pages than needed (prior to this commit it would always request the total amount needed rather than only the incremental amount needed).

# How Has This Been Tested?

The `grow_then_write_stable_bytes` function was first implemented in OpenChat where we thoroughly tested it, upgrading canisters multiple times and adding lots of data between upgrades. After each upgrade we could see that the `stable_memory_size` value for the affected canister had increased on the replica dashboard.
This function is now running in the production OpenChat deployment.

I have also locally deployed a version of OpenChat which references this branch of the cdk and can again see the upgrades working correctly.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.