### PR TITLE
chore: BREAKING CHANGE: Update for HTTPS Outcalls transform function with context.

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,7 +12,7 @@ concurrency:
 
 env:
   rust-version: 1.60.0
-  dfx-version: 0.12.0-beta.3
+  dfx-version: 0.12.0-beta.6
 
 jobs:
   test:

--- a/examples/management_canister/src/caller/lib.rs
+++ b/examples/management_canister/src/caller/lib.rs
@@ -110,13 +110,13 @@ mod http_request {
 
     // transform function must be a *query* method of the canister
     #[query]
-    fn transform(arg: HttpResponse) -> HttpResponse {
+    fn transform(arg: TransformArgs) -> HttpResponse {
         HttpResponse {
             headers: vec![HttpHeader {
                 name: "custom-header".to_string(),
                 value: "test".to_string(),
             }],
-            ..arg
+            ..arg.response
         }
     }
 }

--- a/examples/management_canister/src/caller/lib.rs
+++ b/examples/management_canister/src/caller/lib.rs
@@ -95,13 +95,7 @@ mod http_request {
             method: HttpMethod::GET,
             headers: vec![],
             body: None,
-            transform: Some(TransformContext {
-                function: TransformFunc(candid::Func {
-                    principal: caller_canister.get().0,
-                    method: "transform".clone(),
-                }),
-                context: vec![],
-            }),
+            transform: Some(TransformContext::new(transform, vec![])),
         };
         let response = http_request(arg).await.unwrap().0;
         assert_eq!(response.status, 200);

--- a/examples/management_canister/src/caller/lib.rs
+++ b/examples/management_canister/src/caller/lib.rs
@@ -95,7 +95,13 @@ mod http_request {
             method: HttpMethod::GET,
             headers: vec![],
             body: None,
-            transform: Some(TransformType::from_transform_function(transform)),
+            transform: Some(TransformContext {
+                function: TransformFunc(candid::Func {
+                    principal: caller_canister.get().0,
+                    method: "transform".clone(),
+                }),
+                context: vec![],
+            }),
         };
         let response = http_request(arg).await.unwrap().0;
         assert_eq!(response.status, 200);

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-macros"
-version = "0.6.4"
+version = "0.6.5"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit macros."

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.6.5] - 2022-11-04
+
+### Changed
+
+BREAKING CHANGE of experimental API:
+- `http_request` to support `context` field in callback function. (#326)
+
 ## [0.6.4] - 2022-10-28
 
 ### Added
@@ -23,10 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Refactored
 
 - Separate `ic0` crate for system API. (#324)
-
-### Changed
-
-- `http_request` to support `context` field in callback function (#326)
 
 ## [0.6.1] - 2022-10-14
 

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.2] - 2022-10-24
 
-## Refactored
+### Refactored
 
 - Separate `ic0` crate for system API. (#324)
+
+### Changed
+
+- `http_request` to support `context` field in callback function (#326)
 
 ## [0.6.1] - 2022-10-14
 

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -18,6 +18,7 @@ rust-version = "1.60.0"
 candid = "0.8"
 cfg-if = "1.0.0"
 serde = "1.0.110"
+serde_bytes = "0.11.7"
 ic0 = { path = "../ic0", version = "0.18.4" }
 
 [dev-dependencies]

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.6.4"
+version = "0.6.5"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit for the Internet Computer."

--- a/src/ic-cdk/src/api/management_canister/http_request.rs
+++ b/src/ic-cdk/src/api/management_canister/http_request.rs
@@ -47,7 +47,7 @@ pub struct TransformArgs {
 //       function : func (record {response : http_response; context : blob}) -> (http_response) query;
 //       context : blob;
 //   }`
-#[derive(Clone, Debug, PartialEq, CandidType, Deserialize)]
+#[derive(CandidType, Clone, Debug, Deserialize, PartialEq)]
 pub struct TransformContext {
     /// Reference function with signature: `func (record {response : http_response; context : blob}) -> (http_response) query;`.
     pub function: TransformFunc,

--- a/src/ic-cdk/src/api/management_canister/http_request.rs
+++ b/src/ic-cdk/src/api/management_canister/http_request.rs
@@ -194,7 +194,7 @@ mod tests {
             body: None,
             transform: None,
         };
-        assert_eq!(http_request_required_cycles(&arg), 716500000u128);
+        assert_eq!(http_request_required_cycles(&arg), 718500000u128);
     }
 
     #[test]
@@ -208,7 +208,7 @@ mod tests {
             body: None,
             transform: None,
         };
-        assert_eq!(http_request_required_cycles(&arg), 210130900000u128);
+        assert_eq!(http_request_required_cycles(&arg), 210132900000u128);
     }
 
     #[test]

--- a/src/ic-cdk/src/api/management_canister/http_request.rs
+++ b/src/ic-cdk/src/api/management_canister/http_request.rs
@@ -57,6 +57,41 @@ pub struct TransformContext {
     pub context: Vec<u8>,
 }
 
+impl TransformContext {
+    /// Construct `TransformType` from a transform function.
+    ///
+    /// # example
+    ///
+    /// ```ignore
+    /// #[ic_cdk_macros::query]
+    /// fn my_transform(arg: TransformArgs) -> HttpResponse {
+    ///     ...
+    /// }
+    ///
+    /// let transform = TransformType::from_transform_function(my_transform);
+    /// ```
+    pub fn new<T>(func: T, context: Vec<u8>) -> Self
+    where
+        T: Fn(TransformArgs) -> HttpResponse,
+    {
+        Self {
+            function: TransformFunc(candid::Func {
+                principal: crate::id(),
+                method: get_function_name(func).to_string(),
+            }),
+            context,
+        }
+    }
+}
+
+fn get_function_name<F>(_: F) -> &'static str {
+    let full_name = std::any::type_name::<F>();
+    match full_name.rfind(':') {
+        Some(index) => &full_name[index + 1..],
+        None => full_name,
+    }
+}
+
 /// HTTP header.
 #[derive(
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default,


### PR DESCRIPTION
# Description

Updates CDK in the area of `http_request` through management canister.  Adds `context` field to callback function for response transformation. 

# How Has This Been Tested?

- Updated tests in CDK
- Tested with newest replica + sample dapp for `http_request` feature

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
