### PR TITLE
chore: Improve doc comments for max_response_bytes

### DIFF
--- a/src/ic-cdk/src/api/management_canister/http_request.rs
+++ b/src/ic-cdk/src/api/management_canister/http_request.rs
@@ -133,6 +133,8 @@ pub struct CanisterHttpRequestArgument {
     /// The maximal size of the response in bytes. If None, 2MiB will be the limit.
     /// This value affects the cost of the http request and it is highly recommended
     /// to set it as low as possible to avoid unnecessary extra costs.
+    /// See also the pricing section of HTTP outcalls documentation at
+    /// https://internetcomputer.org/docs/current/developer-docs/integrations/http_requests/http_requests-how-it-works#pricing.
     pub max_response_bytes: Option<u64>,
     /// The method of HTTP request.
     pub method: HttpMethod,

--- a/src/ic-cdk/src/api/management_canister/http_request.rs
+++ b/src/ic-cdk/src/api/management_canister/http_request.rs
@@ -131,6 +131,8 @@ pub struct CanisterHttpRequestArgument {
     /// The requested URL.
     pub url: String,
     /// The maximal size of the response in bytes. If None, 2MiB will be the limit.
+    /// This value affects the cost of the http request and it is highly recommended
+    /// to set it as low as possible to avoid unnecessary extra costs.
     pub max_response_bytes: Option<u64>,
     /// The method of HTTP request.
     pub method: HttpMethod,


### PR DESCRIPTION
# Description

This PR improves the doc comment of the `max_response_bytes` field of canister http requests to explain how it affects pricing and recommend that users set it to as low as possible value.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
