### PR TITLE
docs: fix link to documentation site of the IC

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 You may be looking for:
 
-- [Documentation Site of the Internet Computer](https://smartcontracts.org/)
+- [Documentation Site of the Internet Computer](https://internetcomputer.org/docs)
 - [Tutorials of Rust CDK](https://internetcomputer.org/docs/current/developer-docs/build/cdks/cdk-rs-dfinity/)
 - [Examples](https://github.com/dfinity/cdk-rs/tree/main/examples)
 - [`dfx` for managing IC projects](https://github.com/dfinity/sdk)


### PR DESCRIPTION
# Description

Point documentation site to current url [https://internetcomputer.org/docs](https://internetcomputer.org/docs) in README instead of smartcontracts.org.
