### PR TITLE
feat: impl From<Principal> for Subaccount

### DIFF
--- a/library/ic-ledger-types/src/lib.rs
+++ b/library/ic-ledger-types/src/lib.rs
@@ -123,6 +123,16 @@ impl fmt::Display for Tokens {
 )]
 pub struct Subaccount(pub [u8; 32]);
 
+impl From<Principal> for Subaccount {
+    fn from(principal: Principal) -> Self {
+        let mut subaccount = [0; 32];
+        let principal = principal.as_slice();
+        subaccount[0] = principal.len().try_into().unwrap();
+        subaccount[1..1 + principal.len()].copy_from_slice(principal);
+        Subaccount(subaccount)
+    }
+}
+
 /// AccountIdentifier is a 32-byte array.
 /// The first 4 bytes is big-endian encoding of a CRC32 checksum of the last 28 bytes.
 #[derive(

--- a/library/ic-ledger-types/src/lib.rs
+++ b/library/ic-ledger-types/src/lib.rs
@@ -566,4 +566,15 @@ mod tests {
             Principal::from_text("rkp4c-7iaaa-aaaaa-aaaca-cai").unwrap()
         );
     }
+
+    #[test]
+    fn principal_to_subaccount() {
+        // The account generated is the account used to top up canister 4bkt6-4aaaa-aaaaf-aaaiq-cai
+        let principal = Principal::from_text("4bkt6-4aaaa-aaaaf-aaaiq-cai").unwrap();
+        let subaccount = Subaccount::from(principal);
+        assert_eq!(
+            AccountIdentifier::new(&MAINNET_CYCLES_MINTING_CANISTER_ID, &subaccount).to_string(),
+            "d8646d1cbe44002026fa3e0d86d51a560b1c31d669bc8b7f66421c1b2feaa59f"
+        )
+    }
 }

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+- Implemented `From<Principal>` for `Subaccount` (#361)
+
 ### Refactored
 
 - Change from pleco to tanton for the chess library in the chess example. (#345)


### PR DESCRIPTION
# Description

This PR makes it trivial to convert a Principal into a Subaccount.
Principals are often used as Subaccounts to differentiate between funds controlled by the same Principal (eg. when creating a canister the Subaccount is the Principal of the new canister's controller).

# How Has This Been Tested?

I used this forked version to successfully top up a canister using the canister's Principal as the Subaccount.
I have also added a unit test.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
