### PR TITLE
fix: do not trap in call() if decoder fails

### DIFF
--- a/e2e-tests/canisters/async.rs
+++ b/e2e-tests/canisters/async.rs
@@ -53,4 +53,24 @@ fn notify(whom: Principal, method: String) {
     });
 }
 
+#[query]
+fn greet(name: String) -> String {
+    format!("Hello, {}", name)
+}
+
+#[update]
+async fn invalid_reply_payload_does_not_trap() -> String {
+    // We're decoding an integer instead of a string, decoding must fail.
+    let result: Result<(u64,), _> =
+        ic_cdk::call(ic_cdk::api::id(), "greet", ("World".to_string(),)).await;
+
+    match result {
+        Ok((_n,)) => ic_cdk::api::trap("expected the decoding to fail"),
+        Err((err_code, _)) => format!(
+            "handled decoding error gracefully with code {}",
+            err_code as i32
+        ),
+    }
+}
+
 fn main() {}

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -117,6 +117,11 @@ fn test_panic_after_async_frees_resources() {
 
         assert_eq!(i, n, "expected the invocation count to be {}, got {}", i, n);
     }
+
+    let (message,): (String,) =
+        call_candid(&env, canister_id, "invalid_reply_payload_does_not_trap", ())
+            .expect("call failed");
+    assert_eq!(&message, "handled decoding error gracefully with code 5");
 }
 
 #[test]

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Derive common traits for `RejectionCode` (#294)
 - `ManualReply::reject` function (#297)
 
+### Fixed
+
+- Failure to decode the reply in `ic_cdk::call` does not trap anymore (#301).
+
 ## [0.5.5] - 2022-07-22
 
 ### Added

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -404,7 +404,16 @@ pub fn call<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     let fut = call_raw(id, method, &args_raw, 0);
     async {
         let bytes = fut.await?;
-        decode_args(&bytes).map_err(|err| trap(&format!("{:?}", err)))
+        decode_args(&bytes).map_err(|err| {
+            (
+                RejectionCode::CanisterError,
+                format!(
+                    "failed to decode canister response as {}: {}",
+                    std::any::type_name::<T>(),
+                    err
+                ),
+            )
+        })
     }
 }
 

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -394,6 +394,17 @@ fn call_raw_internal(
     CallFuture { state }
 }
 
+fn decoder_error_to_reject<T>(err: candid::error::Error) -> (RejectionCode, String) {
+    (
+        RejectionCode::CanisterError,
+        format!(
+            "failed to decode canister response as {}: {}",
+            std::any::type_name::<T>(),
+            err
+        ),
+    )
+}
+
 /// Performs an asynchronous call to another canister using the [System API](https://internetcomputer.org/docs/current/references/ic-interface-spec/#system-api-call).
 ///
 /// If the reply payload is not a valid encoding of the expected type [T],
@@ -407,16 +418,7 @@ pub fn call<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     let fut = call_raw(id, method, &args_raw, 0);
     async {
         let bytes = fut.await?;
-        decode_args(&bytes).map_err(|err| {
-            (
-                RejectionCode::CanisterError,
-                format!(
-                    "failed to decode canister response as {}: {}",
-                    std::any::type_name::<T>(),
-                    err
-                ),
-            )
-        })
+        decode_args(&bytes).map_err(decoder_error_to_reject::<T>)
     }
 }
 
@@ -431,7 +433,7 @@ pub fn call_with_payment<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     let fut = call_raw(id, method, &args_raw, cycles);
     async {
         let bytes = fut.await?;
-        decode_args(&bytes).map_err(|err| trap(&format!("{:?}", err)))
+        decode_args(&bytes).map_err(decoder_error_to_reject::<T>)
     }
 }
 
@@ -446,7 +448,7 @@ pub fn call_with_payment128<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     let fut = call_raw128(id, method, &args_raw, cycles);
     async {
         let bytes = fut.await?;
-        decode_args(&bytes).map_err(|err| trap(&format!("{:?}", err)))
+        decode_args(&bytes).map_err(decoder_error_to_reject::<T>)
     }
 }
 

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -394,7 +394,10 @@ fn call_raw_internal(
     CallFuture { state }
 }
 
-/// Performs an asynchronous call to another canister via ic0.
+/// Performs an asynchronous call to another canister using the [System API](https://internetcomputer.org/docs/current/references/ic-interface-spec/#system-api-call).
+///
+/// If the reply payload is not a valid encoding of the expected type [T],
+/// the call results in [RejectionCode::CanisterError] error.
 pub fn call<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     id: Principal,
     method: &str,


### PR DESCRIPTION
# Description

This change maps decoding failure in the call() function to
CanisterError rejection code. This way canisters have a chance to handle
decoding failures gracefully.

# How Has This Been Tested?

The change includes an end-to-end test.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
