### PR TITLE
feat: Implement composite queries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,9 +126,12 @@ jobs:
         with:
           toolchain: ${{ env.rust-version }}
           components: clippy
+      - name: Install protoc
+        run: |
+          sudo apt-get install -y protobuf-compiler
       - name: Run clippy
         run: |
-          cargo clippy --tests --benches --no-deps -- -D clippy::all
+          cargo clippy --tests --benches -- -D clippy::all
 
   aggregate:
     name: ci:required

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.rust-version }}
+      - name: Install protoc
+        run: |
+          sudo apt-get install -y protobuf-compiler
       - name: Run tests
         run: |
           cargo test --all-targets
@@ -125,7 +128,7 @@ jobs:
           components: clippy
       - name: Run clippy
         run: |
-          cargo clippy --tests --benches -- -D clippy::all
+          cargo clippy --tests --benches --no-deps -- -D clippy::all
 
   aggregate:
     name: ci:required

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -32,5 +32,5 @@ name = "api-call"
 path = "canisters/api_call.rs"
 
 [dev-dependencies]
-ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "02a4a828f2f4d3b1dcb93a84e60672a3f3fdb400" }
-candid_legecy = { package = "candid", version = "0.7.18" }
+ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "dcbf401f27d9b48354e68389c6d8293c4233b055" }
+candid = "0.8"

--- a/e2e-tests/canisters/async.rs
+++ b/e2e-tests/canisters/async.rs
@@ -57,6 +57,14 @@ fn greet(name: String) -> String {
     format!("Hello, {}", name)
 }
 
+#[query(composite = true)]
+async fn greet_self(greeter: Principal) -> String {
+    let (greeting,) = ic_cdk::api::call::call(greeter, "greet", ("myself",))
+        .await
+        .unwrap();
+    greeting
+}
+
 #[update]
 async fn invalid_reply_payload_does_not_trap() -> String {
     // We're decoding an integer instead of a string, decoding must fail.

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -173,7 +173,7 @@ fn test_composite_query() {
         .install_canister(wasm.clone(), vec![], None)
         .expect("failed to install sender");
     let receiver_id = env
-        .install_canister(wasm.clone(), vec![], None)
+        .install_canister(wasm, vec![], None)
         .expect("failed to install sender");
     let (greeting,): (String,) = query_candid(&env, sender_id, "greet_self", (receiver_id,))
         .expect("failed to query 'greet_self'");

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -1,7 +1,7 @@
 // use ic_cdk::export::candid::utils::{decode_args, encode_args, ArgumentDecoder, ArgumentEncoder};
 // use ic_cdk::export::candid::Encode;
-use candid_legecy::utils::{decode_args, encode_args, ArgumentDecoder, ArgumentEncoder};
-use candid_legecy::Encode;
+use candid::utils::{decode_args, encode_args, ArgumentDecoder, ArgumentEncoder};
+use candid::Encode;
 use ic_cdk_e2e_tests::cargo_build_canister;
 use ic_state_machine_tests::{CanisterId, ErrorCode, StateMachine, UserError, WasmResult};
 use serde_bytes::ByteBuf;
@@ -163,6 +163,21 @@ fn test_notify_calls() {
     let (n,): (u64,) = query_candid(&env, receiver_id, "notifications_received", ())
         .expect("failed to query 'notifications_received'");
     assert_eq!(n, 1);
+}
+
+#[test]
+fn test_composite_query() {
+    let env = StateMachine::new();
+    let wasm = cargo_build_canister("async");
+    let sender_id = env
+        .install_canister(wasm.clone(), vec![], None)
+        .expect("failed to install sender");
+    let receiver_id = env
+        .install_canister(wasm.clone(), vec![], None)
+        .expect("failed to install sender");
+    let (greeting,): (String,) = query_candid(&env, sender_id, "greet_self", (receiver_id,))
+        .expect("failed to query 'greet_self'");
+    assert_eq!(greeting, "Hello, myself");
 }
 
 #[test]

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-macros"
-version = "0.6.7"
+version = "0.6.8"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit macros."

--- a/src/ic-cdk-macros/src/export.rs
+++ b/src/ic-cdk-macros/src/export.rs
@@ -12,6 +12,8 @@ struct ExportAttributes {
     pub guard: Option<String>,
     #[serde(default)]
     pub manual_reply: bool,
+    #[serde(default)]
+    pub composite: bool,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -135,6 +137,11 @@ fn dfn_macro(
 
     let export_name = if method.is_lifecycle() {
         format!("canister_{}", method)
+    } else if method == MethodType::Query && attrs.composite {
+        format!(
+            "canister_composite_query {}",
+            attrs.name.unwrap_or_else(|| name.to_string())
+        )
     } else {
         format!(
             "canister_{0} {1}",

--- a/src/ic-cdk-macros/src/lib.rs
+++ b/src/ic-cdk-macros/src/lib.rs
@@ -109,7 +109,7 @@ where
 /// To be able to make inter-canister calls from a query call, it must be a *composite* query (which cannot be executed in replicated mode).
 ///
 /// ```rust
-/// # use ic_cdk_macros::*;
+/// # use ic_cdk::query;
 /// # fn wallet_canister_principal() -> ic_cdk::export::Principal { unimplemented!() }
 /// #[query(composite = true)]
 /// async fn composite_query_function() {

--- a/src/ic-cdk-macros/src/lib.rs
+++ b/src/ic-cdk-macros/src/lib.rs
@@ -106,6 +106,17 @@ where
 /// }
 /// ```
 ///
+/// To be able to make inter-canister calls from a query call, it must be a *composite* query (which cannot be executed in replicated mode).
+///
+/// ```rust
+/// # use ic_cdk_macros::*;
+/// # fn wallet_canister_principal() -> ic_cdk::export::Principal { unimplemented!() }
+/// #[query(composite = true)]
+/// async fn composite_query_function() {
+///    let (wallet_name,): (Option<String>,) = ic_cdk::call(wallet_canister_principal(), "name", ()).await.unwrap();
+/// }
+/// ```
+///
 /// If you would rather call the [`call::reply`] function than return a value,
 /// you will need to set `manual_reply` to `true` so that the canister does not
 /// trap.

--- a/src/ic-cdk-macros/tests/pass/blank_methods.rs
+++ b/src/ic-cdk-macros/tests/pass/blank_methods.rs
@@ -15,6 +15,9 @@ fn update() {}
 #[query]
 fn query() {}
 
+#[query(composite = true)]
+fn composite_query() {}
+
 #[heartbeat]
 fn heartbeat() {}
 

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.6.8] - 2022-11-28
+
 ### Added
 
 - Added composite queries via `#[query(composite = true)]`. (#344)

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+- Added composite queries via `#[query(composite = true)]`. (#344)
+
+  Composite queries cannot be run as update calls, but can make inter-canister calls to other query functions.
+
 ## [0.6.7] - 2022-11-16
 
 ### Changed

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.6.7"
+version = "0.6.8"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit for the Internet Computer."

--- a/src/ic0/Cargo.toml
+++ b/src/ic0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic0"
-version = "0.18.6"
+version = "0.18.7"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Internet Computer System API Binding."


### PR DESCRIPTION
This PR adds support for composite queries, via `#[query(composite = true)]`. Composite queries can call other query functions, but cannot be called in replicated mode.

For more details about composite queries, please check these forum threads:
* https://forum.dfinity.org/t/proposal-composite-queries/15979
* https://forum.dfinity.org/t/inter-canister-query-calls-community-consideration/6754

Implements SDK-829.