### PR TITLE
feat: ManualReply::reject API

### DIFF
--- a/e2e-tests/canisters/api_call.rs
+++ b/e2e-tests/canisters/api_call.rs
@@ -1,8 +1,14 @@
+use ic_cdk::api::call::ManualReply;
 use ic_cdk_macros::query;
 
 #[query]
 fn instruction_counter() -> u64 {
     ic_cdk::api::instruction_counter()
+}
+
+#[query(manual_reply = true)]
+fn manual_reject() -> ManualReply<u64> {
+    ManualReply::reject("manual reject")
 }
 
 fn main() {}

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -1,4 +1,5 @@
 use candid::utils::{decode_args, encode_args, ArgumentDecoder, ArgumentEncoder};
+use candid::Encode;
 use ic_cdk_e2e_tests::cargo_build_canister;
 use ic_state_machine_tests::{CanisterId, ErrorCode, StateMachine, UserError, WasmResult};
 use serde_bytes::ByteBuf;
@@ -166,4 +167,9 @@ fn test_api_call() {
     let (result,): (u64,) = query_candid(&env, canister_id, "instruction_counter", ())
         .expect("failed to query instruction_counter");
     assert!(result > 0);
+
+    let result = env
+        .query(canister_id, "manual_reject", Encode!().unwrap())
+        .unwrap();
+    assert_eq!(result, WasmResult::Reject("manual reject".to_string()));
 }

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Derive common traits for `RejectionCode` (#294)
-- `ManualReply::reject` function
+- `ManualReply::reject` function (#297)
 
 ## [0.5.5] - 2022-07-22
 

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Derive common traits for `RejectionCode` (#294)
+- `ManualReply::reject` function
 
 ## [0.5.5] - 2022-07-22
 

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -648,6 +648,13 @@ impl<T: ?Sized> ManualReply<T> {
         reply((value,));
         Self::empty()
     }
+
+    /// Rejects the call with the specified message and returns a new
+    /// `ManualReply`, for a useful reply-then-return shortcut.
+    pub fn reject(message: impl AsRef<str>) -> Self {
+        reject(message.as_ref());
+        Self::empty()
+    }
 }
 
 impl<T> CandidType for ManualReply<T>


### PR DESCRIPTION
# Description

I :heart: the ManualReply interface because it gives so much flexibility.
The type misses on short cut: reject and produce a manual reply object.
This change adds the missing shortcut.

# How Has This Been Tested?

I've added an end-to-end test.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
