### PR TITLE
fix: switch to correct DFX environment variable

### DIFF
--- a/src/ic-cdk-macros/src/import.rs
+++ b/src/ic-cdk-macros/src/import.rs
@@ -15,7 +15,7 @@ struct ImportAttributes {
 
 fn get_env_id_and_candid(canister_name: &str) -> Result<(String, PathBuf), Error> {
     let canister_id_var_name = format!("CANISTER_ID_{}", canister_name);
-    let candid_path_var_name = format!("CANISTER_CANDID_{}", canister_name);
+    let candid_path_var_name = format!("CANISTER_CANDID_PATH_{}", canister_name);
 
     Ok((
         std::env::var(canister_id_var_name).map_err(|_| {

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Use explicitly type u8 in vector initialization (#264)
+- Uses new format for candid environment variables in import macros. Requires DFX >=0.9.2 (#270)
 
 ## [0.5.1] - 2022-05-16
 ### Added


### PR DESCRIPTION
In dfinity/sdk#2032, the environment variables were unified to always be `CANISTER_CANDID_PATH_{name}`. This removes the usage of the deprecated version, `CANISTER_CANDID_{name}`.