### PR TITLE
feat: WASM_PAGE_SIZE_IN_BYTES made pub

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,7 +12,7 @@ concurrency:
 
 env:
   rust-version: 1.66.1
-  dfx-version: 0.12.0-beta.6
+  dfx-version: 0.13.1
 
 jobs:
   test:

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Added
+- `WASM_PAGE_SIZE_IN_BYTES` made `pub`.
+
 ## [0.7.3] = 2023-03-01
 
 ### Fixed

--- a/src/ic-cdk/src/api/stable/mod.rs
+++ b/src/ic-cdk/src/api/stable/mod.rs
@@ -10,7 +10,7 @@ mod tests;
 pub use canister::CanisterStableMemory;
 use std::{error, fmt, io};
 
-const WASM_PAGE_SIZE_IN_BYTES: usize = 64 * 1024; // 64KB
+pub const WASM_PAGE_SIZE_IN_BYTES: usize = 64 * 1024; // 64KB
 
 static CANISTER_STABLE_MEMORY: CanisterStableMemory = CanisterStableMemory {};
 

--- a/src/ic-cdk/src/api/stable/mod.rs
+++ b/src/ic-cdk/src/api/stable/mod.rs
@@ -10,6 +10,7 @@ mod tests;
 pub use canister::CanisterStableMemory;
 use std::{error, fmt, io};
 
+/// WASM page size in bytes.
 pub const WASM_PAGE_SIZE_IN_BYTES: usize = 64 * 1024; // 64KB
 
 static CANISTER_STABLE_MEMORY: CanisterStableMemory = CanisterStableMemory {};


### PR DESCRIPTION
# Description

Add `pub` to `WASM_PAGE_SIZE_IN_BYTES` definition

Why wasn't it `pub`?

# How Has This Been Tested?

Not tested.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
