### PR TITLE
chore: first release ic-cdk-timers

### DIFF
--- a/library/ic-ledger-types/CHANGELOG.md
+++ b/library/ic-ledger-types/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.3.0] - 2023-02-03
+### Changed
+- Upgrade `ic-cdk` to v0.7.
+
 ## [0.2.1] - 2023-01-20
 
 ### Added

--- a/library/ic-ledger-types/Cargo.toml
+++ b/library/ic-ledger-types/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.60.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ic-cdk = { path = "../../src/ic-cdk", version = "0.6" }
+ic-cdk = { path = "../../src/ic-cdk", version = "0.7" }
 candid = "0.8.0"
 crc32fast = "1.2.0"
 hex = "0.4"

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -27,4 +27,4 @@ serde = "1.0.111"
 
 [dev-dependencies]
 trybuild = "1.0"
-ic-cdk = { path = "../ic-cdk", version = "0.6" }
+ic-cdk = { path = "../ic-cdk", version = "0.7" }

--- a/src/ic-cdk-timers/CHANGELOG.md
+++ b/src/ic-cdk-timers/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.1.0] - 2023-02-03
+
 ### Added
 
 - Initial release of the `ic-cdk-timers` library.

--- a/src/ic-cdk-timers/Cargo.toml
+++ b/src/ic-cdk-timers/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/dfinity/cdk-rs"
 rust-version = "1.60.0"
 
 [dependencies]
-ic-cdk = { path = "../../src/ic-cdk", version = "0.6" }
+ic-cdk = { path = "../../src/ic-cdk", version = "0.7" }
 serde = "1.0.110"
 serde_bytes = "0.11.7"
 ic0 = { path = "../ic0", version = "0.18.9" }

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.7.0] - 2023-02-03
+
 ### Changed
 
 - The timers API is not a feature anymore, it moved into a separate library, `ic-cdk-timers`. (#368)

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.6.10"
+version = "0.7.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit for the Internet Computer."


### PR DESCRIPTION
ic-cdk-timers v0.1.0
ic-cdk v0.7.0
ic-ledger-types v0.3.0


