### PR TITLE
feat!: Implement closure-based http transform API

### DIFF
--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -8,7 +8,12 @@ homepage = "https://docs.rs/ic-cdk"
 documentation = "https://docs.rs/ic-cdk"
 license = "Apache-2.0"
 readme = "README.md"
-categories = ["api-bindings", "data-structures", "no-std", "development-tools::ffi"]
+categories = [
+    "api-bindings",
+    "data-structures",
+    "no-std",
+    "development-tools::ffi",
+]
 keywords = ["internet-computer", "types", "dfinity", "canister", "cdk"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 repository = "https://github.com/dfinity/cdk-rs"
@@ -20,9 +25,13 @@ ic0 = { path = "../ic0", version = "0.18.9" }
 ic-cdk-macros = { path = "../ic-cdk-macros", version = "0.6.7" }
 serde = "1.0.110"
 serde_bytes = "0.11.7"
+slotmap = { version = "1.0.6", optional = true }
 
 [dev-dependencies]
 rstest = "0.12.0"
+
+[features]
+http-request = ["dep:slotmap"]
 
 [package.metadata.docs.rs]
 default-target = "wasm32-unknown-unknown"

--- a/src/ic0/src/ic0.rs
+++ b/src/ic0/src/ic0.rs
@@ -65,7 +65,7 @@ extern "C" {
 
 #[cfg(not(target_arch = "wasm32"))]
 #[allow(unused_variables)]
-#[allow(clippy::missing_safety_doc, missing_docs)]
+#[allow(clippy::missing_safety_doc)]
 #[allow(clippy::too_many_arguments)]
 mod non_wasm {
     pub unsafe fn msg_arg_data_size() -> i32 {
@@ -215,14 +215,14 @@ mod non_wasm {
     pub unsafe fn performance_counter(counter_type: i32) -> i64 {
         panic!("performance_counter should only be called inside canisters.");
     }
+    pub unsafe fn is_controller(src: i32, size: i32) -> i32 {
+        panic!("is_controller should only be called inside canisters.");
+    }
     pub unsafe fn debug_print(src: i32, size: i32) {
         panic!("debug_print should only be called inside canisters.");
     }
     pub unsafe fn trap(src: i32, size: i32) {
         panic!("trap should only be called inside canisters.");
-    }
-    pub unsafe fn is_controller(src: i32, size: i32) -> i32 {
-        panic!("is_controller should only be called inside canisters.");
     }
 }
 


### PR DESCRIPTION
The existing HTTP outcall transfrom API uses `std::any::type_name` in the specific way that it says not to, and which is not guaranteed to keep working. This PR changes it to a different system where a closure is used based on the context, rather than requiring the context to be interpreted directly. An optional feature is used for the new API as it requires exporting a canister method. Manual testing was performed to ensure there were no memory leaks. 

Is there a better name for these functions?