### PR TITLE
fix: candid spec to support setting multiple custom HTTP headers on asset creation

### DIFF
--- a/src/ic-certified-assets/CHANGELOG.md
+++ b/src/ic-certified-assets/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2022-07-12
+### Fixed
+- headers field in Candid spec accepts mmultiple HTTP headers
+
 ## [0.2.3] - 2022-07-06
 ### Added
 - Support for setting custom HTTP headers on asset creation 

--- a/src/ic-certified-assets/Cargo.toml
+++ b/src/ic-certified-assets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-certified-assets"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Rust support for asset certification."

--- a/src/ic-certified-assets/assets.did
+++ b/src/ic-certified-assets/assets.did
@@ -7,7 +7,7 @@ type CreateAssetArguments = record {
   key: Key;
   content_type: text;
   max_age: opt nat64;
-  headers: opt HeaderField;
+  headers: opt vec HeaderField;
 };
 
 // Add or change content for an asset, by content encoding


### PR DESCRIPTION
# Description

Continuation of https://github.com/dfinity/cdk-rs/pull/282. The previous PR [incorrectly defined new field in candid spec](https://github.com/dfinity/cdk-rs/blob/7beb1b6e5473ae07337a227059523ff9a376f05f/src/ic-certified-assets/assets.did#L10), which resulted in an incorrect generation of types in e.g. TS:
```ts
export interface CreateAssetArguments {
    key: Key;
    content_type: string;
    headers: [] | [HeaderField];
    max_age: [] | [bigint];
}
export declare type HeaderField = [string, string];
```

This PR fixes that, helping generate correct types (again, TS as an example):
```ts
export interface CreateAssetArguments {
  'key' : Key,
  'content_type' : string,
  'headers' : [] | [Array<HeaderField>], // fixed
  'max_age' : [] | [bigint],
}
export type HeaderField = [string, string];
```


# How Has This Been Tested?

manually inspected if generated TS types from candid spec are correct
```console
cargo install --git https://github.com/dfinity/candid didc
didc bind src/ic-certified-assets/assets.did -t ts
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
