### PR TITLE
fix: handle case where a repeated task is cancelled

### DIFF
--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+- Handle scenario where a repeated canister timer task is cancelled. (#356) 
+
 ### Refactored
 
 - Change from pleco to tanton for the chess library in the chess example. (#345)

--- a/src/ic-cdk/src/timer.rs
+++ b/src/ic-cdk/src/timer.rs
@@ -227,7 +227,13 @@ extern "C" fn timer_executor() {
             }
             Task::Repeated { ref mut func, .. } => {
                 func();
-                TASKS.with(|tasks| *tasks.borrow_mut().get_mut(task_id).unwrap() = task);
+                TASKS.with(|tasks| {
+                    // We need to check that the task still exists since it may have been cleared
+                    // during the processing of `func`
+                    if let Some(t) = tasks.borrow_mut().get_mut(task_id) {
+                        *t = task;
+                    }
+                });
             }
         }
     }


### PR DESCRIPTION
# Description

Prior to this PR, the canister timers code would assume that a repeatable task still exists after it has been executed. But sometimes developers may only want to run a repeatable task until some end point, eg. run the repeatable task until a queue has been processed, then cancel the task.
When this happens, the code panics due to it trying to `unwrap` an `Option` of a task which no longer exists.
This PR replaces the `unwrap` with an `if let Some(...)`, preventing the code from panicking.

# How Has This Been Tested?

I have tested this locally with the scenario mentioned above where I have a queue of events which are processed by a repeated task which is cancelled once the queue is empty.

# Checklist:

- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
