### PR TITLE
feat: Implement canister timers API

### DIFF
--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+- Implemented the canister timers API, located in module `ic_cdk::timer`.
+
 ## [0.6.6] - 2022-11-09
 
 ### Added

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -20,6 +20,16 @@ cfg-if = "1.0.0"
 serde = "1.0.110"
 serde_bytes = "0.11.7"
 ic0 = { path = "../ic0", version = "0.18.4" }
+slotmap = { version = "1.0.6", optional = true }
+futures = { version = "0.3.25", optional = true }
+
+[features]
+timers = ["dep:slotmap", "dep:futures"]
 
 [dev-dependencies]
 rstest = "0.12.0"
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "wasm32-unknown-unknown"
+rustc-args = ["--cfg=docsrs"]

--- a/src/ic-cdk/src/lib.rs
+++ b/src/ic-cdk/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! This crate provides building blocks for developing Internet Computer Canister.
 //!
@@ -13,6 +14,9 @@ pub mod api;
 mod futures;
 mod printer;
 pub mod storage;
+#[cfg(feature = "timers")]
+#[cfg_attr(docsrs, doc(cfg(feature = "timers")))]
+pub mod timer;
 
 pub use api::call::call;
 pub use api::call::notify;
@@ -57,8 +61,8 @@ pub fn spawn<F: 'static + std::future::Future<Output = ()>>(future: F) {
 #[cfg(target_arch = "wasm32")]
 #[macro_export]
 macro_rules! println {
-    ($fmt:expr) => (ic_cdk::print(format!($fmt)));
-    ($fmt:expr, $($arg:tt)*) => (ic_cdk::print(format!($fmt, $($arg)*)));
+    ($fmt:expr) => ($crate::print(format!($fmt)));
+    ($fmt:expr, $($arg:tt)*) => ($crate::print(format!($fmt, $($arg)*)));
 }
 
 /// Format and then print the formatted message
@@ -73,8 +77,8 @@ macro_rules! println {
 #[cfg(target_arch = "wasm32")]
 #[macro_export]
 macro_rules! eprintln {
-    ($fmt:expr) => (ic_cdk::print(format!($fmt)));
-    ($fmt:expr, $($arg:tt)*) => (ic_cdk::print(format!($fmt, $($arg)*)));
+    ($fmt:expr) => ($crate::print(format!($fmt)));
+    ($fmt:expr, $($arg:tt)*) => ($crate::print(format!($fmt, $($arg)*)));
 }
 
 /// Format and then print the formatted message

--- a/src/ic-cdk/src/timer.rs
+++ b/src/ic-cdk/src/timer.rs
@@ -1,0 +1,235 @@
+//! Provides simple timer functionality for executing a function in the future.
+
+use std::{cell::RefCell, cmp::Ordering, collections::BinaryHeap, mem, time::Duration};
+
+use futures::{stream::FuturesUnordered, StreamExt};
+use slotmap::{new_key_type, KeyData, SlotMap};
+
+// To ensure that tasks are removable seamlessly, there are two separate concepts here: tasks, for the actual function being called,
+// and timers, the scheduled execution of tasks. As this is an implementation detail, this does not affect the exported name TimerId,
+// which is more accurately a task ID. (The obvious solution to this, `pub use`, invokes a very silly compiler error.)
+
+thread_local! {
+    static TASKS: RefCell<SlotMap<TimerId, Task>> = RefCell::default();
+    static TIMERS: RefCell<BinaryHeap<Timer>> = RefCell::default();
+}
+
+enum Task {
+    Repeated {
+        func: Box<dyn FnMut()>,
+        interval: Duration,
+    },
+    Once(Box<dyn FnOnce()>),
+}
+
+impl Default for Task {
+    fn default() -> Self {
+        Self::Once(Box::new(|| ()))
+    }
+}
+
+new_key_type! {
+    /// Type returned by the [`set_timer`] and [`set_timer_interval`] functions. Pass to [`clear_timer`] to remove the timer.
+    pub struct TimerId;
+}
+
+struct Timer {
+    task: TimerId,
+    time: u64,
+}
+
+// Timers are sorted such that x > y if x should be executed _before_ y.
+
+impl Ord for Timer {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.time.cmp(&other.time).reverse()
+    }
+}
+
+impl PartialOrd for Timer {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for Timer {
+    fn eq(&self, other: &Self) -> bool {
+        self.time == other.time
+    }
+}
+
+impl Eq for Timer {}
+
+// This function is called by the IC at or after the timestamp provided to `ic0.global_timer_set`.
+#[export_name = "canister_global_timer"]
+extern "C" fn global_timer() {
+    crate::setup();
+    crate::spawn(async {
+        // All the calls are made first, according only to the timestamp we *started* with, and then all the results are awaited.
+        // This allows us to use the minimum number of execution rounds, as well as avoid any race conditions.
+        // The only thing that can happen interleavedly is canceling a task, which is seamless by design.
+        let mut call_futures = FuturesUnordered::new();
+        let now = crate::api::time();
+        TIMERS.with(|timers| {
+            // pop every timer that should have been completed by `now`, and get ready to run its task if it exists
+            loop {
+                let mut timers = timers.borrow_mut();
+                if let Some(timer) = timers.peek() {
+                    if timer.time <= now {
+                        let timer = timers.pop().unwrap();
+                        if TASKS.with(|tasks| tasks.borrow().contains_key(timer.task)) {
+                            // This is the biggest hack in this code. If a callback was called explicitly, and trapped, the rescheduling step wouldn't happen.
+                            // The closest thing to a catch_unwind that's available here is performing an inter-canister call to ourselves;
+                            // traps will be caught at the call boundary. This invokes a meaningful cycles cost, and should an alternative for catching traps
+                            // become available, this code should be rewritten.
+                            call_futures.push(async move {
+                                (
+                                    timer.task,
+                                    crate::call(
+                                        crate::api::id(),
+                                        "<ic-cdk internal> timer_executor",
+                                        (timer.task.0.as_ffi(),),
+                                    )
+                                    .await,
+                                )
+                            });
+                        }
+                        continue;
+                    }
+                }
+                break;
+            }
+        });
+        // run all the collected tasks, and clean up after them if necessary
+        while let Some((task_id, res)) = call_futures.next().await {
+            match res {
+                Ok(()) => {}
+                Err((code, msg)) => {
+                    crate::println!("in canister_global_timer: {code:?}: {msg}");
+                }
+            }
+            TASKS.with(|tasks| {
+                let mut tasks = tasks.borrow_mut();
+                if let Some(task) = tasks.get(task_id) {
+                    match task {
+                        // duplicated on purpose - it must be removed in the function call, to access self by value;
+                        // and it must be removed here, because it may have trapped and not actually been removed.
+                        // Luckily slotmap ops are equivalent to simple vector indexing.
+                        Task::Once(_) => {
+                            tasks.remove(task_id);
+                        }
+                        // reschedule any repeating tasks
+                        Task::Repeated { interval, .. } => {
+                            match now.checked_add(interval.as_nanos() as u64) {
+                                Some(time) => TIMERS.with(|timers| {
+                                    timers.borrow_mut().push(Timer {
+                                        task: task_id,
+                                        time,
+                                    })
+                                }),
+                                None => crate::println!(
+                                    "Failed to reschedule task (needed {interval}, currently {now}, and this would exceed u64::MAX)",
+                                    interval = interval.as_nanos(),
+                                ),
+                            }
+                        }
+                    }
+                }
+            });
+        }
+        update_ic0_timer();
+    });
+}
+
+/// Sets `func` to be executed later, after `delay`. Panics if `delay` + [`time()`][crate::api::time] is more than [`u64::MAX`] nanoseconds.
+///
+/// To cancel the timer before it executes, pass the returned `TimerId` to [`clear_timer`].
+///
+/// Note that timers are not persisted across canister upgrades.
+pub fn set_timer(delay: Duration, func: impl FnOnce() + 'static) -> TimerId {
+    let delay_ns = u64::try_from(delay.as_nanos()).expect(
+        "delay out of bounds (must be within `u64::MAX - ic_cdk::api::time()` nanoseconds)",
+    );
+    let scheduled_time = crate::api::time().checked_add(delay_ns).expect(
+        "delay out of bounds (must be within `u64::MAX - ic_cdk::api::time()` nanoseconds)",
+    );
+    let key = TASKS.with(|tasks| tasks.borrow_mut().insert(Task::Once(Box::new(func))));
+    TIMERS.with(|timers| {
+        timers.borrow_mut().push(Timer {
+            task: key,
+            time: scheduled_time,
+        });
+    });
+    update_ic0_timer();
+    key
+}
+
+/// Sets `func` to be executed every `interval`. Panics if `interval` + [`time()`][crate::api::time] is more than [`u64::MAX`] nanoseconds.
+///
+/// To cancel the interval timer, pass the returned `TimerId` to [`clear_timer`].
+///
+/// Note that timers are not persisted across canister upgrades.
+pub fn set_timer_interval(interval: Duration, func: impl FnMut() + 'static) -> TimerId {
+    let interval_ns = u64::try_from(interval.as_nanos()).expect(
+        "delay out of bounds (must be within `u64::MAX - ic_cdk::api::time()` nanoseconds)",
+    );
+    let scheduled_time = crate::api::time().checked_add(interval_ns).expect(
+        "delay out of bounds (must be within `u64::MAX - ic_cdk::api::time()` nanoseconds)",
+    );
+    let key = TASKS.with(|tasks| {
+        tasks.borrow_mut().insert(Task::Repeated {
+            func: Box::new(func),
+            interval,
+        })
+    });
+    TIMERS.with(|timers| {
+        timers.borrow_mut().push(Timer {
+            task: key,
+            time: scheduled_time,
+        })
+    });
+    update_ic0_timer();
+    key
+}
+
+/// Cancels an existing timer. Does nothing if the timer has already been canceled.
+pub fn clear_timer(id: TimerId) {
+    TASKS.with(|tasks| tasks.borrow_mut().remove(id));
+}
+
+/// Calls `ic0.global_timer_set` with the soonest timer in [`TIMERS`]. This is needed after inserting a timer, and after executing one.
+fn update_ic0_timer() {
+    TIMERS.with(|timers| {
+        let timers = timers.borrow();
+        let soonest_timer = timers.peek().map_or(0, |timer| timer.time);
+        unsafe { ic0::global_timer_set(soonest_timer as i64) };
+    });
+}
+
+#[export_name = "canister_update <ic-cdk internal> timer_executor"]
+extern "C" fn timer_executor() {
+    if crate::api::caller() != crate::api::id() {
+        crate::trap("This function is internal to ic-cdk and should not be called externally.");
+    }
+    let (task_id,) = crate::api::call::arg_data();
+    let task_id = TimerId(KeyData::from_ffi(task_id));
+    // We can't be holding `TASKS` when we call the function, because it may want to schedule more tasks.
+    // Instead, we swap the task out in order to call it, and then either swap it back in, or remove it.
+    let task = TASKS.with(|tasks| {
+        let mut tasks = tasks.borrow_mut();
+        tasks.get_mut(task_id).map(|task| mem::take(task))
+    });
+    if let Some(mut task) = task {
+        match task {
+            Task::Once(func) => {
+                func();
+                TASKS.with(|tasks| tasks.borrow_mut().remove(task_id));
+            }
+            Task::Repeated { ref mut func, .. } => {
+                func();
+                TASKS.with(|tasks| *tasks.borrow_mut().get_mut(task_id).unwrap() = task);
+            }
+        }
+    }
+    crate::api::call::reply(());
+}

--- a/src/ic0/ic0.txt
+++ b/src/ic0/ic0.txt
@@ -44,6 +44,8 @@ ic0.call_cycles_add : (amount : i64) -> ();                                 // U
 ic0.call_cycles_add128 : (amount_high : i64, amount_low: i64) -> ();        // U Ry Rt H
 ic0.call_perform : () -> ( err_code : i32 );                                // U Ry Rt H
 
+ic0.global_timer_set : (timestamp : i64) -> i64;                            // I U Ry Rt C H
+
 ic0.stable_size : () -> (page_count : i32);                                 // *
 ic0.stable_grow : (new_pages : i32) -> (old_page_count : i32);              // *
 ic0.stable_write : (offset : i32, src : i32, size : i32) -> ();             // *

--- a/src/ic0/src/ic0.rs
+++ b/src/ic0/src/ic0.rs
@@ -42,6 +42,7 @@ extern "C" {
     pub fn call_cycles_add(amount: i64);
     pub fn call_cycles_add128(amount_high: i64, amount_low: i64);
     pub fn call_perform() -> i32;
+    pub fn global_timer_set(timestamp: i64) -> i64;
     pub fn stable_size() -> i32;
     pub fn stable_grow(new_pages: i32) -> i32;
     pub fn stable_write(offset: i32, src: i32, size: i32);
@@ -163,6 +164,9 @@ mod non_wasm {
     }
     pub unsafe fn call_perform() -> i32 {
         panic!("call_perform should only be called inside canisters.");
+    }
+    pub unsafe fn global_timer_set(timestamp: i64) -> i64 {
+        panic!("global_timer_set should only be called inside canisters.");
     }
     pub unsafe fn stable_size() -> i32 {
         panic!("stable_size should only be called inside canisters.");


### PR DESCRIPTION
Implements SDK-828.

This PR implements the user-side functionality of the new function `ic0.global_timer_set`. Unlike other functions, it is not exposed directly as it is a single global timer, so for libraries to cooperate they must all be using the same task scheduler. 

It is additionally introduced behind a crate feature as it involves an inter-canister call to self, and if timers are not used by the canister, the canister does not need to be exported. 