### PR TITLE
refactor: move pure assets certification code into a module

### DIFF
--- a/src/ic-certified-assets/src/lib.rs
+++ b/src/ic-certified-assets/src/lib.rs
@@ -1,239 +1,24 @@
+//! This module declares canister methods expected by the assets canister client.
 mod rc_bytes;
+mod state_machine;
+mod types;
+mod url_decode;
+
 #[cfg(test)]
 mod tests;
 
-use crate::rc_bytes::RcBytes;
-use candid::{candid_method, CandidType, Deserialize, Func, Int, Nat, Principal};
+use crate::{
+    rc_bytes::RcBytes,
+    state_machine::{AssetDetails, EncodedAsset, StableState, State},
+    types::*,
+};
+use candid::{candid_method, Principal};
 use ic_cdk::api::{caller, data_certificate, set_certified_data, time, trap};
 use ic_cdk_macros::{query, update};
-use ic_certified_map::{AsHashTree, Hash, HashTree, RbTree};
-use num_traits::ToPrimitive;
-use serde::Serialize;
-use serde_bytes::ByteBuf;
-use sha2::Digest;
 use std::cell::RefCell;
-use std::collections::HashMap;
-use std::convert::TryInto;
-use std::fmt;
-
-/// The amount of time a batch is kept alive. Modifying the batch
-/// delays the expiry further.
-const BATCH_EXPIRY_NANOS: u64 = 300_000_000_000;
-
-/// The order in which we pick encodings for certification.
-const ENCODING_CERTIFICATION_ORDER: &[&str] = &["identity", "gzip", "compress", "deflate", "br"];
-
-/// The file to serve if the requested file wasn't found.
-const INDEX_FILE: &str = "/index.html";
 
 thread_local! {
-    static STATE: State = State::default();
-    static ASSET_HASHES: RefCell<AssetHashes> = RefCell::new(RbTree::new());
-}
-
-type AssetHashes = RbTree<Key, Hash>;
-
-#[derive(Default)]
-struct State {
-    assets: RefCell<HashMap<Key, Asset>>,
-
-    chunks: RefCell<HashMap<ChunkId, Chunk>>,
-    next_chunk_id: RefCell<ChunkId>,
-
-    batches: RefCell<HashMap<BatchId, Batch>>,
-    next_batch_id: RefCell<BatchId>,
-
-    authorized: RefCell<Vec<Principal>>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct StableState {
-    authorized: Vec<Principal>,
-    stable_assets: HashMap<String, Asset>,
-}
-
-#[derive(Default, Clone, Debug, CandidType, Deserialize)]
-struct AssetEncoding {
-    modified: Timestamp,
-    content_chunks: Vec<RcBytes>,
-    total_length: usize,
-    certified: bool,
-    sha256: [u8; 32],
-}
-
-#[derive(Default, Clone, Debug, CandidType, Deserialize)]
-struct Asset {
-    content_type: String,
-    encodings: HashMap<String, AssetEncoding>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct EncodedAsset {
-    content: RcBytes,
-    content_type: String,
-    content_encoding: String,
-    total_length: Nat,
-    sha256: Option<ByteBuf>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct AssetDetails {
-    key: String,
-    content_type: String,
-    encodings: Vec<AssetEncodingDetails>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct AssetEncodingDetails {
-    content_encoding: String,
-    sha256: Option<ByteBuf>,
-    length: Nat,
-    modified: Timestamp,
-}
-
-struct Chunk {
-    batch_id: BatchId,
-    content: RcBytes,
-}
-
-struct Batch {
-    expires_at: Timestamp,
-}
-
-type Timestamp = Int;
-type BatchId = Nat;
-type ChunkId = Nat;
-type Key = String;
-
-// IDL Types
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct CreateAssetArguments {
-    key: Key,
-    content_type: String,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct SetAssetContentArguments {
-    key: Key,
-    content_encoding: String,
-    chunk_ids: Vec<ChunkId>,
-    sha256: Option<ByteBuf>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct UnsetAssetContentArguments {
-    key: Key,
-    content_encoding: String,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct DeleteAssetArguments {
-    key: Key,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct ClearArguments {}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-enum BatchOperation {
-    CreateAsset(CreateAssetArguments),
-    SetAssetContent(SetAssetContentArguments),
-    UnsetAssetContent(UnsetAssetContentArguments),
-    DeleteAsset(DeleteAssetArguments),
-    Clear(ClearArguments),
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct CommitBatchArguments {
-    batch_id: BatchId,
-    operations: Vec<BatchOperation>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct StoreArg {
-    key: Key,
-    content_type: String,
-    content_encoding: String,
-    content: ByteBuf,
-    sha256: Option<ByteBuf>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct GetArg {
-    key: Key,
-    accept_encodings: Vec<String>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct GetChunkArg {
-    key: Key,
-    content_encoding: String,
-    index: Nat,
-    sha256: Option<ByteBuf>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct GetChunkResponse {
-    content: RcBytes,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct CreateBatchResponse {
-    batch_id: BatchId,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct CreateChunkArg {
-    batch_id: BatchId,
-    content: ByteBuf,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct CreateChunkResponse {
-    chunk_id: ChunkId,
-}
-// HTTP interface
-
-type HeaderField = (String, String);
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct HttpRequest {
-    method: String,
-    url: String,
-    headers: Vec<(String, String)>,
-    body: ByteBuf,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct HttpResponse {
-    status_code: u16,
-    headers: Vec<HeaderField>,
-    body: RcBytes,
-    streaming_strategy: Option<StreamingStrategy>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct StreamingCallbackToken {
-    key: String,
-    content_encoding: String,
-    index: Nat,
-    // We don't care about the sha, we just want to be backward compatible.
-    sha256: Option<ByteBuf>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-enum StreamingStrategy {
-    Callback {
-        callback: Func,
-        token: StreamingCallbackToken,
-    },
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct StreamingCallbackHttpResponse {
-    body: RcBytes,
-    token: Option<StreamingCallbackToken>,
+    static STATE: RefCell<State> = RefCell::new(State::default());
 }
 
 #[update]
@@ -241,9 +26,8 @@ struct StreamingCallbackHttpResponse {
 fn authorize(other: Principal) {
     let caller = caller();
     STATE.with(|s| {
-        let caller_autorized = s.authorized.borrow().iter().any(|p| *p == caller);
-        if caller_autorized {
-            s.authorized.borrow_mut().push(other);
+        if let Err(msg) = s.borrow_mut().authorize(&caller, other) {
+            trap(&msg);
         }
     })
 }
@@ -251,17 +35,9 @@ fn authorize(other: Principal) {
 #[query]
 #[candid_method(query)]
 fn retrieve(key: Key) -> RcBytes {
-    STATE.with(|s| {
-        let assets = s.assets.borrow();
-        let asset = assets.get(&key).unwrap_or_else(|| trap("asset not found"));
-        let id_enc = asset
-            .encodings
-            .get("identity")
-            .unwrap_or_else(|| trap("no identity encoding"));
-        if id_enc.content_chunks.len() > 1 {
-            trap("Asset too large. Use get() and get_chunk() instead.");
-        }
-        id_enc.content_chunks[0].clone()
+    STATE.with(|s| match s.borrow().retrieve(&key) {
+        Ok(bytes) => bytes,
+        Err(msg) => trap(&msg),
     })
 }
 
@@ -269,764 +45,159 @@ fn retrieve(key: Key) -> RcBytes {
 #[candid_method(update)]
 fn store(arg: StoreArg) {
     STATE.with(move |s| {
-        let mut assets = s.assets.borrow_mut();
-        let asset = assets.entry(arg.key.clone()).or_default();
-        asset.content_type = arg.content_type;
-
-        let hash = hash_bytes(&arg.content);
-        if let Some(provided_hash) = arg.sha256 {
-            if hash != provided_hash.as_ref() {
-                trap("sha256 mismatch");
-            }
+        if let Err(msg) = s.borrow_mut().store(arg, time()) {
+            trap(&msg);
         }
-
-        let encoding = asset.encodings.entry(arg.content_encoding).or_default();
-        encoding.total_length = arg.content.len();
-        encoding.content_chunks = vec![RcBytes::from(arg.content)];
-        encoding.modified = Int::from(time() as u64);
-        encoding.sha256 = hash;
-
-        on_asset_change(&arg.key, asset);
+        set_certified_data(&s.borrow().root_hash());
     });
 }
 
 #[update(guard = "is_authorized")]
 #[candid_method(update)]
 fn create_batch() -> CreateBatchResponse {
-    STATE.with(|s| {
-        let batch_id = s.next_batch_id.borrow().clone();
-        *s.next_batch_id.borrow_mut() += 1;
-
-        let now = time() as u64;
-
-        let mut batches = s.batches.borrow_mut();
-        batches.insert(
-            batch_id.clone(),
-            Batch {
-                expires_at: Int::from(now + BATCH_EXPIRY_NANOS),
-            },
-        );
-        s.chunks.borrow_mut().retain(|_, c| {
-            batches
-                .get(&c.batch_id)
-                .map(|b| b.expires_at > now)
-                .unwrap_or(false)
-        });
-        batches.retain(|_, b| b.expires_at > now);
-
-        CreateBatchResponse { batch_id }
+    STATE.with(|s| CreateBatchResponse {
+        batch_id: s.borrow_mut().create_batch(time()),
     })
 }
 
 #[update(guard = "is_authorized")]
 #[candid_method(update)]
 fn create_chunk(arg: CreateChunkArg) -> CreateChunkResponse {
-    STATE.with(|s| {
-        let mut batches = s.batches.borrow_mut();
-        let now = time() as u64;
-        let mut batch = batches
-            .get_mut(&arg.batch_id)
-            .unwrap_or_else(|| trap("batch not found"));
-        batch.expires_at = Int::from(now + BATCH_EXPIRY_NANOS);
-
-        let chunk_id = s.next_chunk_id.borrow().clone();
-        *s.next_chunk_id.borrow_mut() += 1;
-
-        s.chunks.borrow_mut().insert(
-            chunk_id.clone(),
-            Chunk {
-                batch_id: arg.batch_id,
-                content: RcBytes::from(arg.content),
-            },
-        );
-
-        CreateChunkResponse { chunk_id }
+    STATE.with(|s| match s.borrow_mut().create_chunk(arg, time()) {
+        Ok(chunk_id) => CreateChunkResponse { chunk_id },
+        Err(msg) => trap(&msg),
     })
 }
 
 #[update(guard = "is_authorized")]
 #[candid_method(update)]
 fn create_asset(arg: CreateAssetArguments) {
-    do_create_asset(arg);
+    STATE.with(|s| {
+        if let Err(msg) = s.borrow_mut().create_asset(arg) {
+            trap(&msg);
+        }
+        set_certified_data(&s.borrow().root_hash());
+    })
 }
 
 #[update(guard = "is_authorized")]
 #[candid_method(update)]
 fn set_asset_content(arg: SetAssetContentArguments) {
-    do_set_asset_content(arg);
+    STATE.with(|s| {
+        if let Err(msg) = s.borrow_mut().set_asset_content(arg, time()) {
+            trap(&msg);
+        }
+        set_certified_data(&s.borrow().root_hash());
+    })
 }
 
 #[update(guard = "is_authorized")]
 #[candid_method(update)]
 fn unset_asset_content(arg: UnsetAssetContentArguments) {
-    do_unset_asset_content(arg);
+    STATE.with(|s| {
+        if let Err(msg) = s.borrow_mut().unset_asset_content(arg) {
+            trap(&msg);
+        }
+        set_certified_data(&s.borrow().root_hash());
+    })
 }
 
 #[update(guard = "is_authorized")]
 #[candid_method(update)]
 fn delete_asset(arg: DeleteAssetArguments) {
-    do_delete_asset(arg);
+    STATE.with(|s| {
+        s.borrow_mut().delete_asset(arg);
+        set_certified_data(&s.borrow().root_hash());
+    });
 }
 
 #[update(guard = "is_authorized")]
 #[candid_method(update)]
 fn clear() {
-    do_clear();
+    STATE.with(|s| {
+        s.borrow_mut().clear();
+        set_certified_data(&s.borrow().root_hash());
+    });
 }
 
 #[update(guard = "is_authorized")]
 #[candid_method(update)]
 fn commit_batch(arg: CommitBatchArguments) {
-    let batch_id = arg.batch_id;
-    for op in arg.operations {
-        match op {
-            BatchOperation::CreateAsset(arg) => do_create_asset(arg),
-            BatchOperation::SetAssetContent(arg) => do_set_asset_content(arg),
-            BatchOperation::UnsetAssetContent(arg) => do_unset_asset_content(arg),
-            BatchOperation::DeleteAsset(arg) => do_delete_asset(arg),
-            BatchOperation::Clear(_) => do_clear(),
-        }
-    }
     STATE.with(|s| {
-        s.batches.borrow_mut().remove(&batch_id);
-    })
+        if let Err(msg) = s.borrow_mut().commit_batch(arg, time()) {
+            trap(&msg);
+        }
+        set_certified_data(&s.borrow().root_hash());
+    });
 }
 
 #[query]
 #[candid_method(query)]
 fn get(arg: GetArg) -> EncodedAsset {
-    STATE.with(|s| {
-        let assets = s.assets.borrow();
-        let asset = assets.get(&arg.key).unwrap_or_else(|| {
-            trap("asset not found");
-        });
-
-        for enc in arg.accept_encodings.iter() {
-            if let Some(asset_enc) = asset.encodings.get(enc) {
-                return EncodedAsset {
-                    content: asset_enc.content_chunks[0].clone(),
-                    content_type: asset.content_type.clone(),
-                    content_encoding: enc.clone(),
-                    total_length: Nat::from(asset_enc.total_length as u64),
-                    sha256: Some(ByteBuf::from(asset_enc.sha256)),
-                };
-            }
-        }
-        trap("no such encoding");
+    STATE.with(|s| match s.borrow().get(arg) {
+        Ok(asset) => asset,
+        Err(msg) => trap(&msg),
     })
 }
 
 #[query]
 #[candid_method(query)]
 fn get_chunk(arg: GetChunkArg) -> GetChunkResponse {
-    STATE.with(|s| {
-        let assets = s.assets.borrow();
-        let asset = assets
-            .get(&arg.key)
-            .unwrap_or_else(|| trap("asset not found"));
-
-        let enc = asset
-            .encodings
-            .get(&arg.content_encoding)
-            .unwrap_or_else(|| trap("no such encoding"));
-
-        if let Some(expected_hash) = arg.sha256 {
-            if expected_hash != enc.sha256 {
-                trap("sha256 mismatch")
-            }
-        }
-        if arg.index >= enc.content_chunks.len() {
-            trap("chunk index out of bounds");
-        }
-        let index: usize = arg.index.0.to_usize().unwrap();
-
-        GetChunkResponse {
-            content: enc.content_chunks[index].clone(),
-        }
+    STATE.with(|s| match s.borrow().get_chunk(arg) {
+        Ok(content) => GetChunkResponse { content },
+        Err(msg) => trap(&msg),
     })
 }
 
 #[query]
 #[candid_method(query)]
 fn list() -> Vec<AssetDetails> {
-    STATE.with(|s| {
-        s.assets
-            .borrow()
-            .iter()
-            .map(|(key, asset)| {
-                let mut encodings: Vec<_> = asset
-                    .encodings
-                    .iter()
-                    .map(|(enc_name, enc)| AssetEncodingDetails {
-                        content_encoding: enc_name.clone(),
-                        sha256: Some(ByteBuf::from(enc.sha256)),
-                        length: Nat::from(enc.total_length),
-                        modified: enc.modified.clone(),
-                    })
-                    .collect();
-                encodings.sort_by(|l, r| l.content_encoding.cmp(&r.content_encoding));
-
-                AssetDetails {
-                    key: key.clone(),
-                    content_type: asset.content_type.clone(),
-                    encodings,
-                }
-            })
-            .collect::<Vec<_>>()
-    })
-}
-
-fn create_token(
-    _asset: &Asset,
-    enc_name: &str,
-    enc: &AssetEncoding,
-    key: &str,
-    chunk_index: usize,
-) -> Option<StreamingCallbackToken> {
-    if chunk_index + 1 >= enc.content_chunks.len() {
-        None
-    } else {
-        Some(StreamingCallbackToken {
-            key: key.to_string(),
-            content_encoding: enc_name.to_string(),
-            index: Nat::from(chunk_index + 1),
-            sha256: Some(ByteBuf::from(enc.sha256)),
-        })
-    }
-}
-
-fn create_strategy(
-    asset: &Asset,
-    enc_name: &str,
-    enc: &AssetEncoding,
-    key: &str,
-    chunk_index: usize,
-) -> Option<StreamingStrategy> {
-    create_token(asset, enc_name, enc, key, chunk_index).map(|token| StreamingStrategy::Callback {
-        callback: ic_cdk::export::candid::Func {
-            method: "http_request_streaming_callback".to_string(),
-            principal: ic_cdk::id(),
-        },
-        token,
-    })
-}
-
-fn build_200(
-    asset: &Asset,
-    enc_name: &str,
-    enc: &AssetEncoding,
-    key: &str,
-    chunk_index: usize,
-    certificate_header: Option<HeaderField>,
-) -> HttpResponse {
-    let mut headers = vec![("Content-Type".to_string(), asset.content_type.to_string())];
-    if enc_name != "identity" {
-        headers.push(("Content-Encoding".to_string(), enc_name.to_string()));
-    }
-    if let Some(head) = certificate_header {
-        headers.push(head);
-    }
-
-    let streaming_strategy = create_strategy(asset, enc_name, enc, key, chunk_index);
-
-    HttpResponse {
-        status_code: 200,
-        headers,
-        body: enc.content_chunks[chunk_index].clone(),
-        streaming_strategy,
-    }
-}
-
-fn build_404(certificate_header: HeaderField) -> HttpResponse {
-    HttpResponse {
-        status_code: 404,
-        headers: vec![certificate_header],
-        body: RcBytes::from(ByteBuf::from("not found")),
-        streaming_strategy: None,
-    }
-}
-
-fn build_http_response(path: &str, encodings: Vec<String>, index: usize) -> HttpResponse {
-    STATE.with(|s| {
-        let assets = s.assets.borrow();
-
-        let index_redirect_certificate = ASSET_HASHES.with(|t| {
-            let tree = t.borrow();
-            if tree.get(path.as_bytes()).is_none() && tree.get(INDEX_FILE.as_bytes()).is_some() {
-                let absence_proof = tree.witness(path.as_bytes());
-                let index_proof = tree.witness(INDEX_FILE.as_bytes());
-                let combined_proof = merge_hash_trees(absence_proof, index_proof);
-                Some(witness_to_header(combined_proof))
-            } else {
-                None
-            }
-        });
-
-        if let Some(certificate_header) = index_redirect_certificate {
-            if let Some(asset) = assets.get(INDEX_FILE) {
-                for enc_name in encodings.iter() {
-                    if let Some(enc) = asset.encodings.get(enc_name) {
-                        if enc.certified {
-                            return build_200(
-                                asset,
-                                enc_name,
-                                enc,
-                                INDEX_FILE,
-                                index,
-                                Some(certificate_header),
-                            );
-                        }
-                    }
-                }
-            }
-        }
-
-        let certificate_header =
-            ASSET_HASHES.with(|t| witness_to_header(t.borrow().witness(path.as_bytes())));
-
-        if let Some(asset) = assets.get(path) {
-            for enc_name in encodings.iter() {
-                if let Some(enc) = asset.encodings.get(enc_name) {
-                    if enc.certified {
-                        return build_200(
-                            asset,
-                            enc_name,
-                            enc,
-                            path,
-                            index,
-                            Some(certificate_header),
-                        );
-                    } else {
-                        // Find if identity is certified, if it's not.
-                        if let Some(id_enc) = asset.encodings.get("identity") {
-                            if id_enc.certified {
-                                return build_200(
-                                    asset,
-                                    enc_name,
-                                    enc,
-                                    path,
-                                    index,
-                                    Some(certificate_header),
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        build_404(certificate_header)
-    })
-}
-
-/// An iterator-like structure that decode a URL.
-struct UrlDecode<'a> {
-    bytes: std::slice::Iter<'a, u8>,
-}
-
-fn convert_percent(iter: &mut std::slice::Iter<u8>) -> Option<u8> {
-    let mut cloned_iter = iter.clone();
-    let result = match cloned_iter.next()? {
-        b'%' => b'%',
-        h => {
-            let h = char::from(*h).to_digit(16)?;
-            let l = char::from(*cloned_iter.next()?).to_digit(16)?;
-            h as u8 * 0x10 + l as u8
-        }
-    };
-    // Update this if we make it this far, otherwise "reset" the iterator.
-    *iter = cloned_iter;
-    Some(result)
-}
-
-#[derive(Debug, PartialEq)]
-pub enum UrlDecodeError {
-    InvalidPercentEncoding,
-}
-
-impl fmt::Display for UrlDecodeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidPercentEncoding => write!(f, "invalid percent encoding"),
-        }
-    }
-}
-
-impl<'a> Iterator for UrlDecode<'a> {
-    type Item = Result<char, UrlDecodeError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let b = self.bytes.next()?;
-        match b {
-            b'%' => Some(
-                convert_percent(&mut self.bytes)
-                    .map(char::from)
-                    .ok_or(UrlDecodeError::InvalidPercentEncoding),
-            ),
-            b'+' => Some(Ok(' ')),
-            x => Some(Ok(char::from(*x))),
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let bytes = self.bytes.len();
-        (bytes / 3, Some(bytes))
-    }
-}
-
-fn url_decode(url: &str) -> Result<String, UrlDecodeError> {
-    UrlDecode {
-        bytes: url.as_bytes().iter(),
-    }
-    .collect()
-}
-
-fn redirect_to_url(host: &str, url: &str) -> Option<String> {
-    if let Some(host) = host.split(':').next() {
-        let host = host.trim();
-        if host == "raw.ic0.app" {
-            return Some(format!("https://ic0.app{}", url));
-        } else if let Some(base) = host.strip_suffix(".raw.ic0.app") {
-            return Some(format!("https://{}.ic0.app{}", base, url));
-        }
-    }
-    None
+    STATE.with(|s| s.borrow().list_assets())
 }
 
 #[query]
 #[candid_method(query)]
 fn http_request(req: HttpRequest) -> HttpResponse {
-    let mut encodings = vec![];
-    for (name, value) in req.headers.iter() {
-        if name.eq_ignore_ascii_case("Accept-Encoding") {
-            for v in value.split(',') {
-                encodings.push(v.trim().to_string());
-            }
-        }
-        if name.eq_ignore_ascii_case("Host") {
-            if let Some(replacement_url) = redirect_to_url(value, &req.url) {
-                return HttpResponse {
-                    status_code: 308,
-                    headers: vec![("Location".to_string(), replacement_url)],
-                    body: RcBytes::from(ByteBuf::default()),
-                    streaming_strategy: None,
-                };
-            }
-        }
-    }
-    encodings.push("identity".to_string());
+    let certificate = data_certificate().unwrap_or_else(|| trap("no data certificate available"));
 
-    let path = match req.url.find('?') {
-        Some(i) => &req.url[..i],
-        None => &req.url[..],
-    };
-    match url_decode(path) {
-        Ok(path) => build_http_response(&path, encodings, 0),
-        Err(err) => HttpResponse {
-            status_code: 400,
-            headers: vec![],
-            body: RcBytes::from(ByteBuf::from(format!(
-                "failed to decode path '{}': {}",
-                path, err
-            ))),
-            streaming_strategy: None,
-        },
-    }
+    STATE.with(|s| s.borrow().http_request(req, &certificate))
 }
 
 #[query]
 #[candid_method(query)]
-fn http_request_streaming_callback(
-    StreamingCallbackToken {
-        key,
-        content_encoding,
-        index,
-        sha256,
-    }: StreamingCallbackToken,
-) -> StreamingCallbackHttpResponse {
+fn http_request_streaming_callback(token: StreamingCallbackToken) -> StreamingCallbackHttpResponse {
     STATE.with(|s| {
-        let assets = s.assets.borrow();
-        let asset = assets
-            .get(&key)
-            .expect("Invalid token on streaming: key not found.");
-        let enc = asset
-            .encodings
-            .get(&content_encoding)
-            .expect("Invalid token on streaming: encoding not found.");
-
-        if let Some(expected_hash) = sha256 {
-            if expected_hash != enc.sha256 {
-                trap("sha256 mismatch");
-            }
-        }
-
-        // MAX is good enough. This means a chunk would be above 64-bits, which is impossible...
-        let chunk_index = index.0.to_usize().unwrap_or(usize::MAX);
-
-        StreamingCallbackHttpResponse {
-            body: enc.content_chunks[chunk_index].clone(),
-            token: create_token(asset, &content_encoding, enc, &key, chunk_index),
-        }
+        s.borrow()
+            .http_request_streaming_callback(token)
+            .unwrap_or_else(|msg| trap(&msg))
     })
 }
 
-fn do_create_asset(arg: CreateAssetArguments) {
+fn is_authorized() -> Result<(), String> {
     STATE.with(|s| {
-        let mut assets = s.assets.borrow_mut();
-        if let Some(asset) = assets.get(&arg.key) {
-            if asset.content_type != arg.content_type {
-                trap("create_asset: content type mismatch");
-            }
-        } else {
-            assets.insert(
-                arg.key,
-                Asset {
-                    content_type: arg.content_type,
-                    encodings: HashMap::new(),
-                },
-            );
-        }
-    })
-}
-
-fn do_set_asset_content(arg: SetAssetContentArguments) {
-    STATE.with(|s| {
-        if arg.chunk_ids.is_empty() {
-            trap("encoding must have at least one chunk");
-        }
-
-        let mut assets = s.assets.borrow_mut();
-        let asset = assets
-            .get_mut(&arg.key)
-            .unwrap_or_else(|| trap("asset not found"));
-        let now = Int::from(time() as u64);
-
-        let mut chunks = s.chunks.borrow_mut();
-
-        let mut content_chunks = vec![];
-        for chunk_id in arg.chunk_ids.iter() {
-            let chunk = chunks.remove(chunk_id).expect("chunk not found");
-            content_chunks.push(chunk.content);
-        }
-
-        let sha256: [u8; 32] = match arg.sha256 {
-            Some(bytes) => bytes
-                .into_vec()
-                .try_into()
-                .unwrap_or_else(|_| trap("invalid SHA-256")),
-            None => {
-                let mut hasher = sha2::Sha256::new();
-                for chunk in content_chunks.iter() {
-                    hasher.update(chunk);
-                }
-                hasher.finalize().into()
-            }
-        };
-
-        let total_length: usize = content_chunks.iter().map(|c| c.len()).sum();
-        let enc = AssetEncoding {
-            modified: now,
-            content_chunks,
-            certified: false,
-            total_length,
-            sha256,
-        };
-        asset.encodings.insert(arg.content_encoding, enc);
-
-        on_asset_change(&arg.key, asset);
-    })
-}
-
-fn do_unset_asset_content(arg: UnsetAssetContentArguments) {
-    STATE.with(|s| {
-        let mut assets = s.assets.borrow_mut();
-        let asset = assets
-            .get_mut(&arg.key)
-            .unwrap_or_else(|| trap("asset not found"));
-
-        if asset.encodings.remove(&arg.content_encoding).is_some() {
-            on_asset_change(&arg.key, asset);
-        }
-    })
-}
-
-fn do_delete_asset(arg: DeleteAssetArguments) {
-    STATE.with(|s| {
-        let mut assets = s.assets.borrow_mut();
-        assets.remove(&arg.key);
-    });
-    delete_asset_hash(&arg.key);
-}
-
-fn do_clear() {
-    STATE.with(|s| {
-        s.assets.borrow_mut().clear();
-        s.batches.borrow_mut().clear();
-        s.chunks.borrow_mut().clear();
-        *s.next_batch_id.borrow_mut() = Nat::from(1);
-        *s.next_chunk_id.borrow_mut() = Nat::from(1);
-    })
-}
-
-pub fn is_authorized() -> Result<(), String> {
-    STATE.with(|s| {
-        s.authorized
-            .borrow()
-            .contains(&caller())
+        s.borrow()
+            .is_authorized(&caller())
             .then(|| ())
             .ok_or_else(|| "Caller is not authorized".to_string())
     })
 }
 
-fn on_asset_change(key: &str, asset: &mut Asset) {
-    // If the most preferred encoding is present and certified,
-    // there is nothing to do.
-    for enc_name in ENCODING_CERTIFICATION_ORDER.iter() {
-        if let Some(enc) = asset.encodings.get(*enc_name) {
-            if enc.certified {
-                return;
-            } else {
-                break;
-            }
-        }
-    }
-
-    if asset.encodings.is_empty() {
-        delete_asset_hash(key);
-        return;
-    }
-
-    // An encoding with a higher priority was added, let's certify it
-    // instead.
-
-    for enc in asset.encodings.values_mut() {
-        enc.certified = false;
-    }
-
-    for enc_name in ENCODING_CERTIFICATION_ORDER.iter() {
-        if let Some(enc) = asset.encodings.get_mut(*enc_name) {
-            certify_asset(key.to_string(), &enc.sha256);
-            enc.certified = true;
-            return;
-        }
-    }
-
-    // No known encodings found. Just pick the first one. The exact
-    // order is hard to predict because we use a hash map. Should
-    // almost never happen anyway.
-    if let Some(enc) = asset.encodings.values_mut().next() {
-        certify_asset(key.to_string(), &enc.sha256);
-        enc.certified = true;
-    }
-}
-
-fn certify_asset(key: Key, content_hash: &Hash) {
-    ASSET_HASHES.with(|t| {
-        let mut tree = t.borrow_mut();
-        tree.insert(key, *content_hash);
-        set_root_hash(&*tree);
-    });
-}
-
-fn delete_asset_hash(key: &str) {
-    ASSET_HASHES.with(|t| {
-        let mut tree = t.borrow_mut();
-        tree.delete(key.as_bytes());
-        set_root_hash(&*tree);
-    });
-}
-
-fn set_root_hash(tree: &AssetHashes) {
-    use ic_certified_map::labeled_hash;
-    let full_tree_hash = labeled_hash(b"http_assets", &tree.root_hash());
-    set_certified_data(&full_tree_hash);
-}
-
-fn witness_to_header(witness: HashTree) -> HeaderField {
-    use ic_certified_map::labeled;
-
-    let hash_tree = labeled(b"http_assets", witness);
-    let mut serializer = serde_cbor::ser::Serializer::new(vec![]);
-    serializer.self_describe().unwrap();
-    hash_tree.serialize(&mut serializer).unwrap();
-
-    let certificate = data_certificate().unwrap_or_else(|| trap("no data certificate available"));
-
-    (
-        "IC-Certificate".to_string(),
-        String::from("certificate=:")
-            + &base64::encode(&certificate)
-            + ":, tree=:"
-            + &base64::encode(&serializer.into_inner())
-            + ":",
-    )
-}
-
-fn merge_hash_trees<'a>(lhs: HashTree<'a>, rhs: HashTree<'a>) -> HashTree<'a> {
-    use HashTree::{Empty, Fork, Labeled, Leaf, Pruned};
-
-    match (lhs, rhs) {
-        (Pruned(l), Pruned(r)) => {
-            if l != r {
-                trap("merge_hash_trees: inconsistent hashes");
-            }
-            Pruned(l)
-        }
-        (Pruned(_), r) => r,
-        (l, Pruned(_)) => l,
-        (Fork(l), Fork(r)) => Fork(Box::new((
-            merge_hash_trees(l.0, r.0),
-            merge_hash_trees(l.1, r.1),
-        ))),
-        (Labeled(l_label, l), Labeled(r_label, r)) => {
-            if l_label != r_label {
-                trap("merge_hash_trees: inconsistent hash tree labels");
-            }
-            Labeled(l_label, Box::new(merge_hash_trees(*l, *r)))
-        }
-        (Empty, Empty) => Empty,
-        (Leaf(l), Leaf(r)) => {
-            if l != r {
-                trap("merge_hash_trees: inconsistent leaves");
-            }
-            Leaf(l)
-        }
-        (_l, _r) => {
-            trap("merge_hash_trees: inconsistent tree structure");
-        }
-    }
-}
-
-fn hash_bytes(bytes: &[u8]) -> Hash {
-    let mut hash = sha2::Sha256::new();
-    hash.update(bytes);
-    hash.finalize().into()
-}
-
 pub fn init() {
-    do_clear();
-    STATE.with(|s| s.authorized.borrow_mut().push(caller()));
+    STATE.with(|s| {
+        let mut s = s.borrow_mut();
+        s.clear();
+        s.authorize_unconditionally(caller());
+    });
 }
 
 pub fn pre_upgrade() -> StableState {
-    STATE.with(|s| StableState {
-        authorized: s.authorized.take(),
-        stable_assets: s.assets.take(),
-    })
+    STATE.with(|s| s.take().into())
 }
 
 pub fn post_upgrade(stable_state: StableState) {
-    do_clear();
     STATE.with(|s| {
-        s.authorized.replace(stable_state.authorized);
-        s.assets.replace(stable_state.stable_assets);
-
-        for (asset_name, asset) in s.assets.borrow_mut().iter_mut() {
-            for enc in asset.encodings.values_mut() {
-                enc.certified = false;
-            }
-            on_asset_change(asset_name, asset);
-        }
+        *s.borrow_mut() = State::from(stable_state);
+        set_certified_data(&s.borrow().root_hash());
     });
 }
 

--- a/src/ic-certified-assets/src/lib.rs
+++ b/src/ic-certified-assets/src/lib.rs
@@ -160,7 +160,16 @@ fn list() -> Vec<AssetDetails> {
 fn http_request(req: HttpRequest) -> HttpResponse {
     let certificate = data_certificate().unwrap_or_else(|| trap("no data certificate available"));
 
-    STATE.with(|s| s.borrow().http_request(req, &certificate))
+    STATE.with(|s| {
+        s.borrow().http_request(
+            req,
+            &certificate,
+            candid::Func {
+                method: "http_request_streaming_callback".to_string(),
+                principal: ic_cdk::id(),
+            },
+        )
+    })
 }
 
 #[query]

--- a/src/ic-certified-assets/src/rc_bytes.rs
+++ b/src/ic-certified-assets/src/rc_bytes.rs
@@ -1,3 +1,4 @@
+//! This module contains an implementation of [RcBytes], a reference-counted byte array.
 use ic_cdk::export::candid::{
     types::{internal::Type, Serializer},
     CandidType, Deserialize,
@@ -9,7 +10,7 @@ use std::ops::Deref;
 use std::rc::Rc;
 
 #[derive(Clone, Debug)]
-pub(crate) struct RcBytes(Rc<ByteBuf>);
+pub struct RcBytes(Rc<ByteBuf>);
 
 impl CandidType for RcBytes {
     fn _ty() -> Type {

--- a/src/ic-certified-assets/src/state_machine.rs
+++ b/src/ic-certified-assets/src/state_machine.rs
@@ -1,0 +1,731 @@
+//! This module contains a pure implementation of the certified assets state machine.
+
+// NB. This module should not depend on ic_cdk, it contains only pure state transition functions.
+// All the environment (time, certificates, etc.) is passed to the state transition functions
+// as formal arguments.  This approach makes it very easy to test the state machine.
+
+use crate::{rc_bytes::RcBytes, types::*, url_decode::url_decode};
+use candid::{CandidType, Deserialize, Int, Nat, Principal};
+use ic_certified_map::{AsHashTree, Hash, HashTree, RbTree};
+use num_traits::ToPrimitive;
+use serde::Serialize;
+use serde_bytes::ByteBuf;
+use sha2::Digest;
+use std::collections::HashMap;
+use std::convert::TryInto;
+
+/// The amount of time a batch is kept alive. Modifying the batch
+/// delays the expiry further.
+const BATCH_EXPIRY_NANOS: u64 = 300_000_000_000;
+
+/// The order in which we pick encodings for certification.
+const ENCODING_CERTIFICATION_ORDER: &[&str] = &["identity", "gzip", "compress", "deflate", "br"];
+
+/// The file to serve if the requested file wasn't found.
+const INDEX_FILE: &str = "/index.html";
+
+type AssetHashes = RbTree<Key, Hash>;
+type Timestamp = Int;
+
+#[derive(Default, Clone, Debug, CandidType, Deserialize)]
+pub struct AssetEncoding {
+    pub modified: Timestamp,
+    pub content_chunks: Vec<RcBytes>,
+    pub total_length: usize,
+    pub certified: bool,
+    pub sha256: [u8; 32],
+}
+
+#[derive(Default, Clone, Debug, CandidType, Deserialize)]
+pub struct Asset {
+    pub content_type: String,
+    pub encodings: HashMap<String, AssetEncoding>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct EncodedAsset {
+    pub content: RcBytes,
+    pub content_type: String,
+    pub content_encoding: String,
+    pub total_length: Nat,
+    pub sha256: Option<ByteBuf>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct AssetDetails {
+    pub key: String,
+    pub content_type: String,
+    pub encodings: Vec<AssetEncodingDetails>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct AssetEncodingDetails {
+    pub content_encoding: String,
+    pub sha256: Option<ByteBuf>,
+    pub length: Nat,
+    pub modified: Timestamp,
+}
+
+pub struct Chunk {
+    pub batch_id: BatchId,
+    pub content: RcBytes,
+}
+
+pub struct Batch {
+    pub expires_at: Timestamp,
+}
+
+#[derive(Default)]
+pub struct State {
+    assets: HashMap<Key, Asset>,
+
+    chunks: HashMap<ChunkId, Chunk>,
+    next_chunk_id: ChunkId,
+
+    batches: HashMap<BatchId, Batch>,
+    next_batch_id: BatchId,
+
+    authorized: Vec<Principal>,
+
+    asset_hashes: AssetHashes,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct StableState {
+    authorized: Vec<Principal>,
+    stable_assets: HashMap<String, Asset>,
+}
+
+impl State {
+    pub fn authorize_unconditionally(&mut self, principal: Principal) {
+        if !self.is_authorized(&principal) {
+            self.authorized.push(principal);
+        }
+    }
+
+    pub fn authorize(&mut self, caller: &Principal, other: Principal) -> Result<(), String> {
+        if !self.is_authorized(&caller) {
+            return Err("the caller is not authorized".to_string());
+        }
+        self.authorize_unconditionally(other);
+        Ok(())
+    }
+
+    pub fn root_hash(&self) -> Hash {
+        use ic_certified_map::labeled_hash;
+        labeled_hash(b"http_assets", &self.asset_hashes.root_hash())
+    }
+
+    pub fn create_asset(&mut self, arg: CreateAssetArguments) -> Result<(), String> {
+        if let Some(asset) = self.assets.get(&arg.key) {
+            if asset.content_type != arg.content_type {
+                return Err("create_asset: content type mismatch".to_string());
+            }
+        } else {
+            self.assets.insert(
+                arg.key,
+                Asset {
+                    content_type: arg.content_type,
+                    encodings: HashMap::new(),
+                },
+            );
+        }
+        Ok(())
+    }
+
+    pub fn set_asset_content(
+        &mut self,
+        arg: SetAssetContentArguments,
+        now: u64,
+    ) -> Result<(), String> {
+        if arg.chunk_ids.is_empty() {
+            return Err("encoding must have at least one chunk".to_string());
+        }
+
+        let asset = self
+            .assets
+            .get_mut(&arg.key)
+            .ok_or_else(|| "asset not found".to_string())?;
+
+        let now = Int::from(now);
+
+        let mut content_chunks = vec![];
+        for chunk_id in arg.chunk_ids.iter() {
+            let chunk = self.chunks.remove(chunk_id).expect("chunk not found");
+            content_chunks.push(chunk.content);
+        }
+
+        let sha256: [u8; 32] = match arg.sha256 {
+            Some(bytes) => bytes
+                .into_vec()
+                .try_into()
+                .map_err(|_| "invalid SHA-256".to_string())?,
+            None => {
+                let mut hasher = sha2::Sha256::new();
+                for chunk in content_chunks.iter() {
+                    hasher.update(chunk);
+                }
+                hasher.finalize().into()
+            }
+        };
+
+        let total_length: usize = content_chunks.iter().map(|c| c.len()).sum();
+        let enc = AssetEncoding {
+            modified: now,
+            content_chunks,
+            certified: false,
+            total_length,
+            sha256,
+        };
+        asset.encodings.insert(arg.content_encoding, enc);
+
+        on_asset_change(&mut self.asset_hashes, &arg.key, asset);
+
+        Ok(())
+    }
+
+    pub fn unset_asset_content(&mut self, arg: UnsetAssetContentArguments) -> Result<(), String> {
+        let asset = self
+            .assets
+            .get_mut(&arg.key)
+            .ok_or_else(|| "asset not found".to_string())?;
+
+        if asset.encodings.remove(&arg.content_encoding).is_some() {
+            on_asset_change(&mut self.asset_hashes, &arg.key, asset);
+        }
+
+        Ok(())
+    }
+
+    pub fn delete_asset(&mut self, arg: DeleteAssetArguments) {
+        self.assets.remove(&arg.key);
+        self.asset_hashes.delete(arg.key.as_bytes());
+    }
+
+    pub fn clear(&mut self) {
+        self.assets.clear();
+        self.batches.clear();
+        self.chunks.clear();
+        self.next_batch_id = Nat::from(1);
+        self.next_chunk_id = Nat::from(1);
+    }
+
+    pub fn is_authorized(&self, principal: &Principal) -> bool {
+        self.authorized.contains(principal)
+    }
+
+    pub fn retrieve(&self, key: &Key) -> Result<RcBytes, String> {
+        let asset = self
+            .assets
+            .get(key)
+            .ok_or_else(|| "asset not found".to_string())?;
+
+        let id_enc = asset
+            .encodings
+            .get("identity")
+            .ok_or_else(|| "no identity encoding".to_string())?;
+
+        if id_enc.content_chunks.len() > 1 {
+            return Err("Asset too large. Use get() and get_chunk() instead.".to_string());
+        }
+
+        Ok(id_enc.content_chunks[0].clone())
+    }
+
+    pub fn store(&mut self, arg: StoreArg, time: u64) -> Result<(), String> {
+        let asset = self.assets.entry(arg.key.clone()).or_default();
+        asset.content_type = arg.content_type;
+
+        let hash = sha2::Sha256::digest(&arg.content).into();
+        if let Some(provided_hash) = arg.sha256 {
+            if hash != provided_hash.as_ref() {
+                return Err("sha256 mismatch".to_string());
+            }
+        }
+
+        let encoding = asset.encodings.entry(arg.content_encoding).or_default();
+        encoding.total_length = arg.content.len();
+        encoding.content_chunks = vec![RcBytes::from(arg.content)];
+        encoding.modified = Int::from(time);
+        encoding.sha256 = hash;
+
+        on_asset_change(&mut self.asset_hashes, &arg.key, asset);
+        Ok(())
+    }
+
+    pub fn create_batch(&mut self, now: u64) -> BatchId {
+        let batch_id = self.next_batch_id.clone();
+        self.next_batch_id += 1;
+
+        self.batches.insert(
+            batch_id.clone(),
+            Batch {
+                expires_at: Int::from(now + BATCH_EXPIRY_NANOS),
+            },
+        );
+        self.chunks.retain(|_, c| {
+            self.batches
+                .get(&c.batch_id)
+                .map(|b| b.expires_at > now)
+                .unwrap_or(false)
+        });
+        self.batches.retain(|_, b| b.expires_at > now);
+
+        batch_id
+    }
+
+    pub fn create_chunk(&mut self, arg: CreateChunkArg, now: u64) -> Result<ChunkId, String> {
+        let mut batch = self
+            .batches
+            .get_mut(&arg.batch_id)
+            .ok_or_else(|| "batch not found".to_string())?;
+
+        batch.expires_at = Int::from(now + BATCH_EXPIRY_NANOS);
+
+        let chunk_id = self.next_chunk_id.clone();
+        self.next_chunk_id += 1;
+
+        self.chunks.insert(
+            chunk_id.clone(),
+            Chunk {
+                batch_id: arg.batch_id,
+                content: RcBytes::from(arg.content),
+            },
+        );
+
+        Ok(chunk_id)
+    }
+
+    pub fn commit_batch(&mut self, arg: CommitBatchArguments, now: u64) -> Result<(), String> {
+        let batch_id = arg.batch_id;
+        for op in arg.operations {
+            match op {
+                BatchOperation::CreateAsset(arg) => self.create_asset(arg)?,
+                BatchOperation::SetAssetContent(arg) => self.set_asset_content(arg, now)?,
+                BatchOperation::UnsetAssetContent(arg) => self.unset_asset_content(arg)?,
+                BatchOperation::DeleteAsset(arg) => self.delete_asset(arg),
+                BatchOperation::Clear(_) => self.clear(),
+            }
+        }
+        self.batches.remove(&batch_id);
+        Ok(())
+    }
+
+    pub fn list_assets(&self) -> Vec<AssetDetails> {
+        self.assets
+            .iter()
+            .map(|(key, asset)| {
+                let mut encodings: Vec<_> = asset
+                    .encodings
+                    .iter()
+                    .map(|(enc_name, enc)| AssetEncodingDetails {
+                        content_encoding: enc_name.clone(),
+                        sha256: Some(ByteBuf::from(enc.sha256)),
+                        length: Nat::from(enc.total_length),
+                        modified: enc.modified.clone(),
+                    })
+                    .collect();
+                encodings.sort_by(|l, r| l.content_encoding.cmp(&r.content_encoding));
+
+                AssetDetails {
+                    key: key.clone(),
+                    content_type: asset.content_type.clone(),
+                    encodings,
+                }
+            })
+            .collect::<Vec<_>>()
+    }
+
+    pub fn get(&self, arg: GetArg) -> Result<EncodedAsset, String> {
+        let asset = self
+            .assets
+            .get(&arg.key)
+            .ok_or_else(|| "asset not found".to_string())?;
+
+        for enc in arg.accept_encodings.iter() {
+            if let Some(asset_enc) = asset.encodings.get(enc) {
+                return Ok(EncodedAsset {
+                    content: asset_enc.content_chunks[0].clone(),
+                    content_type: asset.content_type.clone(),
+                    content_encoding: enc.clone(),
+                    total_length: Nat::from(asset_enc.total_length as u64),
+                    sha256: Some(ByteBuf::from(asset_enc.sha256)),
+                });
+            }
+        }
+        return Err("no such encoding".to_string());
+    }
+
+    pub fn get_chunk(&self, arg: GetChunkArg) -> Result<RcBytes, String> {
+        let asset = self
+            .assets
+            .get(&arg.key)
+            .ok_or_else(|| "asset not found".to_string())?;
+
+        let enc = asset
+            .encodings
+            .get(&arg.content_encoding)
+            .ok_or_else(|| "no such encoding".to_string())?;
+
+        if let Some(expected_hash) = arg.sha256 {
+            if expected_hash != enc.sha256 {
+                return Err("sha256 mismatch".to_string());
+            }
+        }
+        if arg.index >= enc.content_chunks.len() {
+            return Err("chunk index out of bounds".to_string());
+        }
+        let index: usize = arg.index.0.to_usize().unwrap();
+
+        Ok(enc.content_chunks[index].clone())
+    }
+
+    fn build_http_response(
+        &self,
+        certificate: &[u8],
+        path: &str,
+        encodings: Vec<String>,
+        index: usize,
+    ) -> HttpResponse {
+        let index_redirect_certificate = if self.asset_hashes.get(path.as_bytes()).is_none()
+            && self.asset_hashes.get(INDEX_FILE.as_bytes()).is_some()
+        {
+            let absence_proof = self.asset_hashes.witness(path.as_bytes());
+            let index_proof = self.asset_hashes.witness(INDEX_FILE.as_bytes());
+            let combined_proof = merge_hash_trees(absence_proof, index_proof);
+            Some(witness_to_header(combined_proof, certificate))
+        } else {
+            None
+        };
+
+        if let Some(certificate_header) = index_redirect_certificate {
+            if let Some(asset) = self.assets.get(INDEX_FILE) {
+                for enc_name in encodings.iter() {
+                    if let Some(enc) = asset.encodings.get(enc_name) {
+                        if enc.certified {
+                            return build_200(
+                                asset,
+                                enc_name,
+                                enc,
+                                INDEX_FILE,
+                                index,
+                                Some(certificate_header),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        let certificate_header =
+            witness_to_header(self.asset_hashes.witness(path.as_bytes()), certificate);
+
+        if let Some(asset) = self.assets.get(path) {
+            for enc_name in encodings.iter() {
+                if let Some(enc) = asset.encodings.get(enc_name) {
+                    if enc.certified {
+                        return build_200(
+                            asset,
+                            enc_name,
+                            enc,
+                            path,
+                            index,
+                            Some(certificate_header),
+                        );
+                    } else {
+                        // Find if identity is certified, if it's not.
+                        if let Some(id_enc) = asset.encodings.get("identity") {
+                            if id_enc.certified {
+                                return build_200(
+                                    asset,
+                                    enc_name,
+                                    enc,
+                                    path,
+                                    index,
+                                    Some(certificate_header),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        build_404(certificate_header)
+    }
+
+    pub fn http_request(&self, req: HttpRequest, certificate: &[u8]) -> HttpResponse {
+        let mut encodings = vec![];
+        for (name, value) in req.headers.iter() {
+            if name.eq_ignore_ascii_case("Accept-Encoding") {
+                for v in value.split(',') {
+                    encodings.push(v.trim().to_string());
+                }
+            }
+            if name.eq_ignore_ascii_case("Host") {
+                if let Some(replacement_url) = redirect_to_url(value, &req.url) {
+                    return HttpResponse {
+                        status_code: 308,
+                        headers: vec![("Location".to_string(), replacement_url)],
+                        body: RcBytes::from(ByteBuf::default()),
+                        streaming_strategy: None,
+                    };
+                }
+            }
+        }
+        encodings.push("identity".to_string());
+
+        let path = match req.url.find('?') {
+            Some(i) => &req.url[..i],
+            None => &req.url[..],
+        };
+
+        match url_decode(path) {
+            Ok(path) => self.build_http_response(certificate, &path, encodings, 0),
+            Err(err) => HttpResponse {
+                status_code: 400,
+                headers: vec![],
+                body: RcBytes::from(ByteBuf::from(format!(
+                    "failed to decode path '{}': {}",
+                    path, err
+                ))),
+                streaming_strategy: None,
+            },
+        }
+    }
+
+    pub fn http_request_streaming_callback(
+        &self,
+        StreamingCallbackToken {
+            key,
+            content_encoding,
+            index,
+            sha256,
+        }: StreamingCallbackToken,
+    ) -> Result<StreamingCallbackHttpResponse, String> {
+        let asset = self
+            .assets
+            .get(&key)
+            .ok_or_else(|| "Invalid token on streaming: key not found.".to_string())?;
+        let enc = asset
+            .encodings
+            .get(&content_encoding)
+            .ok_or_else(|| "Invalid token on streaming: encoding not found.".to_string())?;
+
+        if let Some(expected_hash) = sha256 {
+            if expected_hash != enc.sha256 {
+                return Err("sha256 mismatch".to_string());
+            }
+        }
+
+        // MAX is good enough. This means a chunk would be above 64-bits, which is impossible...
+        let chunk_index = index.0.to_usize().unwrap_or(usize::MAX);
+
+        Ok(StreamingCallbackHttpResponse {
+            body: enc.content_chunks[chunk_index].clone(),
+            token: create_token(asset, &content_encoding, enc, &key, chunk_index),
+        })
+    }
+}
+
+impl From<State> for StableState {
+    fn from(state: State) -> Self {
+        Self {
+            authorized: state.authorized,
+            stable_assets: state.assets,
+        }
+    }
+}
+
+impl From<StableState> for State {
+    fn from(stable_state: StableState) -> Self {
+        let mut state = Self::default();
+        state.authorized = stable_state.authorized;
+        state.assets = stable_state.stable_assets;
+
+        for (asset_name, asset) in state.assets.iter_mut() {
+            for enc in asset.encodings.values_mut() {
+                enc.certified = false;
+            }
+            on_asset_change(&mut state.asset_hashes, asset_name, asset);
+        }
+        state
+    }
+}
+
+fn on_asset_change(asset_hashes: &mut AssetHashes, key: &str, asset: &mut Asset) {
+    // If the most preferred encoding is present and certified,
+    // there is nothing to do.
+    for enc_name in ENCODING_CERTIFICATION_ORDER.iter() {
+        if let Some(enc) = asset.encodings.get(*enc_name) {
+            if enc.certified {
+                return;
+            } else {
+                break;
+            }
+        }
+    }
+
+    if asset.encodings.is_empty() {
+        asset_hashes.delete(key.as_bytes());
+        return;
+    }
+
+    // An encoding with a higher priority was added, let's certify it
+    // instead.
+
+    for enc in asset.encodings.values_mut() {
+        enc.certified = false;
+    }
+
+    for enc_name in ENCODING_CERTIFICATION_ORDER.iter() {
+        if let Some(enc) = asset.encodings.get_mut(*enc_name) {
+            asset_hashes.insert(key.to_string(), enc.sha256);
+            enc.certified = true;
+            return;
+        }
+    }
+
+    // No known encodings found. Just pick the first one. The exact
+    // order is hard to predict because we use a hash map. Should
+    // almost never happen anyway.
+    if let Some(enc) = asset.encodings.values_mut().next() {
+        asset_hashes.insert(key.to_string(), enc.sha256);
+        enc.certified = true;
+    }
+}
+
+fn witness_to_header(witness: HashTree, certificate: &[u8]) -> HeaderField {
+    use ic_certified_map::labeled;
+
+    let hash_tree = labeled(b"http_assets", witness);
+    let mut serializer = serde_cbor::ser::Serializer::new(vec![]);
+    serializer.self_describe().unwrap();
+    hash_tree.serialize(&mut serializer).unwrap();
+
+    (
+        "IC-Certificate".to_string(),
+        String::from("certificate=:")
+            + &base64::encode(certificate)
+            + ":, tree=:"
+            + &base64::encode(&serializer.into_inner())
+            + ":",
+    )
+}
+
+fn merge_hash_trees<'a>(lhs: HashTree<'a>, rhs: HashTree<'a>) -> HashTree<'a> {
+    use HashTree::{Empty, Fork, Labeled, Leaf, Pruned};
+
+    match (lhs, rhs) {
+        (Pruned(l), Pruned(r)) => {
+            if l != r {
+                panic!("merge_hash_trees: inconsistent hashes");
+            }
+            Pruned(l)
+        }
+        (Pruned(_), r) => r,
+        (l, Pruned(_)) => l,
+        (Fork(l), Fork(r)) => Fork(Box::new((
+            merge_hash_trees(l.0, r.0),
+            merge_hash_trees(l.1, r.1),
+        ))),
+        (Labeled(l_label, l), Labeled(r_label, r)) => {
+            if l_label != r_label {
+                panic!("merge_hash_trees: inconsistent hash tree labels");
+            }
+            Labeled(l_label, Box::new(merge_hash_trees(*l, *r)))
+        }
+        (Empty, Empty) => Empty,
+        (Leaf(l), Leaf(r)) => {
+            if l != r {
+                panic!("merge_hash_trees: inconsistent leaves");
+            }
+            Leaf(l)
+        }
+        (_l, _r) => {
+            panic!("merge_hash_trees: inconsistent tree structure");
+        }
+    }
+}
+
+fn create_token(
+    _asset: &Asset,
+    enc_name: &str,
+    enc: &AssetEncoding,
+    key: &str,
+    chunk_index: usize,
+) -> Option<StreamingCallbackToken> {
+    if chunk_index + 1 >= enc.content_chunks.len() {
+        None
+    } else {
+        Some(StreamingCallbackToken {
+            key: key.to_string(),
+            content_encoding: enc_name.to_string(),
+            index: Nat::from(chunk_index + 1),
+            sha256: Some(ByteBuf::from(enc.sha256)),
+        })
+    }
+}
+
+fn create_strategy(
+    asset: &Asset,
+    enc_name: &str,
+    enc: &AssetEncoding,
+    key: &str,
+    chunk_index: usize,
+) -> Option<StreamingStrategy> {
+    create_token(asset, enc_name, enc, key, chunk_index).map(|token| StreamingStrategy::Callback {
+        callback: ic_cdk::export::candid::Func {
+            method: "http_request_streaming_callback".to_string(),
+            principal: ic_cdk::id(),
+        },
+        token,
+    })
+}
+
+fn build_200(
+    asset: &Asset,
+    enc_name: &str,
+    enc: &AssetEncoding,
+    key: &str,
+    chunk_index: usize,
+    certificate_header: Option<HeaderField>,
+) -> HttpResponse {
+    let mut headers = vec![("Content-Type".to_string(), asset.content_type.to_string())];
+    if enc_name != "identity" {
+        headers.push(("Content-Encoding".to_string(), enc_name.to_string()));
+    }
+    if let Some(head) = certificate_header {
+        headers.push(head);
+    }
+
+    let streaming_strategy = create_strategy(asset, enc_name, enc, key, chunk_index);
+
+    HttpResponse {
+        status_code: 200,
+        headers,
+        body: enc.content_chunks[chunk_index].clone(),
+        streaming_strategy,
+    }
+}
+
+fn build_404(certificate_header: HeaderField) -> HttpResponse {
+    HttpResponse {
+        status_code: 404,
+        headers: vec![certificate_header],
+        body: RcBytes::from(ByteBuf::from("not found")),
+        streaming_strategy: None,
+    }
+}
+
+fn redirect_to_url(host: &str, url: &str) -> Option<String> {
+    if let Some(host) = host.split(':').next() {
+        let host = host.trim();
+        if host == "raw.ic0.app" {
+            return Some(format!("https://ic0.app{}", url));
+        } else if let Some(base) = host.strip_suffix(".raw.ic0.app") {
+            return Some(format!("https://{}.ic0.app{}", base, url));
+        }
+    }
+    None
+}

--- a/src/ic-certified-assets/src/tests.rs
+++ b/src/ic-certified-assets/src/tests.rs
@@ -1,51 +1,93 @@
-use crate::state_machine::State;
+use crate::state_machine::{StableState, State, BATCH_EXPIRY_NANOS};
 use crate::types::{
-    BatchOperation, CommitBatchArguments, CreateAssetArguments, CreateChunkArg, HttpRequest,
-    HttpResponse, SetAssetContentArguments,
+    BatchId, BatchOperation, CommitBatchArguments, CreateAssetArguments, CreateChunkArg,
+    HttpRequest, HttpResponse, SetAssetContentArguments, StreamingStrategy,
 };
+use crate::url_decode::{url_decode, UrlDecodeError};
+use candid::Principal;
 use serde_bytes::ByteBuf;
+
+fn some_principal() -> Principal {
+    Principal::from_text("ryjl3-tyaaa-aaaaa-aaaba-cai").unwrap()
+}
+
+fn unused_callback() -> candid::Func {
+    candid::Func {
+        method: "unused".to_string(),
+        principal: some_principal(),
+    }
+}
+
+fn create_assets(
+    state: &mut State,
+    time_now: u64,
+    assets: Vec<(&str, &str, Vec<(&str, Vec<&[u8]>)>)>,
+) -> BatchId {
+    let batch_id = state.create_batch(time_now);
+
+    let mut operations = vec![];
+
+    for (asset, content_type, encodings) in assets {
+        operations.push(BatchOperation::CreateAsset(CreateAssetArguments {
+            key: asset.to_string(),
+            content_type: content_type.to_string(),
+        }));
+        for (enc, chunks) in encodings {
+            let mut chunk_ids = vec![];
+            for chunk in chunks {
+                chunk_ids.push(
+                    state
+                        .create_chunk(
+                            CreateChunkArg {
+                                batch_id: batch_id.clone(),
+                                content: ByteBuf::from(chunk.to_vec()),
+                            },
+                            time_now,
+                        )
+                        .unwrap(),
+                );
+            }
+
+            operations.push(BatchOperation::SetAssetContent({
+                SetAssetContentArguments {
+                    key: asset.to_string(),
+                    content_encoding: enc.to_string(),
+                    chunk_ids,
+                    sha256: None,
+                }
+            }));
+        }
+    }
+
+    state
+        .commit_batch(
+            CommitBatchArguments {
+                batch_id: batch_id.clone(),
+                operations,
+            },
+            time_now,
+        )
+        .unwrap();
+
+    batch_id
+}
 
 #[test]
 fn can_create_assets_using_batch_api() {
     let mut state = State::default();
     let time_now = 100_000_000_000;
 
-    let batch_id = state.create_batch(time_now);
-
     const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
 
-    let chunk_id = state
-        .create_chunk(
-            CreateChunkArg {
-                batch_id: batch_id.clone(),
-                content: ByteBuf::from(BODY.to_vec()),
-            },
-            time_now,
-        )
-        .unwrap();
-
-    state
-        .commit_batch(
-            CommitBatchArguments {
-                batch_id: batch_id.clone(),
-                operations: vec![
-                    BatchOperation::CreateAsset(CreateAssetArguments {
-                        key: "/contents.html".to_string(),
-                        content_type: "text/html".to_string(),
-                    }),
-                    BatchOperation::SetAssetContent({
-                        SetAssetContentArguments {
-                            key: "/contents.html".to_string(),
-                            content_encoding: "identity".to_string(),
-                            chunk_ids: vec![chunk_id.clone()],
-                            sha256: None,
-                        }
-                    }),
-                ],
-            },
-            time_now,
-        )
-        .unwrap();
+    let batch_id = create_assets(
+        &mut state,
+        time_now,
+        vec![(
+            "/contents.html",
+            "text/html",
+            vec![("identity", vec![BODY])],
+        )],
+    );
 
     let response = state.http_request(
         HttpRequest {
@@ -55,6 +97,7 @@ fn can_create_assets_using_batch_api() {
             url: "/contents.html".to_string(),
         },
         &[],
+        unused_callback(),
     );
 
     assert_eq!(response.status_code, 200);
@@ -81,6 +124,164 @@ fn can_create_assets_using_batch_api() {
 }
 
 #[test]
+fn batches_are_dropped_after_timeout() {
+    let mut state = State::default();
+    let time_now = 100_000_000_000;
+
+    let batch_1 = state.create_batch(time_now);
+
+    const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
+
+    let _chunk_1 = state
+        .create_chunk(
+            CreateChunkArg {
+                batch_id: batch_1.clone(),
+                content: ByteBuf::from(BODY.to_vec()),
+            },
+            time_now,
+        )
+        .unwrap();
+
+    let time_now = time_now + BATCH_EXPIRY_NANOS + 1;
+    let _batch_2 = state.create_batch(time_now);
+
+    match state.create_chunk(
+        CreateChunkArg {
+            batch_id: batch_1,
+            content: ByteBuf::from(BODY.to_vec()),
+        },
+        time_now,
+    ) {
+        Err(err) if err.contains("batch not found") => (),
+        other => panic!("expected 'batch not found' error, got: {:?}", other),
+    }
+}
+
+#[test]
+fn returns_index_file_for_missing_assets() {
+    let mut state = State::default();
+    let time_now = 100_000_000_000;
+
+    const INDEX_BODY: &[u8] = b"<!DOCTYPE html><html>Index</html>";
+    const OTHER_BODY: &[u8] = b"<!DOCTYPE html><html>Other</html>";
+
+    create_assets(
+        &mut state,
+        time_now,
+        vec![
+            (
+                "/index.html",
+                "text/html",
+                vec![("identity", vec![INDEX_BODY])],
+            ),
+            (
+                "/other.html",
+                "text/html",
+                vec![("identity", vec![OTHER_BODY])],
+            ),
+        ],
+    );
+
+    let response = state.http_request(
+        HttpRequest {
+            body: ByteBuf::new(),
+            headers: vec![("Accept-Encoding".to_string(), "gzip,identity".to_string())],
+            method: "GET".to_string(),
+            url: "/missing.html".to_string(),
+        },
+        &[],
+        unused_callback(),
+    );
+
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.body.as_ref(), INDEX_BODY);
+}
+
+#[test]
+fn preserves_state_on_stable_roundtrip() {
+    let mut state = State::default();
+    let time_now = 100_000_000_000;
+
+    const INDEX_BODY: &[u8] = b"<!DOCTYPE html><html>Index</html>";
+
+    create_assets(
+        &mut state,
+        time_now,
+        vec![(
+            "/index.html",
+            "text/html",
+            vec![("identity", vec![INDEX_BODY])],
+        )],
+    );
+
+    let stable_state: StableState = state.into();
+    let state: State = stable_state.into();
+
+    let response = state.http_request(
+        HttpRequest {
+            body: ByteBuf::new(),
+            headers: vec![("Accept-Encoding".to_string(), "gzip,identity".to_string())],
+            method: "GET".to_string(),
+            url: "/index.html".to_string(),
+        },
+        &[],
+        unused_callback(),
+    );
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.body.as_ref(), INDEX_BODY);
+}
+
+#[test]
+fn uses_streaming_for_multichunk_assets() {
+    let mut state = State::default();
+    let time_now = 100_000_000_000;
+
+    const INDEX_BODY_CHUNK_1: &[u8] = b"<!DOCTYPE html>";
+    const INDEX_BODY_CHUNK_2: &[u8] = b"<html>Index</html>";
+
+    create_assets(
+        &mut state,
+        time_now,
+        vec![(
+            "/index.html",
+            "text/html",
+            vec![("identity", vec![INDEX_BODY_CHUNK_1, INDEX_BODY_CHUNK_2])],
+        )],
+    );
+
+    let streaming_callback = candid::Func {
+        method: "stream".to_string(),
+        principal: some_principal(),
+    };
+    let response = state.http_request(
+        HttpRequest {
+            body: ByteBuf::new(),
+            headers: vec![("Accept-Encoding".to_string(), "gzip,identity".to_string())],
+            method: "GET".to_string(),
+            url: "/index.html".to_string(),
+        },
+        &[],
+        streaming_callback.clone(),
+    );
+
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.body.as_ref(), INDEX_BODY_CHUNK_1);
+
+    let StreamingStrategy::Callback { callback, token } = response
+        .streaming_strategy
+        .expect("missing streaming strategy");
+    assert_eq!(callback, streaming_callback);
+
+    let streaming_response = state.http_request_streaming_callback(token).unwrap();
+    assert_eq!(streaming_response.body.as_ref(), INDEX_BODY_CHUNK_2);
+    assert!(
+        streaming_response.token.is_none(),
+        "Unexpected streaming response: {:?}",
+        streaming_response
+    );
+}
+
+#[test]
 fn redirects_cleanly() {
     fn fake(host: &str) -> HttpRequest {
         HttpRequest {
@@ -102,28 +303,55 @@ fn redirects_cleanly() {
     let fake_cert = [0xca, 0xfe];
 
     assert_308(
-        &state.http_request(fake("aaaaa-aa.raw.ic0.app"), &fake_cert),
+        &state.http_request(fake("aaaaa-aa.raw.ic0.app"), &fake_cert, unused_callback()),
         "https://aaaaa-aa.ic0.app/asset.blob",
     );
     assert_308(
-        &state.http_request(fake("my.http.files.raw.ic0.app"), &fake_cert),
+        &state.http_request(
+            fake("my.http.files.raw.ic0.app"),
+            &fake_cert,
+            unused_callback(),
+        ),
         "https://my.http.files.ic0.app/asset.blob",
     );
     assert_308(
-        &state.http_request(fake("raw.ic0.app.raw.ic0.app"), &fake_cert),
+        &state.http_request(
+            fake("raw.ic0.app.raw.ic0.app"),
+            &fake_cert,
+            unused_callback(),
+        ),
         "https://raw.ic0.app.ic0.app/asset.blob",
     );
     assert_308(
-        &state.http_request(fake("raw.ic0.app"), &fake_cert), // for ?canisterId=
+        &state.http_request(fake("raw.ic0.app"), &fake_cert, unused_callback()), // for ?canisterId=
         "https://ic0.app/asset.blob",
     );
     let no_redirect = state
-        .http_request(fake("raw.ic0.app.ic0.app"), &fake_cert)
+        .http_request(fake("raw.ic0.app.ic0.app"), &fake_cert, unused_callback())
         .status_code;
     assert!(!matches!(no_redirect, 308));
 
     let no_redirect2 = state
-        .http_request(fake("straw.ic0.app"), &fake_cert)
+        .http_request(fake("straw.ic0.app"), &fake_cert, unused_callback())
         .status_code;
     assert!(!matches!(no_redirect2, 308));
+}
+
+#[test]
+fn check_url_decode() {
+    assert_eq!(
+        url_decode("/%"),
+        Err(UrlDecodeError::InvalidPercentEncoding)
+    );
+    assert_eq!(url_decode("/%%"), Ok("/%".to_string()));
+    assert_eq!(url_decode("/%20a"), Ok("/ a".to_string()));
+    assert_eq!(
+        url_decode("/%%+a%20+%@"),
+        Err(UrlDecodeError::InvalidPercentEncoding)
+    );
+    assert_eq!(
+        url_decode("/has%percent.txt"),
+        Err(UrlDecodeError::InvalidPercentEncoding)
+    );
+    assert_eq!(url_decode("/%e6"), Ok("/æ".to_string()));
 }

--- a/src/ic-certified-assets/src/tests.rs
+++ b/src/ic-certified-assets/src/tests.rs
@@ -18,10 +18,12 @@ fn unused_callback() -> candid::Func {
     }
 }
 
+type Encodings<'a> = Vec<(&'a str, Vec<&'a [u8]>)>;
+
 fn create_assets(
     state: &mut State,
     time_now: u64,
-    assets: Vec<(&str, &str, Vec<(&str, Vec<&[u8]>)>)>,
+    assets: Vec<(&str, &str, Encodings<'_>)>,
 ) -> BatchId {
     let batch_id = state.create_batch(time_now);
 

--- a/src/ic-certified-assets/src/tests.rs
+++ b/src/ic-certified-assets/src/tests.rs
@@ -1,24 +1,83 @@
-use crate::*;
-
-use std::panic::catch_unwind;
+use crate::state_machine::State;
+use crate::types::{
+    BatchOperation, CommitBatchArguments, CreateAssetArguments, CreateChunkArg, HttpRequest,
+    HttpResponse, SetAssetContentArguments,
+};
+use serde_bytes::ByteBuf;
 
 #[test]
-fn check_url_decode() {
-    assert_eq!(
-        url_decode("/%"),
-        Err(UrlDecodeError::InvalidPercentEncoding)
+fn can_create_assets_using_batch_api() {
+    let mut state = State::default();
+    let time_now = 100_000_000_000;
+
+    let batch_id = state.create_batch(time_now);
+
+    const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
+
+    let chunk_id = state
+        .create_chunk(
+            CreateChunkArg {
+                batch_id: batch_id.clone(),
+                content: ByteBuf::from(BODY.to_vec()),
+            },
+            time_now,
+        )
+        .unwrap();
+
+    state
+        .commit_batch(
+            CommitBatchArguments {
+                batch_id: batch_id.clone(),
+                operations: vec![
+                    BatchOperation::CreateAsset(CreateAssetArguments {
+                        key: "/contents.html".to_string(),
+                        content_type: "text/html".to_string(),
+                    }),
+                    BatchOperation::SetAssetContent({
+                        SetAssetContentArguments {
+                            key: "/contents.html".to_string(),
+                            content_encoding: "identity".to_string(),
+                            chunk_ids: vec![chunk_id.clone()],
+                            sha256: None,
+                        }
+                    }),
+                ],
+            },
+            time_now,
+        )
+        .unwrap();
+
+    let response = state.http_request(
+        HttpRequest {
+            body: ByteBuf::new(),
+            headers: vec![("Accept-Encoding".to_string(), "gzip,identity".to_string())],
+            method: "GET".to_string(),
+            url: "/contents.html".to_string(),
+        },
+        &[],
     );
-    assert_eq!(url_decode("/%%"), Ok("/%".to_string()));
-    assert_eq!(url_decode("/%20a"), Ok("/ a".to_string()));
-    assert_eq!(
-        url_decode("/%%+a%20+%@"),
-        Err(UrlDecodeError::InvalidPercentEncoding)
+
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.body.as_ref(), BODY);
+
+    // Try to update a completed batch.
+    let error_msg = state
+        .create_chunk(
+            CreateChunkArg {
+                batch_id,
+                content: ByteBuf::new(),
+            },
+            time_now,
+        )
+        .unwrap_err();
+
+    let expected = "batch not found";
+    assert!(
+        error_msg.contains(expected),
+        "expected '{}' error, got: {}",
+        expected,
+        error_msg
     );
-    assert_eq!(
-        url_decode("/has%percent.txt"),
-        Err(UrlDecodeError::InvalidPercentEncoding)
-    );
-    assert_eq!(url_decode("/%e6"), Ok("/æ".to_string()));
 }
 
 #[test]
@@ -38,24 +97,33 @@ fn redirects_cleanly() {
             .iter()
             .any(|(key, value)| key == "Location" && value == expected));
     }
+
+    let state = State::default();
+    let fake_cert = [0xca, 0xfe];
+
     assert_308(
-        &http_request(fake("aaaaa-aa.raw.ic0.app")),
+        &state.http_request(fake("aaaaa-aa.raw.ic0.app"), &fake_cert),
         "https://aaaaa-aa.ic0.app/asset.blob",
     );
     assert_308(
-        &http_request(fake("my.http.files.raw.ic0.app")),
+        &state.http_request(fake("my.http.files.raw.ic0.app"), &fake_cert),
         "https://my.http.files.ic0.app/asset.blob",
     );
     assert_308(
-        &http_request(fake("raw.ic0.app.raw.ic0.app")),
+        &state.http_request(fake("raw.ic0.app.raw.ic0.app"), &fake_cert),
         "https://raw.ic0.app.ic0.app/asset.blob",
     );
     assert_308(
-        &http_request(fake("raw.ic0.app")), // for ?canisterId=
+        &state.http_request(fake("raw.ic0.app"), &fake_cert), // for ?canisterId=
         "https://ic0.app/asset.blob",
     );
-    let no_redirect = catch_unwind(|| http_request(fake("raw.ic0.app.ic0.app")).status_code);
-    assert!(!matches!(no_redirect, Ok(308)));
-    let no_redirect2 = catch_unwind(|| http_request(fake("straw.ic0.app")).status_code);
-    assert!(!matches!(no_redirect2, Ok(308)));
+    let no_redirect = state
+        .http_request(fake("raw.ic0.app.ic0.app"), &fake_cert)
+        .status_code;
+    assert!(!matches!(no_redirect, 308));
+
+    let no_redirect2 = state
+        .http_request(fake("straw.ic0.app"), &fake_cert)
+        .status_code;
+    assert!(!matches!(no_redirect2, 308));
 }

--- a/src/ic-certified-assets/src/types.rs
+++ b/src/ic-certified-assets/src/types.rs
@@ -1,0 +1,140 @@
+//! This module defines types shared by the certified assets state machine and the canister
+//! endpoints.
+use crate::rc_bytes::RcBytes;
+use candid::{CandidType, Deserialize, Func, Nat};
+use serde_bytes::ByteBuf;
+
+pub type BatchId = Nat;
+pub type ChunkId = Nat;
+pub type Key = String;
+
+// IDL Types
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct CreateAssetArguments {
+    pub key: Key,
+    pub content_type: String,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct SetAssetContentArguments {
+    pub key: Key,
+    pub content_encoding: String,
+    pub chunk_ids: Vec<ChunkId>,
+    pub sha256: Option<ByteBuf>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct UnsetAssetContentArguments {
+    pub key: Key,
+    pub content_encoding: String,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct DeleteAssetArguments {
+    pub key: Key,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct ClearArguments {}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub enum BatchOperation {
+    CreateAsset(CreateAssetArguments),
+    SetAssetContent(SetAssetContentArguments),
+    UnsetAssetContent(UnsetAssetContentArguments),
+    DeleteAsset(DeleteAssetArguments),
+    Clear(ClearArguments),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct CommitBatchArguments {
+    pub batch_id: BatchId,
+    pub operations: Vec<BatchOperation>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct StoreArg {
+    pub key: Key,
+    pub content_type: String,
+    pub content_encoding: String,
+    pub content: ByteBuf,
+    pub sha256: Option<ByteBuf>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct GetArg {
+    pub key: Key,
+    pub accept_encodings: Vec<String>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct GetChunkArg {
+    pub key: Key,
+    pub content_encoding: String,
+    pub index: Nat,
+    pub sha256: Option<ByteBuf>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct GetChunkResponse {
+    pub content: RcBytes,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct CreateBatchResponse {
+    pub batch_id: BatchId,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct CreateChunkArg {
+    pub batch_id: BatchId,
+    pub content: ByteBuf,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct CreateChunkResponse {
+    pub chunk_id: ChunkId,
+}
+// HTTP interface
+
+pub type HeaderField = (String, String);
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct HttpRequest {
+    pub method: String,
+    pub url: String,
+    pub headers: Vec<(String, String)>,
+    pub body: ByteBuf,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct HttpResponse {
+    pub status_code: u16,
+    pub headers: Vec<HeaderField>,
+    pub body: RcBytes,
+    pub streaming_strategy: Option<StreamingStrategy>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct StreamingCallbackToken {
+    pub key: String,
+    pub content_encoding: String,
+    pub index: Nat,
+    // We don't care about the sha, we just want to be backward compatible.
+    pub sha256: Option<ByteBuf>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub enum StreamingStrategy {
+    Callback {
+        callback: Func,
+        token: StreamingCallbackToken,
+    },
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct StreamingCallbackHttpResponse {
+    pub body: RcBytes,
+    pub token: Option<StreamingCallbackToken>,
+}

--- a/src/ic-certified-assets/src/url_decode.rs
+++ b/src/ic-certified-assets/src/url_decode.rs
@@ -1,0 +1,82 @@
+use std::fmt;
+
+/// An iterator-like structure that decode a URL.
+struct UrlDecode<'a> {
+    bytes: std::slice::Iter<'a, u8>,
+}
+
+fn convert_percent(iter: &mut std::slice::Iter<u8>) -> Option<u8> {
+    let mut cloned_iter = iter.clone();
+    let result = match cloned_iter.next()? {
+        b'%' => b'%',
+        h => {
+            let h = char::from(*h).to_digit(16)?;
+            let l = char::from(*cloned_iter.next()?).to_digit(16)?;
+            h as u8 * 0x10 + l as u8
+        }
+    };
+    // Update this if we make it this far, otherwise "reset" the iterator.
+    *iter = cloned_iter;
+    Some(result)
+}
+
+#[derive(Debug, PartialEq)]
+pub enum UrlDecodeError {
+    InvalidPercentEncoding,
+}
+
+impl fmt::Display for UrlDecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidPercentEncoding => write!(f, "invalid percent encoding"),
+        }
+    }
+}
+
+impl<'a> Iterator for UrlDecode<'a> {
+    type Item = Result<char, UrlDecodeError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let b = self.bytes.next()?;
+        match b {
+            b'%' => Some(
+                convert_percent(&mut self.bytes)
+                    .map(char::from)
+                    .ok_or(UrlDecodeError::InvalidPercentEncoding),
+            ),
+            b'+' => Some(Ok(' ')),
+            x => Some(Ok(char::from(*x))),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let bytes = self.bytes.len();
+        (bytes / 3, Some(bytes))
+    }
+}
+
+pub fn url_decode(url: &str) -> Result<String, UrlDecodeError> {
+    UrlDecode {
+        bytes: url.as_bytes().iter(),
+    }
+    .collect()
+}
+
+#[test]
+fn check_url_decode() {
+    assert_eq!(
+        url_decode("/%"),
+        Err(UrlDecodeError::InvalidPercentEncoding)
+    );
+    assert_eq!(url_decode("/%%"), Ok("/%".to_string()));
+    assert_eq!(url_decode("/%20a"), Ok("/ a".to_string()));
+    assert_eq!(
+        url_decode("/%%+a%20+%@"),
+        Err(UrlDecodeError::InvalidPercentEncoding)
+    );
+    assert_eq!(
+        url_decode("/has%percent.txt"),
+        Err(UrlDecodeError::InvalidPercentEncoding)
+    );
+    assert_eq!(url_decode("/%e6"), Ok("/æ".to_string()));
+}

--- a/src/ic-certified-assets/src/url_decode.rs
+++ b/src/ic-certified-assets/src/url_decode.rs
@@ -61,22 +61,3 @@ pub fn url_decode(url: &str) -> Result<String, UrlDecodeError> {
     }
     .collect()
 }
-
-#[test]
-fn check_url_decode() {
-    assert_eq!(
-        url_decode("/%"),
-        Err(UrlDecodeError::InvalidPercentEncoding)
-    );
-    assert_eq!(url_decode("/%%"), Ok("/%".to_string()));
-    assert_eq!(url_decode("/%20a"), Ok("/ a".to_string()));
-    assert_eq!(
-        url_decode("/%%+a%20+%@"),
-        Err(UrlDecodeError::InvalidPercentEncoding)
-    );
-    assert_eq!(
-        url_decode("/has%percent.txt"),
-        Err(UrlDecodeError::InvalidPercentEncoding)
-    );
-    assert_eq!(url_decode("/%e6"), Ok("/æ".to_string()));
-}


### PR DESCRIPTION
This change is an extensive refactoring of the `ic-certified-assets` package.
The motivation for this change is to make the code more testable and
organized before adding caching logic.

The general idea behind the refactoring is to split out the "state
machine" logic into pure code that does not depend on Rust CDK and
accepts all the environment (time, certificates, etc.) as function
parameters. This logic moved to `state_machine.rs`.

`lib.rs` now contains the minimal glue to connect the state machine to
the Rust CDK interface. Eventually, this part should move back to
https://github.com/dfinity/certified-assets, making
the `ic-certified-assets` package independent from Rust CDK.

The refactoring does not affect the certification logic; all we do is
moving the code around, improving memory-correctness guarantees (no more
RefCells in the state), and adding tests.