### PR TITLE
fix: ic0 can build on non-wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           cargo build --workspace --exclude ic-cdk-e2e-tests --target wasm32-unknown-unknown
           cargo build --workspace --exclude ic-cdk-e2e-tests --target wasm32-unknown-unknown --release
+          cargo build --example=work
 
   test:
     name: cargo test

--- a/src/ic0/Cargo.toml
+++ b/src/ic0/Cargo.toml
@@ -20,3 +20,7 @@ syn = { version = "1.0", features = ["parsing", "full", "extra-traits"] }
 [[example]]
 name = "ic0build"
 path = "util/ic0build.rs"
+
+[[example]]
+name = "work"
+path = "util/work.rs"

--- a/src/ic0/Cargo.toml
+++ b/src/ic0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic0"
-version = "0.18.5"
+version = "0.18.6"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Internet Computer System API Binding."

--- a/src/ic0/src/ic0.rs
+++ b/src/ic0/src/ic0.rs
@@ -1,5 +1,6 @@
 // This file is generated from ic0.txt.
 // Don't manually modify it.
+#[cfg(target_arch = "wasm32")]
 #[link(wasm_import_module = "ic0")]
 extern "C" {
     pub fn msg_arg_data_size() -> i32;
@@ -58,3 +59,158 @@ extern "C" {
     pub fn debug_print(src: i32, size: i32);
     pub fn trap(src: i32, size: i32);
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(unused_variables)]
+mod non_wasm {
+    pub unsafe fn msg_arg_data_size() -> i32 {
+        panic!("msg_arg_data_size should only be called inside canisters.");
+    }
+    pub unsafe fn msg_arg_data_copy(dst: i32, offset: i32, size: i32) {
+        panic!("msg_arg_data_copy should only be called inside canisters.");
+    }
+    pub unsafe fn msg_caller_size() -> i32 {
+        panic!("msg_caller_size should only be called inside canisters.");
+    }
+    pub unsafe fn msg_caller_copy(dst: i32, offset: i32, size: i32) {
+        panic!("msg_caller_copy should only be called inside canisters.");
+    }
+    pub unsafe fn msg_reject_code() -> i32 {
+        panic!("msg_reject_code should only be called inside canisters.");
+    }
+    pub unsafe fn msg_reject_msg_size() -> i32 {
+        panic!("msg_reject_msg_size should only be called inside canisters.");
+    }
+    pub unsafe fn msg_reject_msg_copy(dst: i32, offset: i32, size: i32) {
+        panic!("msg_reject_msg_copy should only be called inside canisters.");
+    }
+    pub unsafe fn msg_reply_data_append(src: i32, size: i32) {
+        panic!("msg_reply_data_append should only be called inside canisters.");
+    }
+    pub unsafe fn msg_reply() {
+        panic!("msg_reply should only be called inside canisters.");
+    }
+    pub unsafe fn msg_reject(src: i32, size: i32) {
+        panic!("msg_reject should only be called inside canisters.");
+    }
+    pub unsafe fn msg_cycles_available() -> i64 {
+        panic!("msg_cycles_available should only be called inside canisters.");
+    }
+    pub unsafe fn msg_cycles_available128(dst: i32) {
+        panic!("msg_cycles_available128 should only be called inside canisters.");
+    }
+    pub unsafe fn msg_cycles_refunded() -> i64 {
+        panic!("msg_cycles_refunded should only be called inside canisters.");
+    }
+    pub unsafe fn msg_cycles_refunded128(dst: i32) {
+        panic!("msg_cycles_refunded128 should only be called inside canisters.");
+    }
+    pub unsafe fn msg_cycles_accept(max_amount: i64) -> i64 {
+        panic!("msg_cycles_accept should only be called inside canisters.");
+    }
+    pub unsafe fn msg_cycles_accept128(max_amount_high: i64, max_amount_low: i64, dst: i32) {
+        panic!("msg_cycles_accept128 should only be called inside canisters.");
+    }
+    pub unsafe fn canister_self_size() -> i32 {
+        panic!("canister_self_size should only be called inside canisters.");
+    }
+    pub unsafe fn canister_self_copy(dst: i32, offset: i32, size: i32) {
+        panic!("canister_self_copy should only be called inside canisters.");
+    }
+    pub unsafe fn canister_cycle_balance() -> i64 {
+        panic!("canister_cycle_balance should only be called inside canisters.");
+    }
+    pub unsafe fn canister_cycle_balance128(dst: i32) {
+        panic!("canister_cycle_balance128 should only be called inside canisters.");
+    }
+    pub unsafe fn canister_status() -> i32 {
+        panic!("canister_status should only be called inside canisters.");
+    }
+    pub unsafe fn msg_method_name_size() -> i32 {
+        panic!("msg_method_name_size should only be called inside canisters.");
+    }
+    pub unsafe fn msg_method_name_copy(dst: i32, offset: i32, size: i32) {
+        panic!("msg_method_name_copy should only be called inside canisters.");
+    }
+    pub unsafe fn accept_message() {
+        panic!("accept_message should only be called inside canisters.");
+    }
+    pub unsafe fn call_new(
+        callee_src: i32,
+        callee_size: i32,
+        name_src: i32,
+        name_size: i32,
+        reply_fun: i32,
+        reply_env: i32,
+        reject_fun: i32,
+        reject_env: i32,
+    ) {
+        panic!("call_new should only be called inside canisters.");
+    }
+    pub unsafe fn call_on_cleanup(fun: i32, env: i32) {
+        panic!("call_on_cleanup should only be called inside canisters.");
+    }
+    pub unsafe fn call_data_append(src: i32, size: i32) {
+        panic!("call_data_append should only be called inside canisters.");
+    }
+    pub unsafe fn call_cycles_add(amount: i64) {
+        panic!("call_cycles_add should only be called inside canisters.");
+    }
+    pub unsafe fn call_cycles_add128(amount_high: i64, amount_low: i64) {
+        panic!("call_cycles_add128 should only be called inside canisters.");
+    }
+    pub unsafe fn call_perform() -> i32 {
+        panic!("call_perform should only be called inside canisters.");
+    }
+    pub unsafe fn stable_size() -> i32 {
+        panic!("stable_size should only be called inside canisters.");
+    }
+    pub unsafe fn stable_grow(new_pages: i32) -> i32 {
+        panic!("stable_grow should only be called inside canisters.");
+    }
+    pub unsafe fn stable_write(offset: i32, src: i32, size: i32) {
+        panic!("stable_write should only be called inside canisters.");
+    }
+    pub unsafe fn stable_read(dst: i32, offset: i32, size: i32) {
+        panic!("stable_read should only be called inside canisters.");
+    }
+    pub unsafe fn stable64_size() -> i64 {
+        panic!("stable64_size should only be called inside canisters.");
+    }
+    pub unsafe fn stable64_grow(new_pages: i64) -> i64 {
+        panic!("stable64_grow should only be called inside canisters.");
+    }
+    pub unsafe fn stable64_write(offset: i64, src: i64, size: i64) {
+        panic!("stable64_write should only be called inside canisters.");
+    }
+    pub unsafe fn stable64_read(dst: i64, offset: i64, size: i64) {
+        panic!("stable64_read should only be called inside canisters.");
+    }
+    pub unsafe fn certified_data_set(src: i32, size: i32) {
+        panic!("certified_data_set should only be called inside canisters.");
+    }
+    pub unsafe fn data_certificate_present() -> i32 {
+        panic!("data_certificate_present should only be called inside canisters.");
+    }
+    pub unsafe fn data_certificate_size() -> i32 {
+        panic!("data_certificate_size should only be called inside canisters.");
+    }
+    pub unsafe fn data_certificate_copy(dst: i32, offset: i32, size: i32) {
+        panic!("data_certificate_copy should only be called inside canisters.");
+    }
+    pub unsafe fn time() -> i64 {
+        panic!("time should only be called inside canisters.");
+    }
+    pub unsafe fn performance_counter(counter_type: i32) -> i64 {
+        panic!("performance_counter should only be called inside canisters.");
+    }
+    pub unsafe fn debug_print(src: i32, size: i32) {
+        panic!("debug_print should only be called inside canisters.");
+    }
+    pub unsafe fn trap(src: i32, size: i32) {
+        panic!("trap should only be called inside canisters.");
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use non_wasm::*;

--- a/src/ic0/src/ic0.rs
+++ b/src/ic0/src/ic0.rs
@@ -62,6 +62,8 @@ extern "C" {
 
 #[cfg(not(target_arch = "wasm32"))]
 #[allow(unused_variables)]
+#[allow(clippy::missing_safety_doc)]
+#[allow(clippy::too_many_arguments)]
 mod non_wasm {
     pub unsafe fn msg_arg_data_size() -> i32 {
         panic!("msg_arg_data_size should only be called inside canisters.");

--- a/src/ic0/util/ic0build.rs
+++ b/src/ic0/util/ic0build.rs
@@ -149,6 +149,8 @@ extern "C" {{"#,
         r#"
 #[cfg(not(target_arch = "wasm32"))]
 #[allow(unused_variables)]
+#[allow(clippy::missing_safety_doc)]
+#[allow(clippy::too_many_arguments)]
 mod non_wasm{{"#,
     )
     .unwrap();

--- a/src/ic0/util/ic0build.rs
+++ b/src/ic0/util/ic0build.rs
@@ -118,20 +118,21 @@ fn main() {
         f,
         r#"// This file is generated from ic0.txt.
 // Don't manually modify it.
+#[cfg(target_arch = "wasm32")]
 #[link(wasm_import_module = "ic0")]
 extern "C" {{"#,
     )
     .unwrap();
 
-    for api in ic0.apis {
-        let fn_name = api.name;
-        let args = api.args;
+    for api in &ic0.apis {
+        let fn_name = &api.name;
+        let args = &api.args;
 
         let mut r = quote! {
             pub fn #fn_name(#(#args),*)
         };
 
-        if let Some(output) = api.output {
+        if let Some(output) = &api.output {
             r = quote! {
                 #r -> #output
             }
@@ -142,6 +143,48 @@ extern "C" {{"#,
     }
 
     writeln!(f, "}}").unwrap();
+
+    writeln!(
+        f,
+        r#"
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(unused_variables)]
+mod non_wasm{{"#,
+    )
+    .unwrap();
+
+    for api in &ic0.apis {
+        let fn_name = &api.name;
+        let args = &api.args;
+
+        let mut r = quote! {
+            pub unsafe fn #fn_name(#(#args),*)
+        };
+
+        if let Some(output) = &api.output {
+            r = quote! {
+                #r -> #output
+            }
+        }
+
+        let panic_str = format!("{} should only be called inside canisters.", fn_name);
+
+        r = quote! {
+        #r {
+            panic!(#panic_str);
+        }};
+        writeln!(f, "{}", r).unwrap();
+    }
+
+    writeln!(
+        f,
+        r#"}}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use non_wasm::*;
+"#
+    )
+    .unwrap();
 
     Command::new("cargo")
         .args(["fmt"])

--- a/src/ic0/util/work.rs
+++ b/src/ic0/util/work.rs
@@ -1,0 +1,6 @@
+// This file should compile on windows
+fn main() {
+    unsafe {
+        ic0::trap(0, 0);
+    }
+}


### PR DESCRIPTION
# Description

For some use cases of test, `ic-cdk` targets not `wasm32`. System API should still be linkable symbols.

# How Has This Been Tested?

`cargo build --example=work` which target host OS.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
