### PR TITLE
feat: generalize stable storage API by adding 64-bit support for std:io traits

### DIFF
--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-macros"
-version = "0.6.5"
+version = "0.6.6"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit macros."

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+- Added `StableIO` to implement both `io::Write` and `io::Read` for stable memory.
+- Added 64-bit support for `io::Write` and `io::Read` via `StableIO`.
+- Implement `io::Seek` for stable storage.
+
+### Changed
+
+-  `StableWriter` and `StableReader` are now wrappers around `StableIO`. 
+
 ## [0.6.5] - 2022-11-04
 
 ### Changed

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,9 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.6.6] - 2022-11-09
+
 ### Added
 
-- Added `StableIO` to implement both `io::Write` and `io::Read` for stable memory.
+- Added `StableIO` to implement both `io::Write` and `io::Read` for stable memory. (#335)
 - Added 64-bit support for `io::Write` and `io::Read` via `StableIO`.
 - Implement `io::Seek` for stable storage.
 

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.6.5"
+version = "0.6.6"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit for the Internet Computer."

--- a/src/ic-cdk/src/api/stable/mod.rs
+++ b/src/ic-cdk/src/api/stable/mod.rs
@@ -3,6 +3,7 @@
 //! You can check the [Internet Computer Specification](https://smartcontracts.org/docs/interface-spec/index.html#system-api-stable-memory)
 //! for a in-depth explanation of stable memory.
 mod canister;
+mod private;
 #[cfg(test)]
 mod tests;
 
@@ -129,6 +130,158 @@ pub fn stable_bytes() -> Vec<u8> {
     vec
 }
 
+/// Performs generic IO (read, write, and seek) on stable memory.
+///
+/// Warning: When using write functionality, this will overwrite any existing
+/// data in stable memory as it writes, so ensure you set the `offset` value
+/// accordingly if you wish to preserve existing data.
+///
+/// Will attempt to grow the memory as it writes,
+/// and keep offsets and total capacity.
+
+pub struct StableIO<M: StableMemory = CanisterStableMemory, A: private::AddressSize = u32> {
+    /// The offset of the next write.
+    offset: A,
+
+    /// The capacity, in pages.
+    capacity: A,
+
+    /// The stable memory to write data to.
+    memory: M,
+}
+
+impl Default for StableIO {
+    fn default() -> Self {
+        Self::with_memory(CanisterStableMemory::default(), 0)
+    }
+}
+
+// Helper macro to implement StableIO for both 32-bit and 64-bit.
+//
+// We use a macro here since capturing all the traits required to add and manipulate memory
+// addresses with generics becomes cumbersome.
+macro_rules! impl_stable_io {
+    ($address:ty) => {
+        impl<M: private::StableMemory_<$address> + StableMemory> StableIO<M, $address> {
+            /// Creates a new `StableIO` which writes to the selected memory
+            pub fn with_memory(memory: M, offset: $address) -> Self {
+                let capacity = memory.stable_size_();
+
+                Self {
+                    offset,
+                    capacity,
+                    memory,
+                }
+            }
+
+            /// Returns the offset of the writer
+            pub fn offset(&self) -> $address {
+                self.offset
+            }
+
+            /// Attempts to grow the memory by adding new pages.
+            pub fn grow(&mut self, new_pages: $address) -> Result<(), StableMemoryError> {
+                let old_page_count = self.memory.stable_grow_(new_pages)?;
+                self.capacity = old_page_count + new_pages;
+                Ok(())
+            }
+
+            /// Writes a byte slice to the buffer.
+            ///
+            /// The only condition where this will
+            /// error out is if it cannot grow the memory.
+            pub fn write(&mut self, buf: &[u8]) -> Result<usize, StableMemoryError> {
+                let required_capacity_bytes = self.offset + buf.len() as $address;
+                let required_capacity_pages =
+                    ((required_capacity_bytes + WASM_PAGE_SIZE_IN_BYTES as $address - 1)
+                        / WASM_PAGE_SIZE_IN_BYTES as $address);
+                let current_pages = self.capacity;
+                let additional_pages_required =
+                    required_capacity_pages.saturating_sub(current_pages);
+
+                if additional_pages_required > 0 {
+                    self.grow(additional_pages_required)?;
+                }
+
+                self.memory.stable_write_(self.offset, buf);
+                self.offset += buf.len() as $address;
+                Ok(buf.len())
+            }
+
+            /// Reads data from the stable memory location specified by an offset.
+            ///
+            /// Note:
+            /// The stable memory size is cached on creation of the StableReader.
+            /// Therefore, in following scenario, it will get an `OutOfBounds` error:
+            /// 1. Create a StableReader
+            /// 2. Write some data to the stable memory which causes it grow
+            /// 3. call `read()` to read the newly written bytes
+            pub fn read(&mut self, buf: &mut [u8]) -> Result<usize, StableMemoryError> {
+                let capacity_bytes = self.capacity * WASM_PAGE_SIZE_IN_BYTES as $address;
+                let read_buf = if buf.len() as $address + self.offset > capacity_bytes {
+                    if self.offset < capacity_bytes {
+                        &mut buf[..(capacity_bytes - self.offset) as usize]
+                    } else {
+                        return Err(StableMemoryError::OutOfBounds);
+                    }
+                } else {
+                    buf
+                };
+                self.memory.stable_read_(self.offset, read_buf);
+                self.offset += read_buf.len() as $address;
+                Ok(read_buf.len())
+            }
+
+            // Helper used to implement io::Seek
+            fn seek(&mut self, offset: io::SeekFrom) -> io::Result<u64> {
+                self.offset = match offset {
+                    io::SeekFrom::Start(offset) => offset as $address,
+                    io::SeekFrom::End(offset) => {
+                        ((self.capacity * WASM_PAGE_SIZE_IN_BYTES as $address) as i64 + offset)
+                            as $address
+                    }
+                    io::SeekFrom::Current(offset) => (self.offset as i64 + offset) as $address,
+                };
+
+                Ok(self.offset as u64)
+            }
+        }
+
+        impl<M: private::StableMemory_<$address> + StableMemory> io::Write
+            for StableIO<M, $address>
+        {
+            fn write(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
+                self.write(buf)
+                    .map_err(|e| io::Error::new(io::ErrorKind::OutOfMemory, e))
+            }
+
+            fn flush(&mut self) -> Result<(), io::Error> {
+                // Noop.
+                Ok(())
+            }
+        }
+
+        impl<M: private::StableMemory_<$address> + StableMemory> io::Read
+            for StableIO<M, $address>
+        {
+            fn read(&mut self, buf: &mut [u8]) -> Result<usize, io::Error> {
+                Self::read(self, buf).or(Ok(0)) // Read defines EOF to be success
+            }
+        }
+
+        impl<M: private::StableMemory_<$address> + StableMemory> io::Seek
+            for StableIO<M, $address>
+        {
+            fn seek(&mut self, offset: io::SeekFrom) -> io::Result<u64> {
+                self.seek(offset)
+            }
+        }
+    };
+}
+
+impl_stable_io!(u32);
+impl_stable_io!(u64);
+
 /// A writer to the stable memory.
 ///
 /// Warning: This will overwrite any existing data in stable memory as it writes, so ensure you set
@@ -136,77 +289,67 @@ pub fn stable_bytes() -> Vec<u8> {
 ///
 /// Will attempt to grow the memory as it writes,
 /// and keep offsets and total capacity.
-pub struct StableWriter<M: StableMemory = CanisterStableMemory> {
-    /// The offset of the next write.
-    offset: usize,
+pub struct StableWriter<M: StableMemory = CanisterStableMemory>(StableIO<M, u32>);
 
-    /// The capacity, in pages.
-    capacity: u32,
-
-    /// The stable memory to write data to.
-    memory: M,
-}
-
+#[allow(clippy::derivable_impls)]
 impl Default for StableWriter {
+    #[inline]
     fn default() -> Self {
-        Self::with_memory(CanisterStableMemory::default(), 0)
+        Self(StableIO::default())
     }
 }
 
 impl<M: StableMemory> StableWriter<M> {
     /// Creates a new `StableWriter` which writes to the selected memory
+    #[inline]
     pub fn with_memory(memory: M, offset: usize) -> Self {
-        let capacity = memory.stable_size();
-
-        Self {
-            offset,
-            capacity,
-            memory,
-        }
+        Self(StableIO::<M, u32>::with_memory(memory, offset as u32))
     }
 
     /// Returns the offset of the writer
+    #[inline]
     pub fn offset(&self) -> usize {
-        self.offset
+        self.0.offset() as usize
     }
 
     /// Attempts to grow the memory by adding new pages.
+    #[inline]
     pub fn grow(&mut self, new_pages: u32) -> Result<(), StableMemoryError> {
-        let old_page_count = self.memory.stable_grow(new_pages)?;
-        self.capacity = old_page_count + new_pages;
-        Ok(())
+        self.0.grow(new_pages)
     }
 
     /// Writes a byte slice to the buffer.
     ///
     /// The only condition where this will
     /// error out is if it cannot grow the memory.
+    #[inline]
     pub fn write(&mut self, buf: &[u8]) -> Result<usize, StableMemoryError> {
-        let required_capacity_bytes = self.offset + buf.len();
-        let required_capacity_pages = ((required_capacity_bytes + WASM_PAGE_SIZE_IN_BYTES - 1)
-            / WASM_PAGE_SIZE_IN_BYTES) as u32;
-        let current_pages = self.capacity;
-        let additional_pages_required = required_capacity_pages.saturating_sub(current_pages);
-
-        if additional_pages_required > 0 {
-            self.grow(additional_pages_required)?;
-        }
-
-        self.memory.stable_write(self.offset as u32, buf);
-        self.offset += buf.len();
-        Ok(buf.len())
+        self.0.write(buf)
     }
 }
 
 impl<M: StableMemory> io::Write for StableWriter<M> {
+    #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
-        self.write(buf)
-            .map_err(|e| io::Error::new(io::ErrorKind::OutOfMemory, e))
+        io::Write::write(&mut self.0, buf)
     }
 
+    #[inline]
     fn flush(&mut self) -> Result<(), io::Error> {
-        // Noop.
-        Ok(())
+        io::Write::flush(&mut self.0)
+    }
+}
+
+impl<M: StableMemory> io::Seek for StableWriter<M> {
+    #[inline]
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        io::Seek::seek(&mut self.0, pos)
+    }
+}
+
+impl<M: StableMemory> From<StableIO<M>> for StableWriter<M> {
+    fn from(io: StableIO<M>) -> Self {
+        Self(io)
     }
 }
 
@@ -253,41 +396,36 @@ impl<M: StableMemory> io::Write for BufferedStableWriter<M> {
     }
 }
 
-/// A reader to the stable memory.
-///
-/// Keeps an offset and reads off stable memory consecutively.
-pub struct StableReader<M: StableMemory = CanisterStableMemory> {
-    /// The offset of the next read.
-    offset: usize,
-
-    /// The capacity, in pages.
-    capacity: u32,
-
-    /// The stable memory to read data from.
-    memory: M,
+impl<M: StableMemory> io::Seek for BufferedStableWriter<M> {
+    #[inline]
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        io::Seek::seek(&mut self.inner, pos)
+    }
 }
 
+// A reader to the stable memory.
+///
+/// Keeps an offset and reads off stable memory consecutively.
+pub struct StableReader<M: StableMemory = CanisterStableMemory>(StableIO<M, u32>);
+
+#[allow(clippy::derivable_impls)]
 impl Default for StableReader {
     fn default() -> Self {
-        Self::with_memory(CanisterStableMemory::default(), 0)
+        Self(StableIO::default())
     }
 }
 
 impl<M: StableMemory> StableReader<M> {
     /// Creates a new `StableReader` which reads from the selected memory
+    #[inline]
     pub fn with_memory(memory: M, offset: usize) -> Self {
-        let capacity = memory.stable_size();
-
-        Self {
-            offset,
-            capacity,
-            memory,
-        }
+        Self(StableIO::<M, u32>::with_memory(memory, offset as u32))
     }
 
     /// Returns the offset of the reader
+    #[inline]
     pub fn offset(&self) -> usize {
-        self.offset
+        self.0.offset() as usize
     }
 
     /// Reads data from the stable memory location specified by an offset.
@@ -298,26 +436,29 @@ impl<M: StableMemory> StableReader<M> {
     /// 1. Create a StableReader
     /// 2. Write some data to the stable memory which causes it grow
     /// 3. call `read()` to read the newly written bytes
+    #[inline]
     pub fn read(&mut self, buf: &mut [u8]) -> Result<usize, StableMemoryError> {
-        let capacity_bytes = self.capacity as usize * WASM_PAGE_SIZE_IN_BYTES;
-        let read_buf = if buf.len() + self.offset > capacity_bytes {
-            if self.offset < capacity_bytes {
-                &mut buf[..capacity_bytes - self.offset]
-            } else {
-                return Err(StableMemoryError::OutOfBounds);
-            }
-        } else {
-            buf
-        };
-        self.memory.stable_read(self.offset as u32, read_buf);
-        self.offset += read_buf.len();
-        Ok(read_buf.len())
+        self.0.read(buf)
     }
 }
 
 impl<M: StableMemory> io::Read for StableReader<M> {
+    #[inline]
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, io::Error> {
-        self.read(buf).or(Ok(0)) // Read defines EOF to be success
+        io::Read::read(&mut self.0, buf)
+    }
+}
+
+impl<M: StableMemory> io::Seek for StableReader<M> {
+    #[inline]
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        io::Seek::seek(&mut self.0, pos)
+    }
+}
+
+impl<M: StableMemory> From<StableIO<M>> for StableReader<M> {
+    fn from(io: StableIO<M>) -> Self {
+        Self(io)
     }
 }
 
@@ -350,5 +491,12 @@ impl<M: StableMemory> BufferedStableReader<M> {
 impl<M: StableMemory> io::Read for BufferedStableReader<M> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.read(buf)
+    }
+}
+
+impl<M: StableMemory> io::Seek for BufferedStableReader<M> {
+    #[inline]
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        io::Seek::seek(&mut self.inner, pos)
     }
 }

--- a/src/ic-cdk/src/api/stable/private.rs
+++ b/src/ic-cdk/src/api/stable/private.rs
@@ -1,0 +1,52 @@
+//! Private module for traits that provide implementations for both u32 and u64 address space.
+
+use super::*;
+pub trait AddressSize {}
+impl AddressSize for u64 {}
+impl AddressSize for u32 {}
+
+// An internal helper trait to have stable memory API specific to an address size
+pub trait StableMemory_<A: AddressSize> {
+    fn stable_size_(&self) -> A;
+    fn stable_grow_(&self, new_pages: A) -> Result<A, StableMemoryError>;
+    fn stable_write_(&self, offset: A, buf: &[u8]);
+    fn stable_read_(&self, offset: A, buf: &mut [u8]);
+}
+
+// Blanket implementation for 32-bit addresses for any stable memory implementation
+impl<M: StableMemory> StableMemory_<u32> for M {
+    fn stable_read_(&self, offset: u32, buf: &mut [u8]) {
+        StableMemory::stable_read(self, offset, buf)
+    }
+
+    fn stable_grow_(&self, new_pages: u32) -> Result<u32, StableMemoryError> {
+        StableMemory::stable_grow(self, new_pages)
+    }
+
+    fn stable_size_(&self) -> u32 {
+        StableMemory::stable_size(self)
+    }
+
+    fn stable_write_(&self, offset: u32, buf: &[u8]) {
+        StableMemory::stable_write(self, offset, buf)
+    }
+}
+
+// Blanket implementation for 64-bit addresses for any stable memory implementation
+impl<M: super::StableMemory> StableMemory_<u64> for M {
+    fn stable_read_(&self, offset: u64, buf: &mut [u8]) {
+        StableMemory::stable64_read(self, offset, buf)
+    }
+
+    fn stable_grow_(&self, new_pages: u64) -> Result<u64, StableMemoryError> {
+        StableMemory::stable64_grow(self, new_pages)
+    }
+
+    fn stable_size_(&self) -> u64 {
+        StableMemory::stable64_size(self)
+    }
+
+    fn stable_write_(&self, offset: u64, buf: &[u8]) {
+        StableMemory::stable64_write(self, offset, buf)
+    }
+}


### PR DESCRIPTION
* Implement io::Seek
* Add StableIO structure that implements both io::Read, and io::Write

Co-authored-by: Dmitry Demin <dmitry.demin@outlook.com>

# Description

The change generalizes the StableWriter and StableReader APIs, while maintaining backwards compatibility, to add support for 64-bit std::io::Read/Write implementations as well as implementing the std::io::Seek implementation.

This greatly increases the utility of stable storage, allowing it to be used for more complex read/write patterns, as well as taking advantage of the greater capacity.

Fixes #333 and #334 

# How Has This Been Tested?

Unit tests + testing with the dscvr canister.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
