### PR TITLE
feat: public function: arg_data_raw_size

### DIFF
--- a/e2e-tests/canisters/reverse.rs
+++ b/e2e-tests/canisters/reverse.rs
@@ -1,9 +1,11 @@
-use ic_cdk::api::call::{arg_data_raw, reply_raw};
+use ic_cdk::api::call::{arg_data_raw, arg_data_raw_size, reply_raw};
 
 #[export_name = "canister_query reverse"]
 fn reverse() {
+    let arg_bytes: Vec<u8> = arg_data_raw();
+    assert_eq!(arg_bytes.len(), arg_data_raw_size());
     reply_raw(
-        arg_data_raw()
+        arg_bytes
             .into_iter()
             .rev()
             .collect::<Vec<_>>()

--- a/e2e-tests/canisters/reverse.rs
+++ b/e2e-tests/canisters/reverse.rs
@@ -4,13 +4,7 @@ use ic_cdk::api::call::{arg_data_raw, arg_data_raw_size, reply_raw};
 fn reverse() {
     let arg_bytes: Vec<u8> = arg_data_raw();
     assert_eq!(arg_bytes.len(), arg_data_raw_size());
-    reply_raw(
-        arg_bytes
-            .into_iter()
-            .rev()
-            .collect::<Vec<_>>()
-            .as_ref(),
-    );
+    reply_raw(arg_bytes.into_iter().rev().collect::<Vec<_>>().as_ref());
 }
 
 fn main() {}

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 
+### Added
+- pub fn `arg_data_raw_size` for checking the size of the arg-data-raw before copying to a vector or deserializing
+
 ## [0.5.1] - 2022-05-16
 ### Added
 - `BufferedStableReader` for efficient reading from stable memory (#247)

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.2] - 
+## [Unreleased] 
 ### Added
 - pub fn `arg_data_raw_size` for checking the size of the arg-data-raw before copying to a vector or deserializing
 

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -565,6 +565,13 @@ pub fn arg_data_raw() -> Vec<u8> {
     }
 }
 
+/// Get the len of the raw-argument-data-bytes.
+pub fn arg_data_raw_size() -> usize {
+    unsafe {
+        ic0::msg_arg_data_size() as usize
+    }
+}
+
 /// Replies with the bytes passed
 pub fn reply_raw(buf: &[u8]) {
     unsafe {

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -567,9 +567,7 @@ pub fn arg_data_raw() -> Vec<u8> {
 
 /// Get the len of the raw-argument-data-bytes.
 pub fn arg_data_raw_size() -> usize {
-    unsafe {
-        ic0::msg_arg_data_size() as usize
-    }
+    unsafe { ic0::msg_arg_data_size() as usize }
 }
 
 /// Replies with the bytes passed


### PR DESCRIPTION
# Summary

Add public function `arg_data_raw_size`. 

Useful for checking the size of the arg-data before deserializing or copying to a vector.

# Tests

The test for this function is put into the reverse-canister test, by making the reverse method check `assert_eq!(arg_data_raw_size(), arg_data_raw().len())`.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
