### PR TITLE
feat: Encapsulate logic to grow stable memory inside StableWriter

### DIFF
--- a/src/ic-cdk/src/api/stable.rs
+++ b/src/ic-cdk/src/api/stable.rs
@@ -142,7 +142,8 @@ impl StableWriter {
     /// error out is if it cannot grow the memory.
     pub fn write(&mut self, buf: &[u8]) -> Result<usize, StableMemoryError> {
         let memory_end_bytes = (self.offset + buf.len()) as u64;
-        let memory_end_pages = (memory_end_bytes + WASM_PAGE_SIZE_IN_BYTES - 1) / WASM_PAGE_SIZE_IN_BYTES;
+        let memory_end_pages =
+            (memory_end_bytes + WASM_PAGE_SIZE_IN_BYTES - 1) / WASM_PAGE_SIZE_IN_BYTES;
         let current_pages = self.capacity as u64;
         let additional_pages_required = memory_end_pages.saturating_sub(current_pages);
 


### PR DESCRIPTION
# Description

I think this improves upon the changes made in my previous PR (#240).
Instead of exposing `grow_then_write_stable_bytes`, I think this logic should simply be encapsulated inside `StableWriter` (which is actually where it was before #240).
So this PR simply moves the logic contained in `grow_then_write_stable_bytes` back into the body of `StableWriter.write`.
This keeps the API clean by only exposing the raw ic0 methods alongside `StableWriter` and `StableReader` which orchestrate over these methods.

# How Has This Been Tested?

I have deployed canisters locally and have upgraded them a few times while added data between each upgrade.
On the replica dashboard I can see the `stable_memory_size` grow after each upgrade.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
