### PR TITLE
chore: update outdated sha2 dependency of ic-certified-map

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -45,8 +45,12 @@ jobs:
           components: rustfmt
 
       - name: Install ic-wasm
+        # might already in cache
         run: |
-          cargo install ic-wasm
+          if ! command -v <the_command> &> /dev/null
+          then
+            cargo install ic-wasm
+          fi
 
       - name: Install DFX
         run: |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -47,8 +47,7 @@ jobs:
       - name: Install ic-wasm
         # might already in cache
         run: |
-          if ! command -v <the_command> &> /dev/null
-          then
+          if ! [ -x "$(command -v ic-wasm)" ]; then
             cargo install ic-wasm
           fi
 

--- a/src/ic-certified-map/CHANGELOG.md
+++ b/src/ic-certified-map/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2022-09-16
+### Changed
+- Updated `sha2` dependency.
+
 ## [0.3.0] - 2022-01-13
 ### Added
 - `RbTree::iter()` method.

--- a/src/ic-certified-map/Cargo.toml
+++ b/src/ic-certified-map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-certified-map"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Merkleized map data structure."

--- a/src/ic-certified-map/Cargo.toml
+++ b/src/ic-certified-map/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.60.0"
 [dependencies]
 serde = "1"
 serde_bytes = "0.11"
-sha2 = "0.9"
+sha2 = "0.10"
 
 [dev-dependencies]
 hex = "0.4"


### PR DESCRIPTION
# Description

The `sha2` dependency has been updated to the latest version.

# How Has This Been Tested?

Tested by running unit tests.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
