### PR TITLE
feat: adds serialization-agnostic API for reading arguments and replying

### DIFF
--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -24,5 +24,9 @@ path = "canisters/simple_kv_store.rs"
 name = "async"
 path = "canisters/async.rs"
 
+[[bin]]
+name = "reverse"
+path = "canisters/reverse.rs"
+
 [dev-dependencies]
 ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "709f9caaffd39c5d63f7ef1ec694eeb2a1b7976a" }

--- a/e2e-tests/canisters/reverse.rs
+++ b/e2e-tests/canisters/reverse.rs
@@ -1,0 +1,14 @@
+use ic_cdk::api::call::{arg_data_raw, reply_raw};
+
+#[export_name = "canister_query reverse"]
+fn reverse() {
+    reply_raw(
+        arg_data_raw()
+            .into_iter()
+            .rev()
+            .collect::<Vec<_>>()
+            .as_ref(),
+    );
+}
+
+fn main() {}

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -117,3 +117,13 @@ fn test_panic_after_async_frees_resources() {
         assert_eq!(i, n, "expected the invocation count to be {}, got {}", i, n);
     }
 }
+
+#[test]
+fn test_raw_api() {
+    let env = StateMachine::new();
+    let rev = cargo_build_canister("reverse");
+    let canister_id = env.install_canister(rev, vec![], None).unwrap();
+
+    let result = env.query(canister_id, "reverse", vec![1, 2, 3, 4]).unwrap();
+    assert_eq!(result, WasmResult::Reply(vec![4, 3, 2, 1]));
+}

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `BufferedStableReader` for efficient reading from stable memory (#247)
 - Add `BufferedStableWriter` for efficient writing to stable memory (#245)
+- Add `reply_raw` and publish `arg_data_raw` for serialization-agnostic arguments fetching and replies
 
 ## [0.5.0] - 2022-03-29
 ### Added

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -205,7 +205,7 @@ fn callback(state_ptr: *const InnerCell<CallFutureState<Vec<u8>>>) {
     // Make sure to un-borrow_mut the state.
     {
         state.borrow_mut().result = Some(match reject_code() {
-            RejectionCode::NoError => unsafe { Ok(arg_data_raw()) },
+            RejectionCode::NoError => Ok(arg_data_raw()),
             n => Err((n, reject_message())),
         });
     }
@@ -226,7 +226,7 @@ fn cleanup(state_ptr: *const InnerCell<CallFutureState<Vec<u8>>>) {
     // None of these calls trap - the rollback from the previous trap ensures that the Mutex is not in a poisoned state.
     {
         state.borrow_mut().result = Some(match reject_code() {
-            RejectionCode::NoError => unsafe { Ok(arg_data_raw()) },
+            RejectionCode::NoError => Ok(arg_data_raw()),
             n => Err((n, reject_message())),
         });
     }
@@ -364,8 +364,9 @@ pub fn call_with_payment128<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
 /// and [reject_message()] if it failed.
 pub fn result<T: for<'a> ArgumentDecoder<'a>>() -> Result<T, String> {
     match reject_code() {
-        RejectionCode::NoError => decode_args(&unsafe { arg_data_raw() })
-            .map_err(|e| format!("Failed to decode arguments: {}", e)),
+        RejectionCode::NoError => {
+            decode_args(&arg_data_raw()).map_err(|e| format!("Failed to decode arguments: {}", e))
+        }
         _ => Err(reject_message()),
     }
 }
@@ -474,22 +475,26 @@ pub fn msg_cycles_accept128(max_amount: u128) -> u128 {
 }
 
 /// Returns the argument data as bytes.
-pub unsafe fn arg_data_raw() -> Vec<u8> {
-    let len: usize = ic0::msg_arg_data_size() as usize;
-    let mut bytes = vec![0u8; len as usize];
-    ic0::msg_arg_data_copy(bytes.as_mut_ptr() as i32, 0, len as i32);
-    bytes
+pub fn arg_data_raw() -> Vec<u8> {
+    unsafe {
+        let len: usize = ic0::msg_arg_data_size() as usize;
+        let mut bytes = vec![0u8; len as usize];
+        ic0::msg_arg_data_copy(bytes.as_mut_ptr() as i32, 0, len as i32);
+        bytes
+    }
 }
 
 /// Replies with the bytes passed
-pub unsafe fn reply_raw(buf: &[u8]) {
-    ic0::msg_reply_data_append(buf.as_ptr() as i32, buf.len() as i32);
-    ic0::msg_reply();
+pub fn reply_raw(buf: &[u8]) {
+    unsafe {
+        ic0::msg_reply_data_append(buf.as_ptr() as i32, buf.len() as i32);
+        ic0::msg_reply();
+    }
 }
 
 /// Returns the argument data in the current call.
 pub fn arg_data<R: for<'a> ArgumentDecoder<'a>>() -> R {
-    let bytes = unsafe { arg_data_raw() };
+    let bytes = arg_data_raw();
 
     match decode_args(&bytes) {
         Err(e) => trap(&format!("{:?}", e)),

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -474,11 +474,17 @@ pub fn msg_cycles_accept128(max_amount: u128) -> u128 {
 }
 
 /// Returns the argument data as bytes.
-pub(crate) unsafe fn arg_data_raw() -> Vec<u8> {
+pub unsafe fn arg_data_raw() -> Vec<u8> {
     let len: usize = ic0::msg_arg_data_size() as usize;
     let mut bytes = vec![0u8; len as usize];
     ic0::msg_arg_data_copy(bytes.as_mut_ptr() as i32, 0, len as i32);
     bytes
+}
+
+/// Replies with the bytes passed
+pub unsafe fn reply_raw(buf: &[u8]) {
+    ic0::msg_reply_data_append(buf.as_ptr() as i32, buf.len() as i32);
+    ic0::msg_reply();
 }
 
 /// Returns the argument data in the current call.

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -480,8 +480,9 @@ pub fn msg_cycles_accept128(max_amount: u128) -> u128 {
 pub fn arg_data_raw() -> Vec<u8> {
     unsafe {
         let len: usize = ic0::msg_arg_data_size() as usize;
-        let mut bytes = vec![0u8; len as usize];
+        let mut bytes = Vec::with_capacity(len);
         ic0::msg_arg_data_copy(bytes.as_mut_ptr() as i32, 0, len as i32);
+        bytes.set_len(len);
         bytes
     }
 }


### PR DESCRIPTION
This patch makes `arg_data_raw` public and adds `reply_raw` to provide a way to read the raw argument bytes of a method and to reply with raw bytes.