### PR TITLE
chore: release ic-certified-assets 0.2.0

### DIFF
--- a/src/ic-certified-assets/CHANGELOG.md
+++ b/src/ic-certified-assets/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2022-05-11
+### Added
+- Support for asset caching based on [ETag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag)
+- Support for asset caching based on [max-age](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
+
 ## [0.1.0] - 2022-02-02
 ### Added
 - First release

--- a/src/ic-certified-assets/Cargo.toml
+++ b/src/ic-certified-assets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-certified-assets"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Rust support for asset certification."

--- a/src/ic-certified-assets/README.md
+++ b/src/ic-certified-assets/README.md
@@ -8,7 +8,7 @@ Certified assets can also be served from any Rust canister by including this lib
 
 ```
 [dependencies]
-ic-certified-assets = "0.1.0"
+ic-certified-assets = "0.2.0"
 ```
 
 The assets are preserved over upgrades by including the corresponding functions in the `init/pre_upgrade/upgrade`
@@ -26,7 +26,7 @@ fn init() {
   crate::assets::init();
 }
 
->>#[pre_upgrade]
+#[pre_upgrade]
 fn pre_upgrade() {
   let stable_state = STATE.with(|s| StableState {
     my_state: s.my_state,
@@ -35,7 +35,7 @@ fn pre_upgrade() {
   ic_cdk::storage::stable_save((stable_state,)).expect("failed to save stable state");
 }
 
->>#[post_upgrade]
+#[post_upgrade]
 fn post_upgrade() {
   let (StableState { assets, my_state },): (StableState,) =
                                          ic_cdk::storage::stable_restore().expect("failed to restore stable state");


### PR DESCRIPTION
# Description

Release version 0.2.0 of `ic-certified-assets`.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
