### PR TITLE
fix: certified assets: parse and produce ETag headers with quotes

### DIFF
--- a/src/ic-certified-assets/CHANGELOG.md
+++ b/src/ic-certified-assets/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.2] - 2022-05-12
+### Fixed
+- Parse and produce ETag headers with quotes around the hash
 
 ## [0.2.1] - 2022-05-12
 ### Fixed

--- a/src/ic-certified-assets/README.md
+++ b/src/ic-certified-assets/README.md
@@ -8,7 +8,7 @@ Certified assets can also be served from any Rust canister by including this lib
 
 ```
 [dependencies]
-ic-certified-assets = "0.2.1"
+ic-certified-assets = "0.2.2"
 ```
 
 The assets are preserved over upgrades by including the corresponding functions in the `init/pre_upgrade/upgrade`

--- a/src/ic-certified-assets/src/tests.rs
+++ b/src/ic-certified-assets/src/tests.rs
@@ -353,7 +353,7 @@ fn supports_etag_caching() {
     assert_eq!(response.body.as_ref(), BODY);
     assert_eq!(
         lookup_header(&response, "ETag"),
-        Some(etag.as_str()),
+        Some(format!("\"{}\"", etag).as_str()),
         "No matching ETag header in response: {:#?}, expected ETag {}",
         response,
         etag
@@ -367,7 +367,7 @@ fn supports_etag_caching() {
     let response = state.http_request(
         RequestBuilder::get("/contents.html")
             .with_header("Accept-Encoding", "gzip,identity")
-            .with_header("If-None-Match", &etag)
+            .with_header("If-None-Match", format!("\"{}\"", etag))
             .build(),
         &[],
         unused_callback(),


### PR DESCRIPTION
This change fixes the handling of ETag header values.
The standard expects hashes to have quotes around them, so the canister
logic produced and parsed asset hashes incorrectly.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
