### PR TITLE
fix: no build script for ic0

### DIFF
--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-macros"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit macros."

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.6.3] - 2022-10-26
+
+### Fixed
+
+- Doc can build on docs.rs. (#327)
+
 ## [0.6.2] - 2022-10-24
 
 ## Refactored

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit for the Internet Computer."

--- a/src/ic0/Cargo.toml
+++ b/src/ic0/Cargo.toml
@@ -11,6 +11,11 @@ keywords = ["internet-computer", "types", "dfinity", "canister", "cdk"]
 repository = "https://github.com/dfinity/cdk-rs"
 rust-version = "1.60.0"
 
-[build-dependencies]
-quote = "1.0"
+[dev-dependencies]
+quote = { version = "1.0" }
 syn = { version = "1.0", features = ["parsing", "full", "extra-traits"] }
+
+# This is not a real example but a utility for auto-generating ic0.rs
+[[example]]
+name = "ic0build"
+path = "util/ic0build.rs"

--- a/src/ic0/Cargo.toml
+++ b/src/ic0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic0"
-version = "0.18.4"
+version = "0.18.5"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Internet Computer System API Binding."
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 readme = "README.md"
 categories = ["api-bindings", "development-tools::ffi"]
 keywords = ["internet-computer", "types", "dfinity", "canister", "cdk"]
+include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 repository = "https://github.com/dfinity/cdk-rs"
 rust-version = "1.60.0"
 

--- a/src/ic0/README.md
+++ b/src/ic0/README.md
@@ -10,7 +10,12 @@ Internet Computer System API binding.
 
 `ic0` keeps in step with [interface-spec][1]. Particularly, `ic0` is directly generated from [ic0.txt][2] in that repo.
 
-When interface-spec releases a new version that modify [ic0.txt][2], we replace `ic0.txt` in the root of this crate and run `cargo build` to generate a new `src/ic0.rs`.
+When interface-spec releases a new version that modify [ic0.txt][2]:
+
+1. replace `ic0.txt` in the root of this crate;
+2. execute `cargo run --example=ic0build`;
+
+`src/ic0.rs` should be updated.
 
 The version of `ic0` crate will also bump to the same version as [interface-spec][1].
 

--- a/src/ic0/util/ic0build.rs
+++ b/src/ic0/util/ic0build.rs
@@ -8,6 +8,7 @@ use syn::{FnArg, Ident, Token, TypePath};
 
 use std::fs;
 use std::io::Write;
+use std::path::PathBuf;
 use std::process::Command;
 
 #[derive(Clone, Debug)]
@@ -105,13 +106,13 @@ impl Parse for IC0 {
 }
 
 fn main() {
-    let s = include_str!("ic0.txt");
+    let s = include_str!("../ic0.txt");
     let ic0: IC0 = syn::parse_str(s).unwrap();
 
-    // let out_dir = env::var_os("OUT_DIR").unwrap();
-    // let dest_path = Path::new(&out_dir).join("ic0.rs");
+    let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    d.push("src/ic0.rs");
 
-    let mut f = fs::File::create("src/ic0.rs").unwrap();
+    let mut f = fs::File::create(d).unwrap();
 
     writeln!(
         f,
@@ -146,7 +147,4 @@ extern "C" {{"#,
         .args(["fmt"])
         .output()
         .expect("`cargo fmt` failed");
-
-    println!("cargo:rerun-if-changed=ic0.txt");
-    println!("cargo:rerun-if-changed=build.rs");
 }


### PR DESCRIPTION
# Description

Existing build script directly write source file which is not allowed in bazel. And it doesn't make sense to run build script for every dependent.

The new approach is to make the build script an example binary. `ic0` maintainer should just execute `cargo run --example=ic0build` locally to update `ic0.rs`.

Also this should fix the [document building issue](https://docs.rs/crate/ic-cdk/0.6.2/builds/655852).

# How Has This Been Tested?

CI

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
