### PR TITLE
fix: make StableState public again

### DIFF
--- a/src/ic-certified-assets/CHANGELOG.md
+++ b/src/ic-certified-assets/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2022-05-12
+### Fixed
+- Make StableState public again
+
 ## [0.2.0] - 2022-05-11
 ### Added
 - Support for asset caching based on [ETag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag)

--- a/src/ic-certified-assets/Cargo.toml
+++ b/src/ic-certified-assets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-certified-assets"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Rust support for asset certification."

--- a/src/ic-certified-assets/README.md
+++ b/src/ic-certified-assets/README.md
@@ -8,7 +8,7 @@ Certified assets can also be served from any Rust canister by including this lib
 
 ```
 [dependencies]
-ic-certified-assets = "0.2.0"
+ic-certified-assets = "0.2.1"
 ```
 
 The assets are preserved over upgrades by including the corresponding functions in the `init/pre_upgrade/upgrade`

--- a/src/ic-certified-assets/src/lib.rs
+++ b/src/ic-certified-assets/src/lib.rs
@@ -1,15 +1,16 @@
 //! This module declares canister methods expected by the assets canister client.
-mod rc_bytes;
-mod state_machine;
-mod types;
+pub mod rc_bytes;
+pub mod state_machine;
+pub mod types;
 mod url_decode;
 
 #[cfg(test)]
 mod tests;
 
+pub use crate::state_machine::StableState;
 use crate::{
     rc_bytes::RcBytes,
-    state_machine::{AssetDetails, EncodedAsset, StableState, State},
+    state_machine::{AssetDetails, EncodedAsset, State},
     types::*,
 };
 use candid::{candid_method, Principal};


### PR DESCRIPTION
This change makes the StableState type from ic-certified-assets package
public again. Making it private was a bug that prevents us from
upgrading the certified assets canister to a newer version of
ic-certified-assets.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
