### PR TITLE
chore: Update dfx to 0.9.3 in CI

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -17,7 +17,7 @@ jobs:
           - build: linux-stable
             os: ubuntu-latest
             rust: 1.58.1
-            dfx: 0.8.1
+            dfx: 0.9.3
 
     steps:
       - uses: actions/checkout@v2

--- a/examples/asset_storage/tests/basic.bats
+++ b/examples/asset_storage/tests/basic.bats
@@ -19,10 +19,10 @@ teardown() {
 }
 
 @test "Can store and restore assets" {
-  dfx deploy --no-wallet
-  dfx canister --no-wallet call asset_storage store '("asset_name", vec { 1; 2; 3; })'
-  dfx canister --no-wallet call asset_storage retrieve '("asset_name")'
-  run dfx canister --no-wallet call asset_storage retrieve '("unknown")'
+  dfx deploy
+  dfx canister call asset_storage store '("asset_name", vec { 1; 2; 3; })'
+  dfx canister call asset_storage retrieve '("asset_name")'
+  run dfx canister call asset_storage retrieve '("unknown")'
   # As of dfx 0.8.1, above command results in following error message:
   # > The Replica returned an error: code 5, message: "IC0502: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped: unreachable"
   [ "$status" != 0 ]
@@ -30,45 +30,45 @@ teardown() {
 
 @test "Will fails on invalid identities" {
   dfx identity use alice
-  dfx deploy --no-wallet
-  dfx canister --no-wallet call asset_storage store '("asset_name", vec { 1; 2; 3; })'
-  dfx canister --no-wallet call asset_storage retrieve '("asset_name")'
+  dfx deploy
+  dfx canister call asset_storage store '("asset_name", vec { 1; 2; 3; })'
+  dfx canister call asset_storage retrieve '("asset_name")'
 
-  dfx canister --no-wallet call asset_storage add_user "(principal \"$(dfx --identity charlie identity get-principal)\")"
+  dfx canister call asset_storage add_user "(principal \"$(dfx --identity charlie identity get-principal)\")"
 
   dfx identity use bob
-  dfx canister --no-wallet call asset_storage retrieve '("asset_name")'
+  dfx canister call asset_storage retrieve '("asset_name")'
 
   # Test that an unknown asset fails.
-  run dfx canister --no-wallet call asset_storage retrieve '("unknown")'
+  run dfx canister call asset_storage retrieve '("unknown")'
   [ "$status" != 0 ]
 
   # Test that cannot upload assets as bob.
-  run dfx canister --no-wallet call asset_storage store '("asset_name", vec { 1; })'
+  run dfx canister call asset_storage store '("asset_name", vec { 1; })'
   [ "$status" != 0 ]
 
   # Test we can upload assets as charlie.
   dfx identity use charlie
-  run dfx canister --no-wallet call asset_storage store '("asset_name_2", vec { 1; 2; 3; })'
+  run dfx canister call asset_storage store '("asset_name_2", vec { 1; 2; 3; })'
   [ "$status" == 0 ]
 }
 
 @test "Can upgrade and keep ACLs" {
   dfx identity use alice
-  dfx deploy --no-wallet
+  dfx deploy
 
-  dfx canister --no-wallet call asset_storage store '("asset_name", vec { 1; 2; 3; })'
+  dfx canister call asset_storage store '("asset_name", vec { 1; 2; 3; })'
   dfx identity use bob
-  run dfx canister --no-wallet call asset_storage retrieve '("unknown")'
+  run dfx canister call asset_storage retrieve '("unknown")'
   [ "$status" != 0 ]
 
   dfx identity use alice
-  dfx canister --no-wallet call asset_storage add_user "(principal \"$(dfx --identity charlie identity get-principal)\")"
+  dfx canister call asset_storage add_user "(principal \"$(dfx --identity charlie identity get-principal)\")"
 
   dfx build
-  dfx canister --no-wallet install --all --mode=upgrade
+  dfx canister install --all --mode=upgrade
 
   dfx identity use charlie
-  run dfx canister --no-wallet call asset_storage store '("asset_name_2", vec { 1; 2; 3; })'
+  run dfx canister call asset_storage store '("asset_name_2", vec { 1; 2; 3; })'
   [ "$status" == 0 ]
 }

--- a/examples/chess/tests/basic.bats
+++ b/examples/chess/tests/basic.bats
@@ -17,13 +17,13 @@ teardown() {
 }
 
 @test "Can play chess against AI" {
-  dfx deploy --no-wallet
-  run dfx canister --no-wallet call chess_rs new '("test", true)'
+  dfx deploy
+  run dfx canister call chess_rs new '("test", true)'
   [ "$output" == "()" ]
-  run dfx canister --no-wallet call chess_rs move '("test", "e2e4")'
+  run dfx canister call chess_rs move '("test", "e2e4")'
   [ "$output" == "(true)" ]
-  run dfx canister --no-wallet call chess_rs move '("test", "d2d3")'
+  run dfx canister call chess_rs move '("test", "d2d3")'
   [ "$output" == "(true)" ]
-  run dfx canister --no-wallet call chess_rs getFen '("test")'
+  run dfx canister call chess_rs getFen '("test")'
   [ "$output" == '(opt "rnb1kbnr/pp1ppppp/1qp5/8/4P3/3P4/PPP2PPP/RNBQKBNR w KQkq - 1 3")' ]
 }


### PR DESCRIPTION
# Description

Update `dfx` used in CI to 0.9.3. Old `dfx` is blocking #240 

# How Has This Been Tested?

CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] ~~I have edited the CHANGELOG accordingly.~~
- [x] ~~I have made corresponding changes to the documentation.~~
