### PR TITLE
feat: add ic0.canister_version to cdk-rs

### DIFF
--- a/src/ic-cdk/src/api/mod.rs
+++ b/src/ic-cdk/src/api/mod.rs
@@ -127,3 +127,9 @@ pub fn performance_counter(counter_type: u32) -> u64 {
     // SAFETY: ic0.performance_counter is always safe to call.
     unsafe { ic0::performance_counter(counter_type as i32) as u64 }
 }
+
+/// Get the value of canister version.
+pub fn canister_version() -> u64 {
+    // SAFETY: ic0.canister_version is always safe to call.
+    unsafe { ic0::canister_version() as u64 }
+}

--- a/src/ic0/ic0.txt
+++ b/src/ic0/ic0.txt
@@ -23,12 +23,13 @@ ic0.canister_self_copy : (dst : i32, offset : i32, size : i32) -> ();       // *
 ic0.canister_cycle_balance : () -> i64;                                     // *
 ic0.canister_cycle_balance128 : (dst : i32) -> ();                          // *
 ic0.canister_status : () -> i32;                                            // *
+ic0.canister_version : () -> i64;                                           // *
 
 ic0.msg_method_name_size : () -> i32;                                       // F
 ic0.msg_method_name_copy : (dst : i32, offset : i32, size : i32) -> ();     // F
 ic0.accept_message : () -> ();                                              // F
 
-ic0.call_new :                                                              // U Ry Rt H
+ic0.call_new :                                                              // U Ry Rt T
   ( callee_src  : i32,
     callee_size : i32,
     name_src : i32,
@@ -38,13 +39,11 @@ ic0.call_new :                                                              // U
     reject_fun : i32,
     reject_env : i32
   ) -> ();
-ic0.call_on_cleanup : (fun : i32, env : i32) -> ();                         // U Ry Rt H
-ic0.call_data_append : (src : i32, size : i32) -> ();                       // U Ry Rt H
-ic0.call_cycles_add : (amount : i64) -> ();                                 // U Ry Rt H
-ic0.call_cycles_add128 : (amount_high : i64, amount_low: i64) -> ();        // U Ry Rt H
-ic0.call_perform : () -> ( err_code : i32 );                                // U Ry Rt H
-
-ic0.global_timer_set : (timestamp : i64) -> i64;                            // I U Ry Rt C H
+ic0.call_on_cleanup : (fun : i32, env : i32) -> ();                         // U Ry Rt T
+ic0.call_data_append : (src : i32, size : i32) -> ();                       // U Ry Rt T
+ic0.call_cycles_add : (amount : i64) -> ();                                 // U Ry Rt T
+ic0.call_cycles_add128 : (amount_high : i64, amount_low: i64) -> ();        // U Ry Rt T
+ic0.call_perform : () -> ( err_code : i32 );                                // U Ry Rt T
 
 ic0.stable_size : () -> (page_count : i32);                                 // *
 ic0.stable_grow : (new_pages : i32) -> (old_page_count : i32);              // *
@@ -55,12 +54,13 @@ ic0.stable64_grow : (new_pages : i64) -> (old_page_count : i64);            // *
 ic0.stable64_write : (offset : i64, src : i64, size : i64) -> ();           // *
 ic0.stable64_read : (dst : i64, offset : i64, size : i64) -> ();            // *
 
-ic0.certified_data_set : (src: i32, size: i32) -> ();                       // I G U Ry Rt H
+ic0.certified_data_set : (src: i32, size: i32) -> ();                       // I G U Ry Rt T
 ic0.data_certificate_present : () -> i32;                                   // *
 ic0.data_certificate_size : () -> i32;                                      // *
 ic0.data_certificate_copy : (dst: i32, offset: i32, size: i32) -> ();       // *
 
 ic0.time : () -> (timestamp : i64);                                         // *
+ic0.global_timer_set : (timestamp : i64) -> i64;                            // I U Ry Rt C T
 ic0.performance_counter : (counter_type : i32) -> (counter : i64);          // * s
 
 ic0.debug_print : (src : i32, size : i32) -> ();                            // * s

--- a/src/ic0/src/ic0.rs
+++ b/src/ic0/src/ic0.rs
@@ -24,6 +24,7 @@ extern "C" {
     pub fn canister_cycle_balance() -> i64;
     pub fn canister_cycle_balance128(dst: i32);
     pub fn canister_status() -> i32;
+    pub fn canister_version() -> i64;
     pub fn msg_method_name_size() -> i32;
     pub fn msg_method_name_copy(dst: i32, offset: i32, size: i32);
     pub fn accept_message();
@@ -128,6 +129,9 @@ mod non_wasm {
     }
     pub unsafe fn canister_status() -> i32 {
         panic!("canister_status should only be called inside canisters.");
+    }
+    pub unsafe fn canister_version() -> i64 {
+        panic!("canister_version should only be called inside canisters.");
     }
     pub unsafe fn msg_method_name_size() -> i32 {
         panic!("msg_method_name_size should only be called inside canisters.");


### PR DESCRIPTION
Introduces new system API call `ic0.canister_version` specified in Interface Spec [here](https://ic-interface-spec.netlify.app/#system-api-canister-version).
