### PR TITLE
feat: Add `BufferedStableReader` for efficient reading from stable memory

### DIFF
--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 ### Added
+- Add `BufferedStableReader` for efficient reading from stable memory (#247)
 - Add `BufferedStableWriter` for efficient writing to stable memory (#245)
 
 ## [0.5.0] - 2022-03-29

--- a/src/ic-cdk/src/api/stable/tests.rs
+++ b/src/ic-cdk/src/api/stable/tests.rs
@@ -9,6 +9,13 @@ pub struct TestStableMemory {
 
 impl TestStableMemory {
     pub fn new(memory: Rc<Mutex<Vec<u8>>>) -> TestStableMemory {
+        let bytes_len = memory.lock().unwrap().len();
+        if bytes_len > 0 {
+            let pages_required = pages_required(bytes_len);
+            let bytes_required = pages_required * WASM_PAGE_SIZE_IN_BYTES;
+            memory.lock().unwrap().resize(bytes_required, 0);
+        }
+
         TestStableMemory { memory }
     }
 }
@@ -16,8 +23,7 @@ impl TestStableMemory {
 impl StableMemory for TestStableMemory {
     fn stable_size(&self) -> u32 {
         let bytes_len = self.memory.lock().unwrap().len();
-        let page_size = WASM_PAGE_SIZE_IN_BYTES as usize;
-        ((bytes_len + page_size - 1) / page_size) as u32
+        pages_required(bytes_len) as u32
     }
 
     fn stable64_size(&self) -> u64 {
@@ -56,15 +62,19 @@ impl StableMemory for TestStableMemory {
         let offset = offset as usize;
 
         let vec = self.memory.lock().unwrap();
-        if offset + buf.len() < vec.len() {
-            panic!("stable memory out of bounds");
-        }
-        buf[..vec.len()].copy_from_slice(&vec[offset..]);
+        let count_to_copy = buf.len();
+
+        buf[..count_to_copy].copy_from_slice(&vec[offset..offset + count_to_copy]);
     }
 
     fn stable64_read(&self, offset: u64, buf: &mut [u8]) {
         self.stable_read(offset as u32, buf)
     }
+}
+
+fn pages_required(bytes_len: usize) -> usize {
+    let page_size = WASM_PAGE_SIZE_IN_BYTES as usize;
+    (bytes_len + page_size - 1) / page_size
 }
 
 mod stable_writer_tests {
@@ -149,6 +159,38 @@ mod stable_writer_tests {
             Box::new(BufferedStableWriter::with_writer(buffer_size, writer))
         } else {
             Box::new(writer)
+        }
+    }
+}
+
+mod stable_reader_tests {
+    use super::*;
+    use rstest::rstest;
+    use std::io::Read;
+
+    #[rstest]
+    #[case(None)]
+    #[case(Some(1))]
+    #[case(Some(10))]
+    #[case(Some(100))]
+    #[case(Some(1000))]
+    fn reads_all_bytes(#[case] buffer_size: Option<usize>) {
+        let input = vec![1; 10_000];
+        let memory = Rc::new(Mutex::new(input.clone()));
+        let mut reader = build_reader(TestStableMemory::new(memory.clone()), buffer_size);
+
+        let mut output = Vec::new();
+        reader.read_to_end(&mut output).unwrap();
+
+        assert_eq!(input, output[..input.len()]);
+    }
+
+    fn build_reader(memory: TestStableMemory, buffer_size: Option<usize>) -> Box<dyn Read> {
+        let reader = StableReader::with_memory(memory, 0);
+        if let Some(buffer_size) = buffer_size {
+            Box::new(BufferedStableReader::with_reader(buffer_size, reader))
+        } else {
+            Box::new(reader)
         }
     }
 }

--- a/src/ic-cdk/src/api/stable/tests.rs
+++ b/src/ic-cdk/src/api/stable/tests.rs
@@ -177,7 +177,7 @@ mod stable_reader_tests {
     fn reads_all_bytes(#[case] buffer_size: Option<usize>) {
         let input = vec![1; 10_000];
         let memory = Rc::new(Mutex::new(input.clone()));
-        let mut reader = build_reader(TestStableMemory::new(memory.clone()), buffer_size);
+        let mut reader = build_reader(TestStableMemory::new(memory), buffer_size);
 
         let mut output = Vec::new();
         reader.read_to_end(&mut output).unwrap();


### PR DESCRIPTION
# Description

This follows on from the `BufferedStableWriter` introduced in #245 by adding an equivalent `BufferedStableReader`.
The current `StableReader` reads the entire stable memory into a Vec on the heap, if we just want to deserialize stable memory then this is very wasteful as it allocates lots of memory which is only used temporarily, but then must be paid for from then on by the canister.
The new `BufferedStableReader` allocates a buffer and then reads from stable memory into that buffer, deserialization can happen incrementally each time the buffer is filled.
This involves more reads from stable memory but allocates less memory, allocating memory is far slower than reading so the end result is that this new version is significantly faster as well as being cheaper for the canister.

# How Has This Been Tested?

There are unit tests and this has been tested on both OpenChat and OpenStorage where it is now running in production. 

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
