### PR TITLE
feat: specify cycles when create canister

### DIFF
--- a/examples/management_canister/src/caller/lib.rs
+++ b/examples/management_canister/src/caller/lib.rs
@@ -15,8 +15,15 @@ mod main {
         };
         create_canister(arg).await.unwrap();
 
-        let canister_id = create_canister_with_extra_cycles(CreateCanisterArgument::default(), 1_000_000_000_000u128).await.unwrap().0.canister_id;
-        
+        let canister_id = create_canister_with_extra_cycles(
+            CreateCanisterArgument::default(),
+            1_000_000_000_000u128,
+        )
+        .await
+        .unwrap()
+        .0
+        .canister_id;
+
         let arg = UpdateSettingsArgument {
             canister_id,
             settings: CanisterSettings::default(),

--- a/examples/management_canister/src/caller/lib.rs
+++ b/examples/management_canister/src/caller/lib.rs
@@ -13,8 +13,10 @@ mod main {
                 freezing_threshold: Some(10000.into()),
             }),
         };
-        let canister_id = create_canister(arg).await.unwrap().0.canister_id;
+        create_canister(arg).await.unwrap();
 
+        let canister_id = create_canister_with_extra_cycles(CreateCanisterArgument::default(), 1_000_000_000_000u128).await.unwrap().0.canister_id;
+        
         let arg = UpdateSettingsArgument {
             canister_id,
             settings: CanisterSettings::default(),

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-macros"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit macros."

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.6.1] - 2022-10-14
+
+### Added
+
+- `create_canister_with_extra_cycles` to specify cycles when create canister (#322)
+
+### Fixed
+
+- `create_canister` should charge 0.1T cycles (#322)
+
 ## [0.6.0] - 2022-10-03
 
 ### Changed

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit for the Internet Computer."

--- a/src/ic-cdk/src/api/management_canister/main/mod.rs
+++ b/src/ic-cdk/src/api/management_canister/main/mod.rs
@@ -11,10 +11,14 @@ use candid::Principal;
 mod types;
 pub use types::*;
 
-// https://internetcomputer.org/docs/current/developer-docs/deploy/computation-and-storage-costs
-const CREATE_CANISTER_CYCLES: u128 = 1_000_000_000_000u128;
+/// Cycles cost to create a canister.
+///
+/// https://internetcomputer.org/docs/current/developer-docs/deploy/computation-and-storage-costs
+pub const CREATE_CANISTER_CYCLES: u128 = 100_000_000_000u128;
 
 /// Register a new canister and get its canister id.
+///
+/// Note: This call charges [CREATE_CANISTER_CYCLES] from the caller canister.
 ///
 /// See [IC method `create_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-create_canister).
 pub async fn create_canister(arg: CreateCanisterArgument) -> CallResult<(CanisterIdRecord,)> {
@@ -23,6 +27,24 @@ pub async fn create_canister(arg: CreateCanisterArgument) -> CallResult<(Caniste
         "create_canister",
         (arg,),
         CREATE_CANISTER_CYCLES,
+    )
+    .await
+}
+
+/// [create_canister] and specify extra cycles to the new canister.
+///
+/// Note: This call charges [CREATE_CANISTER_CYCLES] and the specified extra cycles from the caller canister.
+///
+/// See [IC method `create_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-create_canister).
+pub async fn create_canister_with_extra_cycles(
+    arg: CreateCanisterArgument,
+    cycles: u128,
+) -> CallResult<(CanisterIdRecord,)> {
+    call_with_payment128(
+        Principal::management_canister(),
+        "create_canister",
+        (arg,),
+        CREATE_CANISTER_CYCLES + cycles,
     )
     .await
 }


### PR DESCRIPTION
# Description

Fix wrong number of cycles charged by `create_canister` (1T -> 0.1T).

Add `create_canister_with_extra_cycles`.

# How Has This Been Tested?

Example test.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
