### PR TITLE
refactor: change from pleco to tanton

### DIFF
--- a/examples/asset_storage/src/asset_storage_rs/Cargo.toml
+++ b/examples/asset_storage/src/asset_storage_rs/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "asset_storage_rs"
 version = "0.1.0"
-authors = ["Hans Larsen <hans@larsen.online>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/chess/src/chess_rs/Cargo.toml
+++ b/examples/chess/src/chess_rs/Cargo.toml
@@ -15,3 +15,4 @@ ic-cdk = { path = "../../../../src/ic-cdk" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros" }
 serde = "1.0.111"
 tanton = "1.0.0"
+getrandom = { version = "0.2", features = ["js"] } # tanton requires this to compile on wasm target

--- a/examples/chess/src/chess_rs/Cargo.toml
+++ b/examples/chess/src/chess_rs/Cargo.toml
@@ -16,5 +16,4 @@ ic-cdk = { path = "../../../../src/ic-cdk" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros" }
 serde = "1.0.111"
 tanton = "1.0.0"
-imp = "0.1.0"
 getrandom = { version = "0.2", features = ["js"] }

--- a/examples/chess/src/chess_rs/Cargo.toml
+++ b/examples/chess/src/chess_rs/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "chess_rs"
 version = "0.1.0"
-authors = ["Hans Larsen <hans@larsen.online>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -16,4 +15,3 @@ ic-cdk = { path = "../../../../src/ic-cdk" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros" }
 serde = "1.0.111"
 tanton = "1.0.0"
-getrandom = { version = "0.2", features = ["js"] }

--- a/examples/chess/src/chess_rs/Cargo.toml
+++ b/examples/chess/src/chess_rs/Cargo.toml
@@ -16,3 +16,5 @@ ic-cdk = { path = "../../../../src/ic-cdk" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros" }
 serde = "1.0.111"
 tanton = "1.0.0"
+imp = "0.1.0"
+getrandom = { version = "0.2", features = ["js"] }

--- a/examples/chess/src/chess_rs/Cargo.toml
+++ b/examples/chess/src/chess_rs/Cargo.toml
@@ -15,4 +15,4 @@ ic-cdk = { path = "../../../../src/ic-cdk" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros" }
 serde = "1.0.111"
 tanton = "1.0.0"
-getrandom = { version = "0.2", features = ["js"] } # tanton requires this to compile on wasm target
+getrandom = { version = "0.2", features = ["custom"] } # tanton requires this to compile on wasm target

--- a/examples/chess/src/chess_rs/Cargo.toml
+++ b/examples/chess/src/chess_rs/Cargo.toml
@@ -15,4 +15,4 @@ candid = "0.8.0"
 ic-cdk = { path = "../../../../src/ic-cdk" }
 ic-cdk-macros = { path = "../../../../src/ic-cdk-macros" }
 serde = "1.0.111"
-pleco = "0.5.0"
+tanton = "1.0.0"

--- a/examples/chess/src/chess_rs/getrandom_fail.rs
+++ b/examples/chess/src/chess_rs/getrandom_fail.rs
@@ -1,0 +1,11 @@
+use core::num::NonZeroU32;
+use getrandom::{register_custom_getrandom, Error};
+
+// Some application-specific error code
+const MY_CUSTOM_ERROR_CODE: u32 = Error::CUSTOM_START + 42;
+pub fn always_fail(_buf: &mut [u8]) -> Result<(), Error> {
+    let code = NonZeroU32::new(MY_CUSTOM_ERROR_CODE).unwrap();
+    Err(Error::from(code))
+}
+
+register_custom_getrandom!(always_fail);

--- a/examples/chess/src/chess_rs/lib.rs
+++ b/examples/chess/src/chess_rs/lib.rs
@@ -1,5 +1,5 @@
 use ic_cdk::{export::candid::CandidType, query, update};
-use pleco::tools::Searcher;
+use tanton::tools::Searcher;
 use serde::Serialize;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
@@ -12,7 +12,7 @@ pub struct Game {
 }
 
 pub struct GameInternal {
-    pub board: pleco::Board,
+    pub board: tanton::Board,
 }
 
 thread_local! {
@@ -25,7 +25,7 @@ fn new(name: String, white: bool) {
         game_store.borrow_mut().insert(
             name.clone(),
             GameInternal {
-                board: pleco::Board::start_pos(),
+                board: tanton::Board::start_pos(),
             },
         );
     });
@@ -62,7 +62,7 @@ fn ai_move(name: String) {
             .unwrap_or_else(|| panic!("Game {} does not exist.", name));
 
         let b = game.board.shallow_clone();
-        let m = pleco::bots::MiniMaxSearcher::best_move(b, 3);
+        let m = tanton::bots::MiniMaxSearcher::best_move(b, 3);
 
         game.board.apply_move(m);
     });

--- a/examples/chess/src/chess_rs/lib.rs
+++ b/examples/chess/src/chess_rs/lib.rs
@@ -1,8 +1,10 @@
 use ic_cdk::{export::candid::CandidType, query, update};
-use tanton::tools::Searcher;
 use serde::Serialize;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use tanton::tools::Searcher;
+
+mod getrandom_fail;
 
 type GameStore = BTreeMap<String, GameInternal>;
 

--- a/examples/counter/src/counter_rs/Cargo.toml
+++ b/examples/counter/src/counter_rs/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "counter_rs"
 version = "0.1.0"
-authors = ["Hans Larsen <hans@larsen.online>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/counter/src/inter2_rs/Cargo.toml
+++ b/examples/counter/src/inter2_rs/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "inter2_rs"
 version = "0.1.0"
-authors = ["Hans Larsen <hans@larsen.online>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/counter/src/inter_rs/Cargo.toml
+++ b/examples/counter/src/inter_rs/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "inter_rs"
 version = "0.1.0"
-authors = ["Hans Larsen <hans@larsen.online>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/print/src/print_rs/Cargo.toml
+++ b/examples/print/src/print_rs/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "print_rs"
 version = "0.1.0"
-authors = ["Hans Larsen <hans@larsen.online>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/profile/src/profile_inter_rs/Cargo.toml
+++ b/examples/profile/src/profile_inter_rs/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "profile_inter_rs"
 version = "0.1.0"
-authors = ["Hans Larsen <hans@larsen.online>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/profile/src/profile_rs/Cargo.toml
+++ b/examples/profile/src/profile_rs/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "profile_rs"
 version = "0.1.0"
-authors = ["Hans Larsen <hans@larsen.online>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Refactored
+
+- Change from pleco to tanton for the chess library in the chess example. (#345)
+
 ## [0.6.7] - 2022-11-16
 
 ### Changed


### PR DESCRIPTION
# Description

Pleco is no longer maintained, it has outstanding issues and hasn't had a new contribution in two and half years.  
[Tanton](https://github.com/chase-manning/tanton) is a fork of Pleco that is backward compatable and actively maintained.  
This PR changes from using Pleco to using Tanton.

# How Has This Been Tested?

All of the Pleco tests were kept with Tanton and all are passing on `stable`, `alpha` and `nightly` versions of cargo.

The CI build should run in this PR so should test everything needed from the `cdk-rs` side.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
