### PR TITLE
fix: RUN-527: retry timers execution

### DIFF
--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -250,6 +250,31 @@ fn test_timers_can_cancel_themselves() {
     );
 }
 
+#[test]
+fn test_scheduling_many_timers() {
+    // Must be more than the queue limit (500)
+    let timers_to_schedule = 1_000;
+    let env = StateMachine::new();
+    let wasm = cargo_build_canister("timers");
+    let canister_id = env.install_canister(wasm, vec![], None).unwrap();
+
+    let () = call_candid(
+        &env,
+        canister_id,
+        "schedule_n_timers",
+        (timers_to_schedule,),
+    )
+    .expect("Error calling schedule_n_timers");
+
+    // Up to 500 timers will be executed per round
+    advance_seconds(&env, timers_to_schedule / 500);
+
+    let (executed_timers,): (u32,) = query_candid(&env, canister_id, "executed_timers", ())
+        .expect("Error querying executed_timers");
+
+    assert_eq!(timers_to_schedule, executed_timers);
+}
+
 fn advance_seconds(env: &StateMachine, seconds: u32) {
     for _ in 0..seconds {
         env.advance_time(Duration::from_secs(1));

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+
+- Retry timers execution after a transient system error.
+
 ## [0.6.10] - 2023-01-20
 
 ### Added


### PR DESCRIPTION
# Description

This MR retries timers execution after a transient system error.

Fixes RUN-527
