### PR TITLE
feat: integrate with the ledger's `token_symbol` method

### DIFF
--- a/src/ic-ledger-types/CHANGELOG.md
+++ b/src/ic-ledger-types/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Integrate with the ledger's `token_symbol` method
+
 ### Changed
 * Support conversion from `[u8; 32]` to `AccountIdentifier` via `TryFrom` with CRC-32 check.
 

--- a/src/ic-ledger-types/src/lib.rs
+++ b/src/ic-ledger-types/src/lib.rs
@@ -298,6 +298,27 @@ pub async fn transfer(
     Ok(result)
 }
 
+#[derive(Serialize, Deserialize, CandidType, Clone, Hash, Debug, PartialEq, Eq)]
+pub struct Symbol {
+    pub symbol: String,
+}
+
+/// Calls the "token_symbol" method on the specified canister.
+/// # Example
+/// ```no_run
+/// use candid::Principal;
+/// use ic_cdk::api::{caller, call::call};
+/// use ic_ledger_types::{Symbol, token_symbol};
+///
+/// async fn symbol(ledger_canister_id: Principal) -> String {
+///   token_symbol(ledger_canister_id).await.expect("call to ledger failed").symbol
+/// }
+/// ```
+pub async fn token_symbol(ledger_canister_id: Principal) -> CallResult<Symbol> {
+    let (result,) = ic_cdk::call(ledger_canister_id, "token_symbol", ()).await?;
+    Ok(result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
# Description

The ledger has a relatively new method, `token_symbol`, this PR makes it easy for devs to make a call to that method.

# How Has This Been Tested?

I have been using this successfully within the `TransactionNotifier` (https://github.com/open-ic/transaction-notifier)

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
