### PR TITLE
chore(ci): cancel previous CI run after new push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   rust-version: 1.60.0
 

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,4 +1,5 @@
 name: Check PR title
+
 on:
   pull_request_target:
     types:
@@ -6,6 +7,10 @@ on:
       - reopened
       - edited
       - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   rust-version: 1.60.0
   dfx-version: 0.11.1


### PR DESCRIPTION
# Description

Similar to https://github.com/dfinity/sdk/pull/2573.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
