### PR TITLE
feat: reverse dependency order

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,12 @@ crate-type = ["cdylib"]
 [dependencies]
 candid = "0.8.0" # this is required if you want to use the `#[import]` macro
 ic-cdk = "0.6"
-ic-cdk-macros = "0.6"
 ```
 
 Then in your rust source code:
 
 ```rust
-#[ic_cdk_macros::query]
+#[ic_cdk::query]
 fn print() {
     ic_cdk::print("Hello World from DFINITY!");
 }

--- a/docs/modules/rust-guide/examples/counter-tutorial/counter.rs
+++ b/docs/modules/rust-guide/examples/counter-tutorial/counter.rs
@@ -1,5 +1,4 @@
-use ic_cdk_macros::*;
-use ic_cdk::export::candid;
+use ic_cdk::{export::candid, init, query, update};
 
 static mut COUNTER: Option<candid::Nat> = None;
 

--- a/docs/modules/rust-guide/examples/intercanister-tutorial/profile-interoperation.rs
+++ b/docs/modules/rust-guide/examples/intercanister-tutorial/profile-interoperation.rs
@@ -1,4 +1,4 @@
-use ic_cdk_macros::*;
+use ic_cdk::{import, update};
 
 #[import(canister = "rust_profile")]
 struct ProfileCanister;

--- a/docs/modules/rust-guide/examples/mul-deps/deps-main.rs
+++ b/docs/modules/rust-guide/examples/mul-deps/deps-main.rs
@@ -1,5 +1,4 @@
-use ic_cdk_macros::*;
-use ic_cdk::export::candid;
+use ic_cdk::{import, update, export::candid};
 
 #[import(canister = "multiply_deps")]
 struct CounterCanister;

--- a/docs/modules/rust-guide/examples/profile-tutorial/profile.rs
+++ b/docs/modules/rust-guide/examples/profile-tutorial/profile.rs
@@ -4,8 +4,8 @@ use ic_cdk::{
         candid::{CandidType, Deserialize},
         Principal,
     },
+    query, update,
 };
-use ic_cdk_macros::*;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 

--- a/docs/modules/rust-guide/pages/rust-quickstart.adoc
+++ b/docs/modules/rust-guide/pages/rust-quickstart.adoc
@@ -148,7 +148,7 @@ The default project has a simple `+greet+` function that uses the {cdk-short-nam
 
 [source,rust]
 ----
-#[ic_cdk_macros::query]
+#[ic_cdk::query]
 fn greet(name: String) -> String {
     format!("Hello, {}!", name)
 }

--- a/e2e-tests/canisters/api_call.rs
+++ b/e2e-tests/canisters/api_call.rs
@@ -1,5 +1,4 @@
-use ic_cdk::api::call::ManualReply;
-use ic_cdk_macros::query;
+use ic_cdk::{api::call::ManualReply, query};
 
 #[query]
 fn instruction_counter() -> u64 {

--- a/e2e-tests/canisters/async.rs
+++ b/e2e-tests/canisters/async.rs
@@ -1,5 +1,4 @@
-use ic_cdk::export::Principal;
-use ic_cdk_macros::{query, update};
+use ic_cdk::{export::Principal, query, update};
 use lazy_static::lazy_static;
 use std::sync::RwLock;
 

--- a/e2e-tests/canisters/simple_kv_store.rs
+++ b/e2e-tests/canisters/simple_kv_store.rs
@@ -1,4 +1,4 @@
-use ic_cdk_macros::{post_upgrade, pre_upgrade, query, update};
+use ic_cdk::{post_upgrade, pre_upgrade, query, update};
 use serde_bytes::ByteBuf;
 use std::cell::RefCell;
 use std::collections::BTreeMap;

--- a/examples/asset_storage/src/asset_storage_rs/lib.rs
+++ b/examples/asset_storage/src/asset_storage_rs/lib.rs
@@ -1,5 +1,7 @@
-use ic_cdk::{api::call::ManualReply, export::Principal, storage};
-use ic_cdk_macros::*;
+use ic_cdk::{
+    api::call::ManualReply, export::Principal, init, post_upgrade, pre_upgrade, query, storage,
+    update,
+};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/examples/chess/src/chess_rs/lib.rs
+++ b/examples/chess/src/chess_rs/lib.rs
@@ -1,5 +1,4 @@
-use ic_cdk::export::candid::CandidType;
-use ic_cdk_macros::*;
+use ic_cdk::{export::candid::CandidType, query, update};
 use pleco::tools::Searcher;
 use serde::Serialize;
 use std::cell::RefCell;

--- a/examples/counter/src/counter_rs/lib.rs
+++ b/examples/counter/src/counter_rs/lib.rs
@@ -1,8 +1,8 @@
 use ic_cdk::{
     api::call::ManualReply,
     export::{candid, Principal},
+    init, query, update,
 };
-use ic_cdk_macros::*;
 use std::cell::{Cell, RefCell};
 
 thread_local! {

--- a/examples/counter/src/inter2_rs/lib.rs
+++ b/examples/counter/src/inter2_rs/lib.rs
@@ -1,5 +1,4 @@
-use ic_cdk::export::candid;
-use ic_cdk_macros::*;
+use ic_cdk::{import, update, export::candid};
 
 #[import(canister = "inter_mo")]
 struct CounterCanister;

--- a/examples/counter/src/inter2_rs/lib.rs
+++ b/examples/counter/src/inter2_rs/lib.rs
@@ -1,4 +1,4 @@
-use ic_cdk::{import, update, export::candid};
+use ic_cdk::{export::candid, import, update};
 
 #[import(canister = "inter_mo")]
 struct CounterCanister;

--- a/examples/counter/src/inter_rs/lib.rs
+++ b/examples/counter/src/inter_rs/lib.rs
@@ -1,4 +1,4 @@
-use ic_cdk::{update, import, export::candid};
+use ic_cdk::{export::candid, import, update};
 
 #[import(canister = "counter_mo")]
 struct CounterCanister;

--- a/examples/counter/src/inter_rs/lib.rs
+++ b/examples/counter/src/inter_rs/lib.rs
@@ -1,4 +1,4 @@
-use ic_cdk::{update, export::candid};
+use ic_cdk::{update, import, export::candid};
 
 #[import(canister = "counter_mo")]
 struct CounterCanister;

--- a/examples/counter/src/inter_rs/lib.rs
+++ b/examples/counter/src/inter_rs/lib.rs
@@ -1,5 +1,4 @@
-use ic_cdk::export::candid;
-use ic_cdk_macros::*;
+use ic_cdk::{update, export::candid};
 
 #[import(canister = "counter_mo")]
 struct CounterCanister;

--- a/examples/management_canister/src/caller/lib.rs
+++ b/examples/management_canister/src/caller/lib.rs
@@ -1,4 +1,4 @@
-use ic_cdk_macros::*;
+use ic_cdk::*;
 
 mod main {
     use super::*;

--- a/examples/print/src/print_rs/lib.rs
+++ b/examples/print/src/print_rs/lib.rs
@@ -1,4 +1,4 @@
-#[ic_cdk_macros::query]
+#[ic_cdk::query]
 fn print() {
     ic_cdk::print("Hello World");
 }

--- a/examples/profile/src/profile_inter_rs/lib.rs
+++ b/examples/profile/src/profile_inter_rs/lib.rs
@@ -1,4 +1,4 @@
-use ic_cdk_macros::*;
+use ic_cdk::{import, update};
 
 #[import(canister = "profile_rs")]
 struct ProfileCanister;

--- a/examples/profile/src/profile_rs/lib.rs
+++ b/examples/profile/src/profile_rs/lib.rs
@@ -4,8 +4,8 @@ use ic_cdk::{
         candid::{CandidType, Deserialize},
         Principal,
     },
+    query, update,
 };
-use ic_cdk_macros::*;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -19,7 +19,6 @@ proc-macro = true
 
 [dependencies]
 candid = "0.8.0"
-ic-cdk = { path = "../ic-cdk", version = "0.6" }
 syn = { version = "1.0.58", features = ["fold", "full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
@@ -28,3 +27,4 @@ serde = "1.0.111"
 
 [dev-dependencies]
 trybuild = "1.0"
+ic-cdk = { path = "../ic-cdk", version = "0.6" }

--- a/src/ic-cdk-macros/src/import.rs
+++ b/src/ic-cdk-macros/src/import.rs
@@ -82,8 +82,7 @@ impl candid::codegen::rust::RustBindings for RustLanguageBinding {
 
         // We check the validity of the canister_id early so it fails if the
         // ID isn't in the right text format.
-        let principal: ic_cdk::export::Principal =
-            ic_cdk::export::Principal::from_text(canister_id).unwrap();
+        let principal: candid::Principal = candid::Principal::from_text(canister_id).unwrap();
 
         Ok(format!(
             r#"

--- a/src/ic-cdk-macros/src/lib.rs
+++ b/src/ic-cdk-macros/src/lib.rs
@@ -71,7 +71,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use ic_cdk_macros::query;
+/// # use ic_cdk::query;
 /// #[query]
 /// fn query_function() {
 ///     // ...
@@ -82,7 +82,7 @@ where
 /// You can also specify the name of the exported function.
 ///
 /// ```rust
-/// # use ic_cdk_macros::*;
+/// # use ic_cdk::query;
 /// #[query(name = "some_name")]
 /// fn query_function() {
 ///     // ...
@@ -94,7 +94,7 @@ where
 /// When the guard function returns an error, the query function will not proceed.
 ///
 /// ```rust
-/// # use ic_cdk_macros::*;
+/// # use ic_cdk::query;
 /// fn guard_function() -> Result<(), String> {
 ///     // ...
 /// # unimplemented!()
@@ -113,7 +113,7 @@ where
 /// ```rust
 /// # fn calculate_result() {}
 /// # type MyResult = ();
-/// # use ic_cdk_macros::query;
+/// # use ic_cdk::query;
 /// use ic_cdk::api::call::{self, ManualReply};
 /// #[query(manual_reply = true)]
 /// fn query_function() -> ManualReply<MyResult> {
@@ -136,7 +136,7 @@ pub fn query(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// # Example
 ///
 /// ```rust
-/// # use ic_cdk_macros::update;
+/// # use ic_cdk::update;
 /// #[update]
 /// fn update_function() {
 ///     // ...
@@ -147,7 +147,7 @@ pub fn query(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// You can also specify the name of the exported function.
 ///
 /// ```rust
-/// # use ic_cdk_macros::*;
+/// # use ic_cdk::update;
 /// #[update(name = "some_name")]
 /// fn update_function() {
 ///     // ...
@@ -159,7 +159,7 @@ pub fn query(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// When the guard function returns an error, the update function will not proceed.
 ///
 /// ```rust
-/// # use ic_cdk_macros::*;
+/// # use ic_cdk::update;
 /// fn guard_function() -> Result<(), String> {
 ///     // ...
 /// # unimplemented!()
@@ -178,7 +178,7 @@ pub fn query(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// ```rust
 /// # fn calculate_result() {}
 /// # type MyResult = ();
-/// # use ic_cdk_macros::update;
+/// # use ic_cdk::update;
 /// use ic_cdk::api::call::{self, ManualReply};
 /// #[update(manual_reply = true)]
 /// fn update_function() -> ManualReply<MyResult> {
@@ -205,7 +205,7 @@ pub fn update(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// # Example
 ///
 /// ```rust
-/// # use ic_cdk_macros::init;
+/// # use ic_cdk::init;
 /// #[init]
 /// fn init_function() {
 ///     // ...
@@ -217,7 +217,7 @@ pub fn update(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// When the guard function returns an error, the init function will not proceed.
 ///
 /// ```rust
-/// # use ic_cdk_macros::*;
+/// # use ic_cdk::init;
 /// fn guard_function() -> Result<(), String> {
 ///     // ...
 /// # unimplemented!()
@@ -232,7 +232,7 @@ pub fn update(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// The init function may accept an argument, if that argument is a `CandidType`:
 ///
 /// ```rust
-/// # use ic_cdk_macros::*;
+/// # use ic_cdk::init;
 /// # use candid::*;
 ///
 /// #[derive(Clone, Debug, CandidType, Deserialize)]
@@ -267,7 +267,7 @@ pub fn init(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// # Example
 ///
 /// ```rust
-/// # use ic_cdk_macros::pre_upgrade;
+/// # use ic_cdk::pre_upgrade;
 /// #[pre_upgrade]
 /// fn pre_upgrade_function() {
 ///     // ...
@@ -279,7 +279,7 @@ pub fn init(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// When the guard function returns an error, the pre_upgrade function will not proceed.
 ///
 /// ```rust
-/// # use ic_cdk_macros::*;
+/// # use ic_cdk::pre_upgrade;
 /// fn guard_function() -> Result<(), String> {
 ///     // ...
 /// # unimplemented!()
@@ -307,7 +307,7 @@ pub fn pre_upgrade(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// # Example
 ///
 /// ```rust
-/// # use ic_cdk_macros::post_upgrade;
+/// # use ic_cdk::post_upgrade;
 /// #[post_upgrade]
 /// fn post_upgrade_function() {
 ///     // ...
@@ -319,7 +319,7 @@ pub fn pre_upgrade(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// When the guard function returns an error, the post_upgrade function will not proceed.
 ///
 /// ```rust
-/// # use ic_cdk_macros::*;
+/// # use ic_cdk::post_upgrade
 /// fn guard_function() -> Result<(), String> {
 ///     // ...
 /// # unimplemented!()
@@ -347,7 +347,7 @@ pub fn post_upgrade(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// # Example
 ///
 /// ```rust
-/// # use ic_cdk_macros::heartbeat;
+/// # use ic_cdk::heartbeat;
 /// #[heartbeat]
 /// fn heartbeat_function() {
 ///     // ...
@@ -359,7 +359,7 @@ pub fn post_upgrade(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// When the guard function returns an error, the heartbeat function will not proceed.
 ///
 /// ```rust
-/// # use ic_cdk_macros::*;
+/// # use ic_cdk::heartbeat;
 /// fn guard_function() -> Result<(), String> {
 ///     // ...
 /// # unimplemented!()
@@ -387,7 +387,7 @@ pub fn heartbeat(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// # Example
 ///
 /// ```rust
-/// # use ic_cdk_macros::inspect_message;
+/// # use ic_cdk::inspect_message;
 /// #[inspect_message]
 /// fn inspect_message_function() {
 ///     // ...
@@ -399,7 +399,7 @@ pub fn heartbeat(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// When the guard function returns an error, the inspect_message function will not proceed.
 ///
 /// ```rust
-/// # use ic_cdk_macros::*;
+/// # use ic_cdk::*;
 /// fn guard_function() -> Result<(), String> {
 ///     // ...
 /// # unimplemented!()
@@ -428,7 +428,7 @@ pub fn inspect_message(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// During `dfx build`, the imported canister will be correctly resolved.
 ///
 /// ```rust,ignore
-/// # use ic_cdk_macros::import;
+/// # use ic_cdk::import;
 /// #[import(canister = "some_canister")]
 /// struct SomeCanister;
 /// ```
@@ -436,7 +436,7 @@ pub fn inspect_message(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Or you can specify both the `canister_id` and the `candid_path`.
 ///
 /// ```rust,ignore
-/// # use ic_cdk_macros::import;
+/// # use ic_cdk::import;
 /// #[import(canister_id = "abcde-cai", candid_path = "path/to/some_canister.did")]
 /// struct SomeCanister;
 /// ```

--- a/src/ic-cdk-macros/src/lib.rs
+++ b/src/ic-cdk-macros/src/lib.rs
@@ -122,7 +122,7 @@ where
 /// }
 /// ```
 ///
-/// [`call::reply`]: ic_cdk::api::call::reply
+/// [`call::reply`]: https://docs.rs/ic-cdk/latest/ic_cdk/api/call/fn.reply.html
 #[proc_macro_attribute]
 pub fn query(attr: TokenStream, item: TokenStream) -> TokenStream {
     handle_debug_and_errors(export::ic_query, "ic_query", attr, item)

--- a/src/ic-cdk-macros/tests/compile_fail/lifecycle_functions_should_have_no_return.rs
+++ b/src/ic-cdk-macros/tests/compile_fail/lifecycle_functions_should_have_no_return.rs
@@ -1,4 +1,4 @@
-use ic_cdk_macros::*;
+use ic_cdk::{heartbeat, init, inspect_message, post_upgrade, pre_upgrade};
 
 #[init]
 fn init() -> u32 {}

--- a/src/ic-cdk-macros/tests/compile_fail/no_generic.rs
+++ b/src/ic-cdk-macros/tests/compile_fail/no_generic.rs
@@ -1,4 +1,4 @@
-use ic_cdk_macros::query;
+use ic_cdk::query;
 
 #[query]
 fn method<T>(_arg: T) {}

--- a/src/ic-cdk-macros/tests/compile_fail/no_self.rs
+++ b/src/ic-cdk-macros/tests/compile_fail/no_self.rs
@@ -1,4 +1,4 @@
-use ic_cdk_macros::query;
+use ic_cdk::query;
 
 #[query]
 fn method(self) {}

--- a/src/ic-cdk-macros/tests/compile_fail/only_function.rs
+++ b/src/ic-cdk-macros/tests/compile_fail/only_function.rs
@@ -1,4 +1,4 @@
-use ic_cdk_macros::query;
+use ic_cdk::query;
 
 #[query]
 struct S;

--- a/src/ic-cdk-macros/tests/pass/blank_methods.rs
+++ b/src/ic-cdk-macros/tests/pass/blank_methods.rs
@@ -1,4 +1,4 @@
-use ic_cdk_macros::*;
+use ic_cdk::{heartbeat, init, inspect_message, post_upgrade, pre_upgrade, query, update};
 
 #[init]
 fn init() {}

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -20,6 +20,7 @@ cfg-if = "1.0.0"
 serde = "1.0.110"
 serde_bytes = "0.11.7"
 ic0 = { path = "../ic0", version = "0.18.4" }
+ic-cdk-macros = { path = "../ic-cdk-macros", version = "0.6.7" }
 
 [dev-dependencies]
 rstest = "0.12.0"

--- a/src/ic-cdk/src/api/management_canister/http_request.rs
+++ b/src/ic-cdk/src/api/management_canister/http_request.rs
@@ -58,17 +58,21 @@ pub struct TransformContext {
 }
 
 impl TransformContext {
-    /// Construct `TransformType` from a transform function.
+    /// Construct `TransformContext` from a transform function.
     ///
     /// # example
     ///
-    /// ```ignore
-    /// #[ic_cdk_macros::query]
+    /// ```no_run
+    /// # use ic_cdk::api::management_canister::http_request::{TransformContext, TransformArgs, HttpResponse};
+    /// #[ic_cdk::query]
     /// fn my_transform(arg: TransformArgs) -> HttpResponse {
-    ///     ...
+    ///     // ...
+    /// # unimplemented!()
     /// }
-    ///
-    /// let transform = TransformType::from_transform_function(my_transform);
+    /// # fn main() {
+    /// # let context = vec![];
+    /// let transform = TransformContext::new(my_transform, context);
+    /// # }
     /// ```
     pub fn new<T>(func: T, context: Vec<u8>) -> Self
     where

--- a/src/ic-cdk/src/lib.rs
+++ b/src/ic-cdk/src/lib.rs
@@ -9,6 +9,9 @@
 #[cfg(target_feature = "atomics")]
 compile_error!("This version of the CDK does not support multithreading.");
 
+#[doc(inline)]
+pub use ic_cdk_macros::*;
+
 pub mod api;
 mod futures;
 mod printer;


### PR DESCRIPTION
This PR removes ic-cdk-macros's dependency on ic-cdk, which was only used for an intra-doc link and the reexported `Principal` more easily accessed from Candid. This enables ic-cdk to depend on ic-cdk-macros and reexport its macros; with this change, users no longer need to declare two dependencies for the full CDK.