### PR TITLE
fix(doc): update comments for ManualReply

### DIFF
--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `CanisterStableMemory` public (#281)
 - BREAKING CHANGE: move performance_counter from the `ic_cdk::api::call` to `ic_cdk::api` module.
 
+### Fixed
+- Outdated documentation for `ManualReply`.
+
 ## [0.5.2] - 2022-06-23 
 ### Added
 - `arg_data_raw_size` for checking the size of the arg-data-raw before copying to a vector or deserializing (#263)

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 
 ### Added
-- `instruction_counter` function as a shorthand for `performance_counter(0)`.
+- `instruction_counter` function as a shorthand for `performance_counter(0)` (#283).
 
 ### Changed
 - Make `CanisterStableMemory` public (#281)
-- BREAKING CHANGE: move performance_counter from the `ic_cdk::api::call` to `ic_cdk::api` module.
+- BREAKING CHANGE: move performance_counter from the `ic_cdk::api::call` to `ic_cdk::api` module (#283).
 
 ### Fixed
-- Outdated documentation for `ManualReply`.
+- Outdated documentation for `ManualReply` (#286).
 
 ## [0.5.2] - 2022-06-23 
 ### Added

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -618,7 +618,7 @@ pub fn performance_counter(counter_type: u32) -> u64 {
 /// Pretends to have the Candid type `T`, but unconditionally errors
 /// when serialized.
 ///
-/// Usable, but not required, as metadata when using `#[query(reply = false)]`,
+/// Usable, but not required, as metadata when using `#[query(manual_reply = true)]`,
 /// so an accurate Candid file can still be generated.
 #[derive(Debug, Copy, Clone, Default)]
 pub struct ManualReply<T: ?Sized>(PhantomData<T>);


### PR DESCRIPTION
# Description

This change fixes the commentary for ManualReply that mentioned
non-existing `#[query(reply = false)]` syntax.
The correct syntax is `#[query(manual_reply = true)]`.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
