### PR TITLE
feat: allow specifying custom serializer / deserializer in macros

### DIFF
--- a/src/ic-cdk-macros/src/export.rs
+++ b/src/ic-cdk-macros/src/export.rs
@@ -10,7 +10,13 @@ use syn::{spanned::Spanned, FnArg, ItemFn, Pat, PatIdent, PatType, ReturnType, S
 struct ExportAttributes {
     pub name: Option<String>,
     pub guard: Option<String>,
+    /// The name of the function to use to serialize the response to bytes, if none, the response
+    /// will be serialized using candid.
+    /// `fn<T>(response: T) -> Vec<u8>`
     pub serializer: Option<String>,
+    /// The name of the function to use to deserialize the request from bytes, if none, the request
+    /// will be deserialized using candid.
+    /// `fn<T>(bytes: &[u8]) -> T`
     pub deserializer: Option<String>,
     #[serde(default)]
     pub manual_reply: bool,

--- a/src/ic-cdk-macros/src/export.rs
+++ b/src/ic-cdk-macros/src/export.rs
@@ -169,10 +169,7 @@ fn dfn_macro(
         quote! {}
     } else if let Some(serializer) = attrs.serializer {
         let serializer_ident = syn::Ident::new(&serializer, Span::call_site());
-        match return_length {
-            0 => quote! { ic_cdk::api::call::reply_raw(&#serializer_ident (())) },
-            _ => quote! { ic_cdk::api::call::reply_raw(&#serializer_ident (result)) },
-        }
+        quote! { ic_cdk::api::call::reply_raw(&#serializer_ident (result)) }
     } else {
         match return_length {
             0 => quote! { ic_cdk::api::call::reply(()) },

--- a/src/ic-cdk-macros/src/export.rs
+++ b/src/ic-cdk-macros/src/export.rs
@@ -16,7 +16,13 @@ struct ExportAttributes {
     pub serializer: Option<String>,
     /// The name of the function to use to deserialize the request from bytes, if none, the request
     /// will be deserialized using candid.
-    /// `fn<T>(bytes: &[u8]) -> T`
+    ///
+    /// If the request takes a single arg, the deserializer function must return that arg.
+    /// fn<T>(bytes: &[u8]) -> T
+    ///
+    /// If the request takes multiple args, the deserializer function must return a tuple containing
+    /// each of the args in turn.
+    /// fn<T1, T2>(bytes: &[u8]) -> (T1, T2)
     pub deserializer: Option<String>,
     #[serde(default)]
     pub manual_reply: bool,

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+- Support custom serializer/deserializer functions within macros 
 
 ## [0.5.7] - 2022-09-27
 

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
-- Support custom serializer/deserializer functions within macros 
+- Support custom serializer/deserializer functions within macros (#320) 
 
 ## [0.5.7] - 2022-09-27
 


### PR DESCRIPTION
# Description

Currently, when using the macros exposed by this cdk (`query`, `update`, etc.), the request and response must be serialized and deserialized using candid.
This PR allows developers to pass in custom functions to handle serialization and deserialization.
We have been using the [MessagePack](https://msgpack.org/index.html) serializer within OpenChat for many months now using the change in this PR.

# How Has This Been Tested?

We have been using this within OpenChat for many months now and have had no issues with it.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
