### PR TITLE
feat: make CanisterStableMemory public

### DIFF
--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changed
+- Make `CanisterStableMemory` public (#281)
+
 ## [0.5.2] - 2022-06-23 
 ### Added
 - `arg_data_raw_size` for checking the size of the arg-data-raw before copying to a vector or deserializing (#263)

--- a/src/ic-cdk/src/api/stable.rs
+++ b/src/ic-cdk/src/api/stable.rs
@@ -6,7 +6,7 @@ mod canister;
 #[cfg(test)]
 mod tests;
 
-use canister::CanisterStableMemory;
+pub use canister::CanisterStableMemory;
 use std::{error, fmt, io};
 
 const WASM_PAGE_SIZE_IN_BYTES: usize = 64 * 1024; // 64KB

--- a/src/ic-cdk/src/api/stable/canister.rs
+++ b/src/ic-cdk/src/api/stable/canister.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::api::ic0;
 
+/// A standard implementation of [`StableMemory`].
+///
+/// Useful for creating [`StableWriter`] and [`StableReader`].
 #[derive(Default)]
 pub struct CanisterStableMemory {}
 


### PR DESCRIPTION
# Description

The `with_memory()` constructors of `StableWriter` and `StableReader` will be practically useful.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
