### PR TITLE
feat: support performance_counter

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,10 +15,10 @@ jobs:
         include:
           - build: linux-stable
             os: ubuntu-latest
-            rust: 1.58.1
+            rust: 1.60.0
           - build: macos-stable
             os: macos-latest
-            rust: 1.58.1
+            rust: 1.60.0
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - build: linux-stable
             os: ubuntu-latest
-            rust: 1.58.1
+            rust: 1.60.0
             dfx: 0.9.3
 
     steps:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [ 1.58.1 ]
+        rust: [ 1.60.0 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [ 1.58.1 ]
+        rust: [ 1.60.0 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,13 @@ jobs:
         include:
           - build: linux-stable
             os: ubuntu-latest
-            rust: 1.58.1
+            rust: 1.60.0
           - build: macos-stable
             os: macos-latest
-            rust: 1.58.1
+            rust: 1.60.0
           - build: windows-stable
             os: windows-latest
-            rust: 1.58.1
+            rust: 1.60.0
 
     steps:
       - uses: actions/checkout@v2

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -29,4 +29,4 @@ name = "reverse"
 path = "canisters/reverse.rs"
 
 [dev-dependencies]
-ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "709f9caaffd39c5d63f7ef1ec694eeb2a1b7976a" }
+ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "92e6b0ed36cdc9322a3588f46a8c8c7cc567e143" }

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -28,5 +28,9 @@ path = "canisters/async.rs"
 name = "reverse"
 path = "canisters/reverse.rs"
 
+[[bin]]
+name = "api-call"
+path = "canisters/api_call.rs"
+
 [dev-dependencies]
 ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "92e6b0ed36cdc9322a3588f46a8c8c7cc567e143" }

--- a/e2e-tests/canisters/api_call.rs
+++ b/e2e-tests/canisters/api_call.rs
@@ -1,0 +1,8 @@
+use ic_cdk_macros::query;
+
+#[query]
+fn instruction_counter() -> u64 {
+    ic_cdk::api::call::performance_counter(0)
+}
+
+fn main() {}

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -22,7 +22,7 @@ pub fn cargo_build_canister(bin_name: &str) -> Vec<u8> {
 
     let cargo_build = CargoBuild::new()
         .target("wasm32-unknown-unknown")
-        .bin(bin_name.to_string())
+        .bin(bin_name)
         .args(["--profile", "canister-release"])
         .manifest_path(&cargo_toml_path)
         .target_dir(&wasm_target_dir);

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -156,3 +156,14 @@ fn test_notify_calls() {
         .expect("failed to query 'notifications_received'");
     assert_eq!(n, 1);
 }
+
+#[test]
+fn test_api_call() {
+    let env = StateMachine::new();
+    let rev = cargo_build_canister("api-call");
+    let canister_id = env.install_canister(rev, vec![], None).unwrap();
+
+    let (result,): (u64,) = query_candid(&env, canister_id, "instruction_counter", ())
+        .expect("failed to query instruction_counter");
+    assert!(result > 0);
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.58.1"
+channel = "1.60.0"
 targets = ["wasm32-unknown-unknown"]
 components = ["rustfmt", "clippy"]

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["api-bindings", "data-structures", "no-std", "development-tools::f
 keywords = ["internet-computer", "types", "dfinity", "canister", "cdk"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 repository = "https://github.com/dfinity/cdk-rs"
-rust-version = "1.58.1"
+rust-version = "1.60.0"
 
 [lib]
 proc-macro = true

--- a/src/ic-cdk-optimizer/Cargo.toml
+++ b/src/ic-cdk-optimizer/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["api-bindings", "data-structures", "no-std", "command-line-utiliti
 keywords = ["internet-computer", "dfinity", "canister", "cli", "optimizer"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 repository = "https://github.com/dfinity/cdk-rs"
-rust-version = "1.58.1"
+rust-version = "1.60.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] 
 ### Added
-- pub fn `arg_data_raw_size` for checking the size of the arg-data-raw before copying to a vector or deserializing (#263)
+- `arg_data_raw_size` for checking the size of the arg-data-raw before copying to a vector or deserializing (#263)
+- `performance_counter` for getting the value of specified performance counter (#277)
 
 ### Fixed
 - Use explicitly type u8 in vector initialization (#264)

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["api-bindings", "data-structures", "no-std", "development-tools::f
 keywords = ["internet-computer", "types", "dfinity", "canister", "cdk"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 repository = "https://github.com/dfinity/cdk-rs"
-rust-version = "1.58.1"
+rust-version = "1.60.0"
 
 [dependencies]
 candid = "0.7.4"

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -608,7 +608,7 @@ pub fn method_name() -> String {
 }
 
 /// Get the value of specified performance counter
-/// 
+///
 /// Supported counter type:
 /// 0 : instruction counter. The number of WebAssembly instructions the system has determined that the canister has executed.
 pub fn performance_counter(counter_type: u32) -> u64 {

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -607,6 +607,14 @@ pub fn method_name() -> String {
     String::from_utf8_lossy(&bytes).to_string()
 }
 
+/// Get the value of specified performance counter
+/// 
+/// Supported counter type:
+/// 0 : instruction counter. The number of WebAssembly instructions the system has determined that the canister has executed.
+pub fn performance_counter(counter_type: u32) -> u64 {
+    unsafe { ic0::performance_counter(counter_type as i32) as u64 }
+}
+
 /// Pretends to have the Candid type `T`, but unconditionally errors
 /// when serialized.
 ///

--- a/src/ic-cdk/src/api/ic0.rs
+++ b/src/ic-cdk/src/api/ic0.rs
@@ -61,19 +61,20 @@ macro_rules! ic0_module {
 
 // This is a private module that can only be used internally in this file.
 // Copy-paste the spec section of the API here.
-// Current spec version: 0.18.2
+// https://github.com/dfinity/interface-spec/blob/master/spec/ic0.txt
 /*
 The comment after each function lists from where these functions may be invoked:
 I: from canister_init or canister_post_upgrade
 G: from canister_pre_upgrade
-U: from canister_update
+U: from canister_update …
 Q: from canister_query …
 Ry: from a reply callback
 Rt: from a reject callback
 C: from a cleanup callback
 s: the (start) module initialization function
 F: from canister_inspect_message
-* = I G U Q Ry Rt C F (NB: Not (start))
+H: from canister_heartbeat
+* = I G U Q Ry Rt C F H (NB: Not (start))
 */
 ic0_module! {
     ic0.msg_arg_data_size : () -> i32;                                          // I U Q Ry F
@@ -92,9 +93,9 @@ ic0_module! {
     ic0.msg_cycles_available128 : (dst : i32) -> ();                            // U Rt Ry
     ic0.msg_cycles_refunded : () -> i64;                                        // Rt Ry
     ic0.msg_cycles_refunded128 : (dst : i32) -> ();                             // Rt Ry
-    ic0.msg_cycles_accept : ( max_amount : i64) -> ( amount : i64 );            // U Rt Ry
-    ic0.msg_cycles_accept128 : ( max_amount_high : i64, max_amount_low: i64, dst : i32)
-                       -> ();                                                   // U Rt Ry
+    ic0.msg_cycles_accept : (max_amount : i64) -> (amount : i64);               // U Rt Ry
+    ic0.msg_cycles_accept128 : (max_amount_high : i64, max_amount_low: i64, dst : i32)
+                           -> ();                                               // U Rt Ry
 
     ic0.canister_self_size : () -> i32;                                         // *
     ic0.canister_self_copy : (dst : i32, offset : i32, size : i32) -> ();       // *
@@ -118,8 +119,8 @@ ic0_module! {
       ) -> ();
     ic0.call_on_cleanup : (fun : i32, env : i32) -> ();                         // U Ry Rt H
     ic0.call_data_append : (src : i32, size : i32) -> ();                       // U Ry Rt H
-    ic0.call_cycles_add : ( amount : i64 ) -> ();                               // U Ry Rt H
-    ic0.call_cycles_add128 : ( amount_high : i64, amount_low: i64 ) -> ();      // U Ry Rt H
+    ic0.call_cycles_add : (amount : i64) -> ();                                 // U Ry Rt H
+    ic0.call_cycles_add128 : (amount_high : i64, amount_low: i64) -> ();        // U Ry Rt H
     ic0.call_perform : () -> ( err_code : i32 );                                // U Ry Rt H
 
     ic0.stable_size : () -> (page_count : i32);                                 // *
@@ -137,7 +138,7 @@ ic0_module! {
     ic0.data_certificate_copy : (dst: i32, offset: i32, size: i32) -> ();       // *
 
     ic0.time : () -> (timestamp : i64);                                         // *
-    ic0.performance_counter : () -> (counter : i64);                            // * s
+    ic0.performance_counter : (counter_type : i32) -> (counter : i64);          // * s
 
     ic0.debug_print : (src : i32, size : i32) -> ();                            // * s
     ic0.trap : (src : i32, size : i32) -> ();                                   // * s

--- a/src/ic-certified-assets/Cargo.toml
+++ b/src/ic-certified-assets/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 keywords = ["internet-computer", "dfinity"]
 categories = ["wasm", "filesystem", "data-structures"]
 repository = "https://github.com/dfinity/cdk-rs"
-rust-version = "1.58.1"
+rust-version = "1.60.0"
 
 [dependencies]
 base64 = "0.13"

--- a/src/ic-certified-map/Cargo.toml
+++ b/src/ic-certified-map/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["data-structures", "cryptography", "cryptography::cryptocurrencies
 keywords = ["internet-computer", "types", "dfinity", "map"]
 include = ["src", "Cargo.toml", "CHANGELOG.md", "LICENSE", "README.md"]
 repository = "https://github.com/dfinity/cdk-rs"
-rust-version = "1.58.1"
+rust-version = "1.60.0"
 
 [dependencies]
 serde = "1"

--- a/src/ic-ledger-types/Cargo.toml
+++ b/src/ic-ledger-types/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["internet-computer", "ledger"]
 categories = ["cryptography::cryptocurrencies", "data-structures"]
 include = ["src", "Cargo.toml", "CHANGELOG.md", "LICENSE", "README.md"]
 repository = "https://github.com/dfinity/cdk-rs"
-rust-version = "1.58.1"
+rust-version = "1.60.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
# Description

Add support for new system API `performance_counter`:

```rust
ic_cdk::api::call::performance_counter(counter_type: u32) -> u64
```

The rust toolchain is updated to 1.60.0 in consistent with `ic`.

# How Has This Been Tested?

e2e test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
