### PR TITLE
feat: Add a TryFrom instance for AccountIdentifier that checks CRC-32

### DIFF
--- a/src/ic-ledger-types/CHANGELOG.md
+++ b/src/ic-ledger-types/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Changed
+* Support conversion from `[u8; 32]` to `AccountIdentifier` via `TryFrom` with CRC-32 check.
+
 ## [0.1.1] - 2022-02-04
 ### Changed
 * Upgrade `ic-cdk` to v0.4.0.


### PR DESCRIPTION
# Description

We add a TryFrom instance from [u8; 32] to AccountIdentifier that checks if the bytes has a correct CRC-32 hash. 

This is a often required feature for an application that accepts account bytes from user input.

Also the ICP ledger canister itself will fail if CRC-32 is wrong. It is better to prevent wrong input in the construction. 

# How Has This Been Tested?

A simple unit test is added.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.