### PR TITLE
refactor: move performance_counter to ic_cdk::api module

### DIFF
--- a/e2e-tests/canisters/api_call.rs
+++ b/e2e-tests/canisters/api_call.rs
@@ -2,7 +2,7 @@ use ic_cdk_macros::query;
 
 #[query]
 fn instruction_counter() -> u64 {
-    ic_cdk::api::call::performance_counter(0)
+    ic_cdk::api::instruction_counter()
 }
 
 fn main() {}

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,8 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+- `instruction_counter` function as a shorthand for `performance_counter(0)`.
+
 ### Changed
 - Make `CanisterStableMemory` public (#281)
+- BREAKING CHANGE: move performance_counter from the `ic_cdk::api::call` to `ic_cdk::api` module.
 
 ## [0.5.2] - 2022-06-23 
 ### Added

--- a/src/ic-cdk/src/api.rs
+++ b/src/ic-cdk/src/api.rs
@@ -98,3 +98,19 @@ pub fn data_certificate() -> Option<Vec<u8>> {
     }
     Some(buf)
 }
+
+/// Returns the number of instructions that the canister executed since the last [entry
+/// point](https://internetcomputer.org/docs/current/references/ic-interface-spec/#entry-points).
+#[inline]
+pub fn instruction_counter() -> u64 {
+    performance_counter(0)
+}
+
+/// Get the value of specified performance counter.
+///
+/// Supported counter type:
+/// 0 : instruction counter. The number of WebAssembly instructions the system has determined that the canister has executed.
+#[inline]
+pub fn performance_counter(counter_type: u32) -> u64 {
+    unsafe { ic0::performance_counter(counter_type as i32) as u64 }
+}


### PR DESCRIPTION
This change attempts to make performance_counter API a bit easier to
find and use:

  1. Move `performance_counter` from `ic_cdk::api::call` to
     `ic_cdk::api` because the counter has nothing to do with making
     calls.
  2. Introduce an alias for `performance_counter(0)`,
     `instruction_counter()`. It's much better on the eye and doesn't
     force the code reader to learn about valid inputs for
     `performance_counter`.