### PR TITLE
feat: add support for max_age field

### DIFF
--- a/src/ic-certified-assets/assets.did
+++ b/src/ic-certified-assets/assets.did
@@ -6,6 +6,7 @@ type Time = int;
 type CreateAssetArguments = record {
   key: Key;
   content_type: text;
+  max_age: opt nat64;
 };
 
 // Add or change content for an asset, by content encoding

--- a/src/ic-certified-assets/src/state_machine.rs
+++ b/src/ic-certified-assets/src/state_machine.rs
@@ -40,6 +40,7 @@ pub struct AssetEncoding {
 pub struct Asset {
     pub content_type: String,
     pub encodings: HashMap<String, AssetEncoding>,
+    pub max_age: Option<u64>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
@@ -127,6 +128,7 @@ impl State {
                 Asset {
                     content_type: arg.content_type,
                     encodings: HashMap::new(),
+                    max_age: arg.max_age,
                 },
             );
         }
@@ -719,6 +721,9 @@ fn build_ok(
     }
     if let Some(head) = certificate_header {
         headers.push(head);
+    }
+    if let Some(max_age) = asset.max_age {
+        headers.push(("Cache-Control".to_string(), format!("max-age={}", max_age)));
     }
 
     let streaming_strategy = create_token(asset, enc_name, enc, key, chunk_index)

--- a/src/ic-certified-assets/src/types.rs
+++ b/src/ic-certified-assets/src/types.rs
@@ -14,6 +14,7 @@ pub type Key = String;
 pub struct CreateAssetArguments {
     pub key: Key,
     pub content_type: String,
+    pub max_age: Option<u64>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]


### PR DESCRIPTION
This change extends the certified assets canister interface to support
setting max_age field for an asset.
If the field is present, the canister will translate it into
"Cache-Control: max-age={max_age}" header.
