### PR TITLE
feat: support ETags in certified assets

### DIFF
--- a/src/ic-certified-assets/src/rc_bytes.rs
+++ b/src/ic-certified-assets/src/rc_bytes.rs
@@ -9,7 +9,7 @@ use std::convert::AsRef;
 use std::ops::Deref;
 use std::rc::Rc;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct RcBytes(Rc<ByteBuf>);
 
 impl CandidType for RcBytes {

--- a/src/ic-certified-assets/src/state_machine.rs
+++ b/src/ic-certified-assets/src/state_machine.rs
@@ -387,6 +387,7 @@ impl State {
         encodings: Vec<String>,
         index: usize,
         callback: Func,
+        etag: Option<Hash>,
     ) -> HttpResponse {
         let index_redirect_certificate = if self.asset_hashes.get(path.as_bytes()).is_none()
             && self.asset_hashes.get(INDEX_FILE.as_bytes()).is_some()
@@ -404,7 +405,7 @@ impl State {
                 for enc_name in encodings.iter() {
                     if let Some(enc) = asset.encodings.get(enc_name) {
                         if enc.certified {
-                            return build_200(
+                            return build_ok(
                                 asset,
                                 enc_name,
                                 enc,
@@ -412,6 +413,7 @@ impl State {
                                 index,
                                 Some(certificate_header),
                                 callback,
+                                etag,
                             );
                         }
                     }
@@ -426,7 +428,7 @@ impl State {
             for enc_name in encodings.iter() {
                 if let Some(enc) = asset.encodings.get(enc_name) {
                     if enc.certified {
-                        return build_200(
+                        return build_ok(
                             asset,
                             enc_name,
                             enc,
@@ -434,12 +436,13 @@ impl State {
                             index,
                             Some(certificate_header),
                             callback,
+                            etag,
                         );
                     } else {
                         // Find if identity is certified, if it's not.
                         if let Some(id_enc) = asset.encodings.get("identity") {
                             if id_enc.certified {
-                                return build_200(
+                                return build_ok(
                                     asset,
                                     enc_name,
                                     enc,
@@ -447,6 +450,7 @@ impl State {
                                     index,
                                     Some(certificate_header),
                                     callback,
+                                    etag,
                                 );
                             }
                         }
@@ -465,6 +469,7 @@ impl State {
         callback: Func,
     ) -> HttpResponse {
         let mut encodings = vec![];
+        let mut etag = None;
         for (name, value) in req.headers.iter() {
             if name.eq_ignore_ascii_case("Accept-Encoding") {
                 for v in value.split(',') {
@@ -481,6 +486,25 @@ impl State {
                     };
                 }
             }
+            if name.eq_ignore_ascii_case("If-None-Match") {
+                let mut hash = Hash::default();
+                match hex::decode_to_slice(value, &mut hash[..]) {
+                    Ok(()) => {
+                        etag = Some(hash);
+                    }
+                    Err(err) => {
+                        return HttpResponse {
+                            status_code: 400,
+                            headers: vec![],
+                            body: RcBytes::from(ByteBuf::from(format!(
+                                "Invalid {} header: {}",
+                                name, err
+                            ))),
+                            streaming_strategy: None,
+                        };
+                    }
+                }
+            }
         }
         encodings.push("identity".to_string());
 
@@ -490,7 +514,7 @@ impl State {
         };
 
         match url_decode(path) {
-            Ok(path) => self.build_http_response(certificate, &path, encodings, 0, callback),
+            Ok(path) => self.build_http_response(certificate, &path, encodings, 0, callback, etag),
             Err(err) => HttpResponse {
                 status_code: 400,
                 headers: vec![],
@@ -678,7 +702,7 @@ fn create_token(
     }
 }
 
-fn build_200(
+fn build_ok(
     asset: &Asset,
     enc_name: &str,
     enc: &AssetEncoding,
@@ -686,6 +710,7 @@ fn build_200(
     chunk_index: usize,
     certificate_header: Option<HeaderField>,
     callback: Func,
+    etag: Option<Hash>,
 ) -> HttpResponse {
     let mut headers = vec![("Content-Type".to_string(), asset.content_type.to_string())];
     if enc_name != "identity" {
@@ -698,10 +723,17 @@ fn build_200(
     let streaming_strategy = create_token(asset, enc_name, enc, key, chunk_index)
         .map(|token| StreamingStrategy::Callback { callback, token });
 
+    let (status_code, body) = if etag == Some(enc.sha256) {
+        (304, RcBytes::default())
+    } else {
+        headers.push(("ETag".to_string(), hex::encode(enc.sha256)));
+        (200, enc.content_chunks[chunk_index].clone())
+    };
+
     HttpResponse {
-        status_code: 200,
+        status_code,
         headers,
-        body: enc.content_chunks[chunk_index].clone(),
+        body,
         streaming_strategy,
     }
 }

--- a/src/ic-certified-assets/src/state_machine.rs
+++ b/src/ic-certified-assets/src/state_machine.rs
@@ -702,6 +702,7 @@ fn create_token(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_ok(
     asset: &Asset,
     enc_name: &str,

--- a/src/ic-certified-assets/src/tests.rs
+++ b/src/ic-certified-assets/src/tests.rs
@@ -6,6 +6,7 @@ use crate::types::{
 use crate::url_decode::{url_decode, UrlDecodeError};
 use candid::Principal;
 use serde_bytes::ByteBuf;
+use sha2::Digest;
 
 fn some_principal() -> Principal {
     Principal::from_text("ryjl3-tyaaa-aaaaa-aaaba-cai").unwrap()
@@ -281,6 +282,98 @@ fn uses_streaming_for_multichunk_assets() {
         "Unexpected streaming response: {:?}",
         streaming_response
     );
+}
+
+#[test]
+fn supports_etag_caching() {
+    let mut state = State::default();
+    let time_now = 100_000_000_000;
+
+    const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
+    let hash: [u8; 32] = sha2::Sha256::digest(BODY).into();
+    let etag = hex::encode(hash);
+
+    create_assets(
+        &mut state,
+        time_now,
+        vec![(
+            "/contents.html",
+            "text/html",
+            vec![("identity", vec![BODY])],
+        )],
+    );
+
+    let response = state.http_request(
+        HttpRequest {
+            body: ByteBuf::new(),
+            headers: vec![("Accept-Encoding".to_string(), "gzip,identity".to_string())],
+            method: "GET".to_string(),
+            url: "/contents.html".to_string(),
+        },
+        &[],
+        unused_callback(),
+    );
+
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.body.as_ref(), BODY);
+    assert!(
+        response
+            .headers
+            .contains(&("ETag".to_string(), etag.clone())),
+        "Not ETag header in response: {:#?}",
+        response
+    );
+
+    let response = state.http_request(
+        HttpRequest {
+            body: ByteBuf::new(),
+            headers: vec![
+                ("Accept-Encoding".to_string(), "gzip,identity".to_string()),
+                ("If-None-Match".to_string(), etag),
+            ],
+            method: "GET".to_string(),
+            url: "/contents.html".to_string(),
+        },
+        &[],
+        unused_callback(),
+    );
+
+    assert_eq!(response.status_code, 304);
+    assert_eq!(response.body.as_ref(), &[] as &[u8]);
+}
+
+#[test]
+fn returns_400_on_invalid_etag() {
+    let mut state = State::default();
+    let time_now = 100_000_000_000;
+
+    const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
+
+    create_assets(
+        &mut state,
+        time_now,
+        vec![(
+            "/contents.html",
+            "text/html",
+            vec![("identity", vec![BODY])],
+        )],
+    );
+
+    let response = state.http_request(
+        HttpRequest {
+            body: ByteBuf::new(),
+            headers: vec![
+                ("Accept-Encoding".to_string(), "gzip,identity".to_string()),
+                ("If-None-Match".to_string(), "cafe".to_string()),
+            ],
+            method: "GET".to_string(),
+            url: "/contents.html".to_string(),
+        },
+        &[],
+        unused_callback(),
+    );
+
+    assert_eq!(response.status_code, 400);
 }
 
 #[test]

--- a/src/ic-certified-assets/src/tests.rs
+++ b/src/ic-certified-assets/src/tests.rs
@@ -320,7 +320,16 @@ fn supports_etag_caching() {
         response
             .headers
             .contains(&("ETag".to_string(), etag.clone())),
-        "No ETag header in response: {:#?}",
+        "No matching ETag header in response: {:#?}, expected ETag {}",
+        response,
+        etag
+    );
+    assert!(
+        response
+            .headers
+            .iter()
+            .any(|(name, _)| name.eq_ignore_ascii_case("IC-Certificate")),
+        "No IC-Certificate header in response: {:#?}",
         response
     );
 

--- a/src/ic-certified-assets/src/tests.rs
+++ b/src/ic-certified-assets/src/tests.rs
@@ -320,7 +320,7 @@ fn supports_etag_caching() {
         response
             .headers
             .contains(&("ETag".to_string(), etag.clone())),
-        "Not ETag header in response: {:#?}",
+        "No ETag header in response: {:#?}",
         response
     );
 


### PR DESCRIPTION
This change implements [ETag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) caching headers support in the ic-certified-assets package.