### PR TITLE
refactor: make `RbTree` more `const`

### DIFF
--- a/library/ic-certified-map/CHANGELOG.md
+++ b/library/ic-certified-map/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+Make `RbTree::new` and `RbTree::is_empty` both `const`.
+
 ## [0.3.1] - 2022-09-16
 ### Changed
 - Updated `sha2` dependency.

--- a/library/ic-certified-map/CHANGELOG.md
+++ b/library/ic-certified-map/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.3.2] - 2022-11-10
 ### Changed
 Make `RbTree::new` and `RbTree::is_empty` both `const`.
 

--- a/library/ic-certified-map/Cargo.toml
+++ b/library/ic-certified-map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-certified-map"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Merkleized map data structure."

--- a/library/ic-certified-map/src/rbtree.rs
+++ b/library/ic-certified-map/src/rbtree.rs
@@ -268,7 +268,7 @@ impl<'a, K, V> std::iter::Iterator for Iter<'a, K, V> {
 /// Implements mutable left-leaning red-black trees as defined in
 /// https://www.cs.princeton.edu/~rs/talks/LLRB/LLRB.pdf
 #[derive(Default, Clone)]
-pub struct RbTree<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> {
+pub struct RbTree<K, V> {
     root: NodeRef<K, V>,
 }
 
@@ -345,17 +345,19 @@ where
     }
 }
 
-impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> RbTree<K, V> {
+impl<K, V> RbTree<K, V> {
     /// Constructs a new empty tree.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self { root: None }
     }
 
     /// Returns true if the map is empty.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.root.is_none()
     }
+}
 
+impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> RbTree<K, V> {
     pub fn get(&self, key: &[u8]) -> Option<&V> {
         let mut root = self.root.as_ref();
         while let Some(n) = root {


### PR DESCRIPTION
# Description

Make `RbTree::new` and `RbTree::is_empty` const. Doing this requires removing the bounds from the `RbTree` declaration, but wider bounds and adding `const` are both backwards compatible.

# How Has This Been Tested?

`cargo test`

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
