### PR TITLE
fix: use explicitly type u8 in vector initialization

### DIFF
--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Use explicitly type u8 in vector initialization (#264)
+
 ## [0.5.1] - 2022-05-16
 ### Added
 - `BufferedStableReader` for efficient reading from stable memory (#247)

--- a/src/ic-cdk/src/api.rs
+++ b/src/ic-cdk/src/api.rs
@@ -31,7 +31,7 @@ pub fn time() -> u64 {
 /// Returns the caller of the current call.
 pub fn caller() -> Principal {
     let len: u32 = unsafe { ic0::msg_caller_size() as u32 };
-    let mut bytes = vec![0; len as usize];
+    let mut bytes = vec![0u8; len as usize];
     unsafe {
         ic0::msg_caller_copy(bytes.as_mut_ptr() as i32, 0, len as i32);
     }
@@ -41,7 +41,7 @@ pub fn caller() -> Principal {
 /// Returns the canister id as a blob.
 pub fn id() -> Principal {
     let len: u32 = unsafe { ic0::canister_self_size() as u32 };
-    let mut bytes = vec![0; len as usize];
+    let mut bytes = vec![0u8; len as usize];
     unsafe {
         ic0::canister_self_copy(bytes.as_mut_ptr() as i32, 0, len as i32);
     }

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -460,7 +460,7 @@ pub fn reject_code() -> RejectionCode {
 /// Returns the rejection message.
 pub fn reject_message() -> String {
     let len: u32 = unsafe { ic0::msg_reject_msg_size() as u32 };
-    let mut bytes = vec![0; len as usize];
+    let mut bytes = vec![0u8; len as usize];
     unsafe {
         ic0::msg_reject_msg_copy(bytes.as_mut_ptr() as i32, 0, len as i32);
     }
@@ -593,7 +593,7 @@ pub fn accept_message() {
 /// Returns the name of current canister method.
 pub fn method_name() -> String {
     let len: u32 = unsafe { ic0::msg_method_name_size() as u32 };
-    let mut bytes = vec![0; len as usize];
+    let mut bytes = vec![0u8; len as usize];
     unsafe {
         ic0::msg_method_name_copy(bytes.as_mut_ptr() as i32, 0, len as i32);
     }


### PR DESCRIPTION
# Description
> This finding was marked as a False Positive and its Overall Risk rating was reduced to Informational since it was pointed out that the compiler was able to unambiguously infer the data
type due to the function calls following the array declaration. For example, the only From trait
implemented for Principals converts a byte array into a Principal, and there are currently
no other try_from implementations. Nevertheless, consider following the recommendation
outlined in this finding to remove any potential ambiguity.

The rust complier is able to infer the type of `u8`.  Marking it more explicitly helps reduce ambiguity.

Fixes #79

# How Has This Been Tested?
CI. This PR should not change any behavior.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
