### PR TITLE
chore: Have a nicer error message on trap while decoding arguments

### DIFF
--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -599,7 +599,7 @@ pub fn arg_data<R: for<'a> ArgumentDecoder<'a>>() -> R {
     let bytes = arg_data_raw();
 
     match decode_args(&bytes) {
-        Err(e) => trap(&format!("{:?}", e)),
+        Err(e) => trap(&format!("failed to decode call arguments: {:?}", e)),
         Ok(r) => r,
     }
 }


### PR DESCRIPTION
# Description

Make it more clear what happened if the argument parsing traps. I just ran into an issue related to that and it took me longer than necessary to figure out the trap came from code generated by cdk macros.

Fixes # (issue)

# How Has This Been Tested?

n/a

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly. (not necessary)
- [x] I have made corresponding changes to the documentation. (not necessary)
