### PR TITLE
feat: expose offsets in reader and writer

### DIFF
--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-macros"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit macros."

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,9 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.6.4] - 2022-10-28
+
 ### Added
 
-- `offset` for exposing offsets of `StableReader` and `StableWriter` implementations
+- Expose `offset` of `StableReader` and `StableWriter`. (#330)
 
 ## [0.6.3] - 2022-10-26
 

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+- `offset` for exposing offsets of `StableReader` and `StableWriter` implementations
+
 ## [0.6.3] - 2022-10-26
 
 ### Fixed

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit for the Internet Computer."

--- a/src/ic-cdk/src/api/stable/mod.rs
+++ b/src/ic-cdk/src/api/stable/mod.rs
@@ -165,6 +165,11 @@ impl<M: StableMemory> StableWriter<M> {
         }
     }
 
+    /// Returns the offset of the writer
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
     /// Attempts to grow the memory by adding new pages.
     pub fn grow(&mut self, new_pages: u32) -> Result<(), StableMemoryError> {
         let old_page_count = self.memory.stable_grow(new_pages)?;
@@ -231,6 +236,11 @@ impl<M: StableMemory> BufferedStableWriter<M> {
             inner: io::BufWriter::with_capacity(buffer_size, writer),
         }
     }
+
+    /// Returns the offset of the writer
+    pub fn offset(&self) -> usize {
+        self.inner.get_ref().offset()
+    }
 }
 
 impl<M: StableMemory> io::Write for BufferedStableWriter<M> {
@@ -273,6 +283,11 @@ impl<M: StableMemory> StableReader<M> {
             capacity,
             memory,
         }
+    }
+
+    /// Returns the offset of the reader
+    pub fn offset(&self) -> usize {
+        self.offset
     }
 
     /// Reads data from the stable memory location specified by an offset.
@@ -324,6 +339,11 @@ impl<M: StableMemory> BufferedStableReader<M> {
         BufferedStableReader {
             inner: io::BufReader::with_capacity(buffer_size, reader),
         }
+    }
+
+    /// Returns the offset of the reader
+    pub fn offset(&self) -> usize {
+        self.inner.get_ref().offset()
     }
 }
 


### PR DESCRIPTION
# Description

Expose offsets in reader and writer. The change is useful to use stable storage with common serialization libraries.

Fixes #323

# How Has This Been Tested?

Unit tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
