### PR TITLE
chore: Fail CI for explicitly enabled clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
           sudo apt-get install -y protobuf-compiler
       - name: Run clippy
         run: |
-          cargo clippy --tests --benches -- -D clippy::all
+          cargo clippy --tests --benches -- -D warnings
 
   aggregate:
     name: ci:required


### PR DESCRIPTION
We use `-Dclippy::all` in CI, which only causes a failed check for lints clippy enables by default, and not any we've specifically enabled like `clippy::missing_safety_doc`. The correct flag for this is `-Dwarnings`.