### PR TITLE
chore: aggregate matrix checks for required statuses

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,3 +51,13 @@ jobs:
           # information. An alternative solution here is to install GNU tar, but
           # flushing the disk cache seems to work, too.
           sudo /usr/sbin/purge
+
+  aggregate:
+    name: e2e:required
+    if: ${{ always() }}
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: check step result directly
+        if: ${{ needs.test.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -65,3 +65,13 @@ jobs:
           # information. An alternative solution here is to install GNU tar, but
           # flushing the disk cache seems to work, too.
           sudo /usr/sbin/purge
+
+  aggregate:
+    name: examples:required
+    if: ${{ always() }}
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: check step result directly
+        if: ${{ needs.test.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -34,3 +34,13 @@ jobs:
         run: cargo fmt --all -- --check
         env:
           RUST_BACKTRACE: 1
+
+  aggregate:
+    name: fmt:required
+    if: ${{ always() }}
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: check step result directly
+        if: ${{ needs.test.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,3 +31,13 @@ jobs:
         run: cargo clippy --tests --benches -- -D clippy::all
         env:
           RUST_BACKTRACE: 1
+
+  aggregate:
+    name: lint:required
+    if: ${{ always() }}
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: check step result directly
+        if: ${{ needs.test.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,3 +73,13 @@ jobs:
           # information. An alternative solution here is to install GNU tar, but
           # flushing the disk cache seems to work, too.
           sudo /usr/sbin/purge
+
+  aggregate:
+    name: test:required
+    if: ${{ always() }}
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: check step result directly
+        if: ${{ needs.test.result != 'success' }}
+        run: exit 1


### PR DESCRIPTION
Aggregate the status checks so that we can add required statuses that do not specify a rust version or particular runner OS.
