### PR TITLE
chore(SDK-417): add an e2d test for async cleanup

### DIFF
--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -11,13 +11,18 @@ repository = "https://github.com/dfinity/cdk-rs"
 candid = "0.7.4"
 cargo_metadata = "0.14.2"
 escargot = { version = "0.5.7", features = ["print"] }
-serde_bytes = "0.11"
 ic-cdk = { path = "../src/ic-cdk" }
 ic-cdk-macros = { path = "../src/ic-cdk-macros" }
+lazy_static = "1.4.0"
+serde_bytes = "0.11"
 
 [[bin]]
 name = "simple-kv-store"
 path = "canisters/simple_kv_store.rs"
+
+[[bin]]
+name = "async"
+path = "canisters/async.rs"
 
 [dev-dependencies]
 ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "709f9caaffd39c5d63f7ef1ec694eeb2a1b7976a" }

--- a/e2e-tests/canisters/async.rs
+++ b/e2e-tests/canisters/async.rs
@@ -1,0 +1,34 @@
+use ic_cdk_macros::{query, update};
+use lazy_static::lazy_static;
+use std::sync::RwLock;
+
+lazy_static! {
+    static ref RESOURCE: RwLock<u64> = RwLock::new(0);
+}
+
+#[query]
+fn inc(n: u64) -> u64 {
+    n + 1
+}
+
+#[query]
+fn invocation_count() -> u64 {
+    let lock = RESOURCE
+        .read()
+        .unwrap_or_else(|_| ic_cdk::api::trap("failed to obtain a read lock"));
+    *lock
+}
+
+#[update]
+async fn panic_after_async() {
+    let mut lock = RESOURCE
+        .write()
+        .unwrap_or_else(|_| ic_cdk::api::trap("failed to obtain a write lock"));
+    *lock += 1;
+    let _: (u64,) = ic_cdk::call(ic_cdk::api::id(), "inc", (*lock,))
+        .await
+        .expect("failed to call self");
+    ic_cdk::api::trap("Goodbye, cruel world.")
+}
+
+fn main() {}

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -97,7 +97,13 @@ fn test_panic_after_async_frees_resources() {
             Err(CallError::Reject(msg)) => panic!("unexpected reject: {}", msg),
             Err(CallError::UserError(e)) => {
                 assert_eq!(e.code(), ErrorCode::CanisterCalledTrap);
-                assert_eq!(e.description(), "Goodbye, cruel world.");
+                assert_eq!(
+                    e.description(),
+                    &format!(
+                        "Canister {} trapped explicitly: Goodbye, cruel world.",
+                        canister_id
+                    )
+                );
             }
         }
 

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -1,6 +1,6 @@
 use candid::utils::{decode_args, encode_args, ArgumentDecoder, ArgumentEncoder};
 use ic_cdk_e2e_tests::cargo_build_canister;
-use ic_state_machine_tests::{CanisterId, StateMachine, UserError, WasmResult};
+use ic_state_machine_tests::{CanisterId, ErrorCode, StateMachine, UserError, WasmResult};
 use serde_bytes::ByteBuf;
 
 #[derive(Debug)]
@@ -83,4 +83,27 @@ fn test_storage_roundtrip() {
     let (result,): (Option<ByteBuf>,) =
         query_candid(&env, canister_id, "lookup", (&"candid",)).expect("failed to lookup 'candid'");
     assert_eq!(result, Some(ByteBuf::from(b"did".to_vec())));
+}
+
+#[test]
+fn test_panic_after_async_frees_resources() {
+    let env = StateMachine::new();
+    let wasm = cargo_build_canister("async");
+    let canister_id = env.install_canister(wasm.clone(), vec![], None).unwrap();
+
+    for i in 1..3 {
+        match call_candid(&env, canister_id, "panic_after_async", ()) {
+            Ok(()) => (),
+            Err(CallError::Reject(msg)) => panic!("unexpected reject: {}", msg),
+            Err(CallError::UserError(e)) => {
+                assert_eq!(e.code(), ErrorCode::CanisterCalledTrap);
+                assert_eq!(e.description(), "Goodbye, cruel world.");
+            }
+        }
+
+        let (n,): (u64,) = call_candid(&env, canister_id, "invocation_count", ())
+            .expect("failed to call invocation_count");
+
+        assert_eq!(i, n, "expected the invocation count to be {}, got {}", i, n);
+    }
 }

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -89,7 +89,9 @@ fn test_storage_roundtrip() {
 fn test_panic_after_async_frees_resources() {
     let env = StateMachine::new();
     let wasm = cargo_build_canister("async");
-    let canister_id = env.install_canister(wasm.clone(), vec![], None).unwrap();
+    let canister_id = env
+        .install_canister(wasm, vec![], None)
+        .expect("failed to install a canister");
 
     for i in 1..3 {
         match call_candid(&env, canister_id, "panic_after_async", ()) {

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -96,13 +96,15 @@ fn test_panic_after_async_frees_resources() {
             Ok(()) => (),
             Err(CallError::Reject(msg)) => panic!("unexpected reject: {}", msg),
             Err(CallError::UserError(e)) => {
+                println!("Got a user error as expected: {}", e);
+
                 assert_eq!(e.code(), ErrorCode::CanisterCalledTrap);
-                assert_eq!(
-                    e.description(),
-                    &format!(
-                        "Canister {} trapped explicitly: Goodbye, cruel world.",
-                        canister_id
-                    )
+                let expected_message = "Goodbye, cruel world.";
+                assert!(
+                    e.description().contains(expected_message),
+                    "Expected the user error to contain '{}', got: {}",
+                    expected_message,
+                    e.description()
                 );
             }
         }


### PR DESCRIPTION
This change adds an end-to-end test checking that the CDK frees
canister resources if the canister traps after an async call.

This feature was implemented in https://github.com/dfinity/cdk-rs/pull/232.
The test revealed that the feature is broken, so this PR also fixes the
cleanup logic to make the test pass.