### PR TITLE
feat: Derive CandidType for RejectionCode

### DIFF
--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -130,7 +130,7 @@ use rc::{InnerCell, WasmCell};
 /// These can be obtained either using `reject_code()` or `reject_result()`.
 #[allow(missing_docs)]
 #[repr(i32)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, CandidType, Clone, Copy)]
 pub enum RejectionCode {
     NoError = 0,
 


### PR DESCRIPTION
# Description

To test the canister HTTP feature, we run a proxy canister that should return the response 1:1 and `RejectionCode` can not be candid encoded.
