### PR TITLE
chore: deprecate optimizer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,26 +36,8 @@ jobs:
           target: wasm32-unknown-unknown
       - name: Run builds
         run: |
-          cargo build --workspace --exclude ic-cdk-optimizer --exclude ic-cdk-e2e-tests --target wasm32-unknown-unknown
-          cargo build --workspace --exclude ic-cdk-optimizer --exclude ic-cdk-e2e-tests --target wasm32-unknown-unknown --release
-
-  build-ic-cdk-optimizer:
-    name: Build ic-cdk-optimizer
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: ${{ env.rust-version }}
-      - name: Run builds
-        run: |
-          cargo build -p ic-cdk-optimizer
+          cargo build --workspace --exclude ic-cdk-e2e-tests --target wasm32-unknown-unknown
+          cargo build --workspace --exclude ic-cdk-e2e-tests --target wasm32-unknown-unknown --release
 
   test:
     name: cargo test
@@ -143,14 +125,11 @@ jobs:
   aggregate:
     name: ci:required
     if: ${{ always() }}
-    needs: [build, build-ic-cdk-optimizer, test, fmt, clippy]
+    needs: [build, test, fmt, clippy]
     runs-on: ubuntu-latest
     steps:
       - name: check build result
         if: ${{ needs.build.result != 'success' }}
-        run: exit 1
-      - name: check build-ic-cdk-optimizer result
-        if: ${{ needs.build-ic-cdk-optimizer.result != 'success' }}
         run: exit 1
       - name: check test result
         if: ${{ needs.test.result != 'success' }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -44,6 +44,10 @@ jobs:
           target: wasm32-unknown-unknown
           components: rustfmt
 
+      - name: Install ic-wasm
+        run: |
+          cargo install ic-wasm
+
       - name: Install DFX
         run: |
           export DFX_VERSION=${{env.dfx-version }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 members = [
     "src/ic-cdk",
     "src/ic-cdk-macros",
-    "src/ic-cdk-optimizer",
     "src/ic-certified-map",
     "src/ic-ledger-types",
     "e2e-tests",

--- a/examples/build.sh
+++ b/examples/build.sh
@@ -12,6 +12,6 @@ cargo build --manifest-path="$example_root/Cargo.toml" \
     --release \
     --package "$package"
 
-cargo run --manifest-path="$root/Cargo.toml" --bin ic-cdk-optimizer -- \
+ic-wasm "$example_root/target/wasm32-unknown-unknown/release/$package.wasm" \
     -o "$example_root/target/wasm32-unknown-unknown/release/$package-opt.wasm" \
-    "$example_root/target/wasm32-unknown-unknown/release/$package.wasm"
+    shrink

--- a/src/ic-cdk-optimizer/CHANGELOG.md
+++ b/src/ic-cdk-optimizer/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.5] - 2022-09-15
+This is the final release of this deprecated tool.
+
 ### Added
 - Specifying `-` as the input or output argument refers to stdin or stdout respectively (#230)
 

--- a/src/ic-cdk-optimizer/Cargo.toml
+++ b/src/ic-cdk-optimizer/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "ic-cdk-optimizer"
 version = "0.3.5"

--- a/src/ic-cdk-optimizer/Cargo.toml
+++ b/src/ic-cdk-optimizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-optimizer"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "WASM Optimizer for the IC CDK (experimental)."

--- a/src/ic-cdk-optimizer/README.md
+++ b/src/ic-cdk-optimizer/README.md
@@ -1,5 +1,5 @@
 # Deprecated
-This tool is deprecated since Sep 2022. The last release of it was [v0.3.4](https://github.com/dfinity/cdk-rs/releases/tag/0.3.4).
+This tool is deprecated since Sep 2022. The last release of it was [v0.3.5](https://github.com/dfinity/cdk-rs/releases/tag/0.3.5).
 
 
 Use ic-wasm shrink instead to reduce size of WASM modules for Internet Computer. Check [ic-wasm](https://github.com/dfinity/ic-wasm) repo here.

--- a/src/ic-cdk-optimizer/README.md
+++ b/src/ic-cdk-optimizer/README.md
@@ -1,4 +1,8 @@
-# ic-cdk-optimizer
-Optimizer library to reduce the size of CDK WASMs.
+# Deprecated
+This tool is deprecated since Sep 2022. The last release of it was [v0.3.4](https://github.com/dfinity/cdk-rs/releases/tag/0.3.4).
 
-Documentation TBD
+
+Use ic-wasm shrink instead to reduce size of WASM modules for Internet Computer. Check [ic-wasm](https://github.com/dfinity/ic-wasm) repo here.
+
+## ic-cdk-optimizer
+Optimizer to reduce the size of CDK WASMs.


### PR DESCRIPTION
# Description

To end the life of ic-cdk-optimizer, we remove it from rust workspace and CI.

Also, close #187.

# How Has This Been Tested?

CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
