### PR TITLE
fix: Future-proof against multithreading

### DIFF
--- a/src/ic-cdk/src/lib.rs
+++ b/src/ic-cdk/src/lib.rs
@@ -6,6 +6,9 @@
 //! https://smartcontracts.org/docs/interface-spec/index.html#system-api-imports)
 //! for a full list of the system API functions.
 
+#[cfg(target_feature = "atomics")]
+compile_error!("This version of the CDK does not support multithreading.");
+
 pub mod api;
 mod futures;
 mod printer;


### PR DESCRIPTION
Many of our abstractions, both safe and unsafe, rely on the assumption that WASM is single-threaded. The WASM atomics proposal, enabled by `-Ctarget-feature=+atomics`, enables multithreading; it requires both that the code be compiled to support it, and that the module be run on a compliant runtime. It is unlikely, but not out of the question, that the IC eventually supports threads via the atomics proposal. This PR adds a compile error if the module is being compiled for multithreading, as future-proofing against such support, for both CDK code and dependents.