### PR TITLE
feat: Add `BufferedStableWriter` which aims to minimise system calls

### DIFF
--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Added
+- Add `BufferedStableWriter` for efficient writing to stable memory (#245)
+
 ## [0.5.0] - 2022-03-29
 ### Added
 - Update canister calling API for 128-bit cycles (#228)

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -19,5 +19,8 @@ candid = "0.7.4"
 cfg-if = "1.0.0"
 serde = "1.0.110"
 
+[dev-dependencies]
+rstest = "0.12.0"
+
 [features]
 experimental = []

--- a/src/ic-cdk/src/api/stable.rs
+++ b/src/ic-cdk/src/api/stable.rs
@@ -131,6 +131,9 @@ pub fn stable_bytes() -> Vec<u8> {
 
 /// A writer to the stable memory.
 ///
+/// Warning: This will overwrite any existing data in stable memory as it writes, so ensure you set
+/// the `offset` value accordingly if you wish to preserve existing data.
+///
 /// Will attempt to grow the memory as it writes,
 /// and keep offsets and total capacity.
 pub struct StableWriter<M: StableMemory = CanisterStableMemory> {
@@ -204,6 +207,9 @@ impl<M: StableMemory> io::Write for StableWriter<M> {
 
 /// A writer to the stable memory which first writes the bytes to an in memory buffer and flushes
 /// the buffer to stable memory each time it becomes full.
+///
+/// Warning: This will overwrite any existing data in stable memory as it writes, so ensure you set
+/// the `offset` value accordingly if you wish to preserve existing data.
 ///
 /// Note: Each call to grow or write to stable memory is a relatively expensive operation, so pick a
 /// buffer size large enough to avoid excessive calls to stable memory.

--- a/src/ic-cdk/src/api/stable.rs
+++ b/src/ic-cdk/src/api/stable.rs
@@ -7,6 +7,7 @@ mod canister;
 mod tests;
 
 use canister::CanisterStableMemory;
+use std::cmp::Ordering;
 use std::{error, fmt, io};
 
 const WASM_PAGE_SIZE_IN_BYTES: u64 = 64 * 1024; // 64KB

--- a/src/ic-cdk/src/api/stable/canister.rs
+++ b/src/ic-cdk/src/api/stable/canister.rs
@@ -5,15 +5,15 @@ use crate::api::ic0;
 pub struct CanisterStableMemory {}
 
 impl StableMemory for CanisterStableMemory {
-    fn stable_size() -> u32 {
+    fn stable_size(&self) -> u32 {
         unsafe { ic0::stable_size() as u32 }
     }
 
-    fn stable64_size() -> u64 {
+    fn stable64_size(&self) -> u64 {
         unsafe { ic0::stable64_size() as u64 }
     }
 
-    fn stable_grow(new_pages: u32) -> Result<u32, StableMemoryError> {
+    fn stable_grow(&self, new_pages: u32) -> Result<u32, StableMemoryError> {
         unsafe {
             match ic0::stable_grow(new_pages as i32) {
                 -1 => Err(StableMemoryError::OutOfMemory),
@@ -22,7 +22,7 @@ impl StableMemory for CanisterStableMemory {
         }
     }
 
-    fn stable64_grow(new_pages: u64) -> Result<u64, StableMemoryError> {
+    fn stable64_grow(&self, new_pages: u64) -> Result<u64, StableMemoryError> {
         unsafe {
             match ic0::stable64_grow(new_pages as i64) {
                 -1 => Err(StableMemoryError::OutOfMemory),
@@ -31,25 +31,25 @@ impl StableMemory for CanisterStableMemory {
         }
     }
 
-    fn stable_write(offset: u32, buf: &[u8]) {
+    fn stable_write(&self, offset: u32, buf: &[u8]) {
         unsafe {
             ic0::stable_write(offset as i32, buf.as_ptr() as i32, buf.len() as i32);
         }
     }
 
-    fn stable64_write(offset: u64, buf: &[u8]) {
+    fn stable64_write(&self, offset: u64, buf: &[u8]) {
         unsafe {
             ic0::stable64_write(offset as i64, buf.as_ptr() as i64, buf.len() as i64);
         }
     }
 
-    fn stable_read(offset: u32, buf: &mut [u8]) {
+    fn stable_read(&self, offset: u32, buf: &mut [u8]) {
         unsafe {
             ic0::stable_read(buf.as_ptr() as i32, offset as i32, buf.len() as i32);
         }
     }
 
-    fn stable64_read(offset: u64, buf: &mut [u8]) {
+    fn stable64_read(&self, offset: u64, buf: &mut [u8]) {
         unsafe {
             ic0::stable64_read(buf.as_ptr() as i64, offset as i64, buf.len() as i64);
         }

--- a/src/ic-cdk/src/api/stable/canister.rs
+++ b/src/ic-cdk/src/api/stable/canister.rs
@@ -1,5 +1,5 @@
-use crate::api::ic0;
 use super::*;
+use crate::api::ic0;
 
 #[derive(Default)]
 pub struct CanisterStableMemory {}

--- a/src/ic-cdk/src/api/stable/canister.rs
+++ b/src/ic-cdk/src/api/stable/canister.rs
@@ -1,0 +1,57 @@
+use crate::api::ic0;
+use super::*;
+
+#[derive(Default)]
+pub struct CanisterStableMemory {}
+
+impl StableMemory for CanisterStableMemory {
+    fn stable_size() -> u32 {
+        unsafe { ic0::stable_size() as u32 }
+    }
+
+    fn stable64_size() -> u64 {
+        unsafe { ic0::stable64_size() as u64 }
+    }
+
+    fn stable_grow(new_pages: u32) -> Result<u32, StableMemoryError> {
+        unsafe {
+            match ic0::stable_grow(new_pages as i32) {
+                -1 => Err(StableMemoryError::OutOfMemory),
+                x => Ok(x as u32),
+            }
+        }
+    }
+
+    fn stable64_grow(new_pages: u64) -> Result<u64, StableMemoryError> {
+        unsafe {
+            match ic0::stable64_grow(new_pages as i64) {
+                -1 => Err(StableMemoryError::OutOfMemory),
+                x => Ok(x as u64),
+            }
+        }
+    }
+
+    fn stable_write(offset: u32, buf: &[u8]) {
+        unsafe {
+            ic0::stable_write(offset as i32, buf.as_ptr() as i32, buf.len() as i32);
+        }
+    }
+
+    fn stable64_write(offset: u64, buf: &[u8]) {
+        unsafe {
+            ic0::stable64_write(offset as i64, buf.as_ptr() as i64, buf.len() as i64);
+        }
+    }
+
+    fn stable_read(offset: u32, buf: &mut [u8]) {
+        unsafe {
+            ic0::stable_read(buf.as_ptr() as i32, offset as i32, buf.len() as i32);
+        }
+    }
+
+    fn stable64_read(offset: u64, buf: &mut [u8]) {
+        unsafe {
+            ic0::stable64_read(buf.as_ptr() as i64, offset as i64, buf.len() as i64);
+        }
+    }
+}

--- a/src/ic-cdk/src/api/stable/tests.rs
+++ b/src/ic-cdk/src/api/stable/tests.rs
@@ -4,14 +4,12 @@ use std::sync::Mutex;
 
 #[derive(Default)]
 pub struct TestStableMemory {
-    memory: Rc<Mutex<Vec<u8>>>
+    memory: Rc<Mutex<Vec<u8>>>,
 }
 
 impl TestStableMemory {
     pub fn new(memory: Rc<Mutex<Vec<u8>>>) -> TestStableMemory {
-        TestStableMemory {
-            memory
-        }
+        TestStableMemory { memory }
     }
 }
 
@@ -75,7 +73,8 @@ mod buffer_writer_tests {
     #[test]
     fn write_single_slice() {
         let memory = Rc::new(Mutex::new(Vec::new()));
-        let mut writer = BufferedStableWriter::with_memory(1024, TestStableMemory::new(memory.clone()));
+        let mut writer =
+            BufferedStableWriter::with_memory(1024, TestStableMemory::new(memory.clone()));
 
         let bytes = vec![1; 128];
 
@@ -90,7 +89,8 @@ mod buffer_writer_tests {
     #[test]
     fn write_many_slices() {
         let memory = Rc::new(Mutex::new(Vec::new()));
-        let mut writer = BufferedStableWriter::with_memory(1024, TestStableMemory::new(memory.clone()));
+        let mut writer =
+            BufferedStableWriter::with_memory(1024, TestStableMemory::new(memory.clone()));
 
         for i in 1..100 {
             let bytes = vec![i as u8; i];
@@ -112,7 +112,8 @@ mod buffer_writer_tests {
     #[test]
     fn write_many_slices_some_exceeding_buffer_capacity() {
         let memory = Rc::new(Mutex::new(Vec::new()));
-        let mut writer = BufferedStableWriter::with_memory(10, TestStableMemory::new(memory.clone()));
+        let mut writer =
+            BufferedStableWriter::with_memory(10, TestStableMemory::new(memory.clone()));
 
         for i in 1..100 {
             let bytes = vec![i as u8; i];

--- a/src/ic-cdk/src/api/stable/tests.rs
+++ b/src/ic-cdk/src/api/stable/tests.rs
@@ -1,67 +1,133 @@
 use super::*;
-use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Mutex;
 
-thread_local! {
-    static MEMORY: RefCell<Vec<u8>> = RefCell::default();
+#[derive(Default)]
+pub struct TestStableMemory {
+    memory: Rc<Mutex<Vec<u8>>>
 }
 
-pub struct TestStableMemory {}
+impl TestStableMemory {
+    pub fn new(memory: Rc<Mutex<Vec<u8>>>) -> TestStableMemory {
+        TestStableMemory {
+            memory
+        }
+    }
+}
 
 impl StableMemory for TestStableMemory {
-    fn stable_size() -> u32 {
-        let bytes_len = MEMORY.with(|m| m.borrow().len()) as u32;
-        (bytes_len + WASM_PAGE_SIZE_IN_BYTES - 1) / WASM_PAGE_SIZE_IN_BYTES
+    fn stable_size(&self) -> u32 {
+        let bytes_len = self.memory.lock().unwrap().len();
+        let page_size = WASM_PAGE_SIZE_IN_BYTES as usize;
+        ((bytes_len + page_size - 1) / page_size) as u32
     }
 
-    fn stable64_size() -> u64 {
-        TestStableMemory::stable_size() as u64
+    fn stable64_size(&self) -> u64 {
+        self.stable_size() as u64
     }
 
-    fn stable_grow(new_pages: u32) -> Result<u32, StableMemoryError> {
-        let new_bytes = (new_pages as usize * WASM_PAGE_SIZE_IN_BYTES as usize);
+    fn stable_grow(&self, new_pages: u32) -> Result<u32, StableMemoryError> {
+        let new_bytes = new_pages as usize * WASM_PAGE_SIZE_IN_BYTES as usize;
 
-        MEMORY.with(|m| {
-            let mut vec = m.borrow_mut();
-            let previous_len = vec.len();
-            let new_len = vec.len() + new_bytes;
-            vec.resize(new_len, 0);
-            Ok(previous_len as u32)
-        })
+        let mut vec = self.memory.lock().unwrap();
+        let previous_len = vec.len();
+        let new_len = vec.len() + new_bytes;
+        vec.resize(new_len, 0);
+        Ok(previous_len as u32)
     }
 
-    fn stable64_grow(new_pages: u64) -> Result<u64, StableMemoryError> {
-        TestStableMemory::stable_grow(new_pages as u32).map(|len| len as u64)
+    fn stable64_grow(&self, new_pages: u64) -> Result<u64, StableMemoryError> {
+        self.stable_grow(new_pages as u32).map(|len| len as u64)
     }
 
-    fn stable_write(offset: u32, buf: &[u8]) {
+    fn stable_write(&self, offset: u32, buf: &[u8]) {
         let offset = offset as usize;
 
-        MEMORY.with(|m| {
-            let mut vec = m.borrow_mut();
-            if offset + buf.len() > vec.len() {
-                panic!("stable memory out of bounds".to_string());
-            }
-            vec[offset..(offset + buf.len())] = *buf;
-        })
+        let mut vec = self.memory.lock().unwrap();
+        if offset + buf.len() > vec.len() {
+            panic!("stable memory out of bounds");
+        }
+        vec[offset..(offset + buf.len())].clone_from_slice(buf);
     }
 
-    fn stable64_write(offset: u64, buf: &[u8]) {
-        TestStableMemory::stable_write(offset as u32, buf)
+    fn stable64_write(&self, offset: u64, buf: &[u8]) {
+        self.stable_write(offset as u32, buf)
     }
 
-    fn stable_read(offset: u32, buf: &mut [u8]) {
+    fn stable_read(&self, offset: u32, buf: &mut [u8]) {
         let offset = offset as usize;
 
-        MEMORY.with(|m| {
-            let vec = m.borrow();
-            if offset + buf.len() < vec.len() {
-                panic!("stable memory out of bounds".to_string());
-            }
-            buf[..vec.len()].copy_from_slice(&vec[offset..]);
-        })
+        let vec = self.memory.lock().unwrap();
+        if offset + buf.len() < vec.len() {
+            panic!("stable memory out of bounds");
+        }
+        buf[..vec.len()].copy_from_slice(&vec[offset..]);
     }
 
-    fn stable64_read(offset: u64, buf: &mut [u8]) {
-        TestStableMemory::stable_read(offset as u32, buf)
+    fn stable64_read(&self, offset: u64, buf: &mut [u8]) {
+        self.stable_read(offset as u32, buf)
+    }
+}
+
+mod buffer_writer_tests {
+    use super::*;
+
+    #[test]
+    fn write_single_slice() {
+        let memory = Rc::new(Mutex::new(Vec::new()));
+        let mut writer = BufferedStableWriter::with_memory(1024, TestStableMemory::new(memory.clone()));
+
+        let bytes = vec![1; 128];
+
+        writer.write(&bytes).unwrap();
+        writer.flush().unwrap();
+
+        let result = &*memory.lock().unwrap();
+
+        assert_eq!(bytes, result[..bytes.len()]);
+    }
+
+    #[test]
+    fn write_many_slices() {
+        let memory = Rc::new(Mutex::new(Vec::new()));
+        let mut writer = BufferedStableWriter::with_memory(1024, TestStableMemory::new(memory.clone()));
+
+        for i in 1..100 {
+            let bytes = vec![i as u8; i];
+            writer.write(&bytes).unwrap();
+        }
+
+        writer.flush().unwrap();
+
+        let result = &*memory.lock().unwrap();
+
+        let mut offset = 0;
+        for i in 1..100 {
+            let bytes = &result[offset..offset + i];
+            assert_eq!(bytes, vec![i as u8; i]);
+            offset += i;
+        }
+    }
+
+    #[test]
+    fn write_many_slices_some_exceeding_buffer_capacity() {
+        let memory = Rc::new(Mutex::new(Vec::new()));
+        let mut writer = BufferedStableWriter::with_memory(10, TestStableMemory::new(memory.clone()));
+
+        for i in 1..100 {
+            let bytes = vec![i as u8; i];
+            writer.write(&bytes).unwrap();
+        }
+
+        writer.flush().unwrap();
+
+        let result = &*memory.lock().unwrap();
+
+        let mut offset = 0;
+        for i in 1..100 {
+            let bytes = &result[offset..offset + i];
+            assert_eq!(bytes, vec![i as u8; i]);
+            offset += i;
+        }
     }
 }

--- a/src/ic-cdk/src/api/stable/tests.rs
+++ b/src/ic-cdk/src/api/stable/tests.rs
@@ -96,7 +96,6 @@ mod buffer_writer_tests {
             let bytes = vec![i as u8; i];
             writer.write(&bytes).unwrap();
         }
-
         writer.flush().unwrap();
 
         let result = &*memory.lock().unwrap();
@@ -119,7 +118,6 @@ mod buffer_writer_tests {
             let bytes = vec![i as u8; i];
             writer.write(&bytes).unwrap();
         }
-
         writer.flush().unwrap();
 
         let result = &*memory.lock().unwrap();

--- a/src/ic-cdk/src/api/stable/tests.rs
+++ b/src/ic-cdk/src/api/stable/tests.rs
@@ -1,0 +1,67 @@
+use std::cell::RefCell;
+use super::*;
+
+thread_local! {
+    static MEMORY: RefCell<Vec<u8>> = RefCell::default();
+}
+
+pub struct TestStableMemory {}
+
+impl StableMemory for TestStableMemory {
+    fn stable_size() -> u32 {
+        let bytes_len = MEMORY.with(|m| m.borrow().len()) as u32;
+        (bytes_len + WASM_PAGE_SIZE_IN_BYTES - 1) / WASM_PAGE_SIZE_IN_BYTES
+    }
+
+    fn stable64_size() -> u64 {
+        TestStableMemory::stable_size() as u64
+    }
+
+    fn stable_grow(new_pages: u32) -> Result<u32, StableMemoryError> {
+        let new_bytes = (new_pages as usize * WASM_PAGE_SIZE_IN_BYTES as usize);
+
+        MEMORY.with(|m| {
+            let mut vec = m.borrow_mut();
+            let previous_len = vec.len();
+            let new_len = vec.len() + new_bytes;
+            vec.resize(new_len, 0);
+            Ok(previous_len as u32)
+        })
+    }
+
+    fn stable64_grow(new_pages: u64) -> Result<u64, StableMemoryError> {
+        TestStableMemory::stable_grow(new_pages as u32).map(|len| len as u64)
+    }
+
+    fn stable_write(offset: u32, buf: &[u8]) {
+        let offset = offset as usize;
+
+        MEMORY.with(|m| {
+            let mut vec = m.borrow_mut();
+            if offset + buf.len() > vec.len() {
+                panic!("stable memory out of bounds".to_string());
+            }
+            vec[offset..(offset + buf.len())] = *buf;
+        })
+    }
+
+    fn stable64_write(offset: u64, buf: &[u8]) {
+        TestStableMemory::stable_write(offset as u32, buf)
+    }
+
+    fn stable_read(offset: u32, buf: &mut [u8]) {
+        let offset = offset as usize;
+
+        MEMORY.with(|m| {
+            let vec = m.borrow();
+            if offset + buf.len() < vec.len() {
+                panic!("stable memory out of bounds".to_string());
+            }
+            buf[..vec.len()].copy_from_slice(&vec[offset..]);
+        })
+    }
+
+    fn stable64_read(offset: u64, buf: &mut [u8]) {
+        TestStableMemory::stable_read(offset as u32, buf)
+    }
+}

--- a/src/ic-cdk/src/api/stable/tests.rs
+++ b/src/ic-cdk/src/api/stable/tests.rs
@@ -137,7 +137,8 @@ mod stable_writer_tests {
         writer.flush().unwrap();
 
         let capacity_pages = TestStableMemory::new(memory).stable64_size();
-        let min_pages_required = (total_bytes + WASM_PAGE_SIZE_IN_BYTES - 1)  / WASM_PAGE_SIZE_IN_BYTES;
+        let min_pages_required =
+            (total_bytes + WASM_PAGE_SIZE_IN_BYTES - 1) / WASM_PAGE_SIZE_IN_BYTES;
 
         assert_eq!(capacity_pages, min_pages_required as u64);
     }

--- a/src/ic-cdk/src/api/stable/tests.rs
+++ b/src/ic-cdk/src/api/stable/tests.rs
@@ -119,10 +119,11 @@ mod stable_writer_tests {
     }
 
     fn build_writer(memory: TestStableMemory, buffer_size: Option<usize>) -> Box<dyn Write> {
+        let writer = StableWriter::with_memory(memory, 0);
         if let Some(buffer_size) = buffer_size {
-            Box::new(BufferedStableWriter::with_memory(buffer_size, memory))
+            Box::new(BufferedStableWriter::with_writer(buffer_size, writer))
         } else {
-            Box::new(StableWriter::with_memory(memory))
+            Box::new(writer)
         }
     }
 }

--- a/src/ic-cdk/src/api/stable/tests.rs
+++ b/src/ic-cdk/src/api/stable/tests.rs
@@ -1,5 +1,5 @@
-use std::cell::RefCell;
 use super::*;
+use std::cell::RefCell;
 
 thread_local! {
     static MEMORY: RefCell<Vec<u8>> = RefCell::default();

--- a/src/ic-cdk/src/api/stable/tests.rs
+++ b/src/ic-cdk/src/api/stable/tests.rs
@@ -84,7 +84,7 @@ mod stable_writer_tests {
 
         let bytes = vec![1; 100];
 
-        writer.write(&bytes).unwrap();
+        writer.write_all(&bytes).unwrap();
         writer.flush().unwrap();
 
         let result = &*memory.lock().unwrap();
@@ -104,7 +104,7 @@ mod stable_writer_tests {
 
         for i in 1..100 {
             let bytes = vec![i as u8; i];
-            writer.write(&bytes).unwrap();
+            writer.write_all(&bytes).unwrap();
         }
         writer.flush().unwrap();
 


### PR DESCRIPTION
# Description

This adds a new stable memory writer called `BufferedStableWriter` which first buffers bytes in canister memory and only flushes those bytes to stable memory when the buffer becomes full.
Allocating additional memory and making system calls (`stable_grow` and `stable_write`) are both expensive operations, this writer minimises both.

# How Has This Been Tested?

There are unit test which cover the new `BufferedStableWriter` and the existing `StableWriter`.
I have also tested this locally and have successfully performed a few canister upgrades, adding data between each upgrade.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
