### PR TITLE
fix: do not append reply data on empty buffer

### DIFF
--- a/e2e-tests/canisters/reverse.rs
+++ b/e2e-tests/canisters/reverse.rs
@@ -10,5 +10,9 @@ fn reverse() {
             .as_ref(),
     );
 }
+#[export_name = "canister_update empty_call"]
+fn empty_call() {
+    reply_raw(&[]);
+}
 
 fn main() {}

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -126,6 +126,11 @@ fn test_raw_api() {
 
     let result = env.query(canister_id, "reverse", vec![1, 2, 3, 4]).unwrap();
     assert_eq!(result, WasmResult::Reply(vec![4, 3, 2, 1]));
+
+    let result = env
+        .execute_ingress(canister_id, "empty_call", Default::default())
+        .unwrap();
+    assert_eq!(result, WasmResult::Reply(Default::default()));
 }
 
 #[test]

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Use explicitly type u8 in vector initialization (#264)
+- Make `reply_raw` avoid writing empty replies
 
 ## [0.5.1] - 2022-05-16
 ### Added

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -568,7 +568,9 @@ pub fn arg_data_raw() -> Vec<u8> {
 /// Replies with the bytes passed
 pub fn reply_raw(buf: &[u8]) {
     unsafe {
-        ic0::msg_reply_data_append(buf.as_ptr() as i32, buf.len() as i32);
+        if !buf.is_empty() {
+            ic0::msg_reply_data_append(buf.as_ptr() as i32, buf.len() as i32)
+        };
         ic0::msg_reply();
     }
 }


### PR DESCRIPTION
# Description

The current implementation of `reply_raw` does not skip the call to `msg_reply_data_append` even if the passed bytes are empty. The problem with this is that while all functions are expected to call `reply`, not all functions are allowed to reply with data. The current patch introduces a simple check and skips calling `msg_reply_data_append` if no bytes were provided.

# How Has This Been Tested?

Unit test added.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
