### PR TITLE
Add borrowed arg data to lazy calls

### DIFF
--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -7,7 +7,7 @@ use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::atomic::Ordering;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, RwLock, Weak};
 use std::task::{Context, Poll, Waker};
 
 /// Rejection code from calling another canister.
@@ -54,25 +54,25 @@ impl From<u32> for RejectionCode {
 pub type CallResult<R> = Result<R, (RejectionCode, String)>;
 
 // Internal state for the Future when sending a call.
-struct CallFutureState {
+struct CallFutureState<T: AsRef<[u8]>> {
     result: Option<CallResult<Vec<u8>>>,
     waker: Option<Waker>,
     id: Principal,
     method: String,
-    arg: Vec<u8>,
+    arg: T,
     payment: u128,
 }
 
-struct CallFuture {
-    state: Arc<RwLock<CallFutureState>>,
+struct CallFuture<T: AsRef<[u8]>> {
+    state: Arc<RwLock<CallFutureState<T>>>,
 }
 
-impl Future for CallFuture {
+impl<T: AsRef<[u8]>> Future for CallFuture<T> {
     type Output = CallResult<Vec<u8>>;
 
     fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
         let self_ref = Pin::into_inner(self);
-        let state_ptr = Arc::into_raw(self_ref.state.clone());
+        let state_ptr = Weak::into_raw(Arc::downgrade(&self_ref.state));
         let mut state = self_ref.state.write().unwrap();
 
         if let Some(result) = state.result.take() {
@@ -81,32 +81,35 @@ impl Future for CallFuture {
             if state.waker.is_none() {
                 let callee = state.id.as_slice();
                 let method = &state.method;
-                let args = &state.arg;
+                let args = state.arg.as_ref();
                 let payment = state.payment;
                 // SAFETY:
                 // `callee`, being &[u8], is a readable sequence of bytes and therefore can be passed to ic0.call_new.
                 // `method`, being &str, is a readable sequence of bytes and therefore can be passed to ic0.call_new.
                 // `callback` is a function with signature (env : i32) -> () and therefore can be called as both reply and reject fn for ic0.call_new.
-                // `state_ptr` is a pointer created via Arc::into_raw, and can therefore be passed as the userdata for `callback`.
+                // `state_ptr` is a pointer created via Weak::into_raw, and can therefore be passed as the userdata for `callback`.
                 // `args`, being a &[u8], is a readable sequence of bytes and therefore can be passed to ic0.call_data_append.
                 // `cleanup` is a function with signature (env : i32) -> () and therefore can be called as a cleanup fn for ic0.call_on_cleanup.
-                // `state_ptr` is a pointer created via Arc::into_raw, and can therefore be passed as the userdata for `cleanup`.
+                // `state_ptr` is a pointer created via Weak::into_raw, and can therefore be passed as the userdata for `cleanup`.
                 // ic0.call_perform is always safe to call.
+                // callback and cleanup are safe to parameterize with T because:
+                // - if the future is dropped before the callback is called, there will be no more strong references and the weak reference will fail to upgrade
+                // - if the future is *not* dropped before the callback is called, the compiler will mandate that any data borrowed by T is still alive
                 let err_code = unsafe {
                     ic0::call_new(
                         callee.as_ptr() as i32,
                         callee.len() as i32,
                         method.as_ptr() as i32,
                         method.len() as i32,
-                        callback as usize as i32,
+                        callback::<T> as usize as i32,
                         state_ptr as i32,
-                        callback as usize as i32,
+                        callback::<T> as usize as i32,
                         state_ptr as i32,
                     );
 
                     ic0::call_data_append(args.as_ptr() as i32, args.len() as i32);
                     add_payment(payment);
-                    ic0::call_on_cleanup(cleanup as usize as i32, state_ptr as i32);
+                    ic0::call_on_cleanup(cleanup::<T> as usize as i32, state_ptr as i32);
                     ic0::call_perform()
                 };
 
@@ -133,22 +136,24 @@ impl Future for CallFuture {
 ///
 /// # Safety
 ///
-/// This function must only be passed to the IC with a pointer from Arc::into_raw as userdata.
-unsafe fn callback(state_ptr: *const RwLock<CallFutureState>) {
-    // SAFETY: This function is only ever called by the IC, and we only ever pass a Arc as userdata.
-    let state = unsafe { Arc::from_raw(state_ptr) };
-    // Make sure to un-borrow_mut the state.
-    {
-        state.write().unwrap().result = Some(match reject_code() {
-            RejectionCode::NoError => Ok(arg_data_raw()),
-            n => Err((n, reject_message())),
-        });
-    }
-    let w = state.write().unwrap().waker.take();
-    if let Some(waker) = w {
-        // This is all to protect this little guy here which will call the poll() which
-        // borrow_mut() the state as well. So we need to be careful to not double-borrow_mut.
-        waker.wake()
+/// This function must only be passed to the IC with a pointer from Weak::into_raw as userdata.
+unsafe fn callback<T: AsRef<[u8]>>(state_ptr: *const RwLock<CallFutureState<T>>) {
+    // SAFETY: This function is only ever called by the IC, and we only ever pass a Weak as userdata.
+    let state = unsafe { Weak::from_raw(state_ptr) };
+    if let Some(state) = state.upgrade() {
+        // Make sure to un-borrow_mut the state.
+        {
+            state.write().unwrap().result = Some(match reject_code() {
+                RejectionCode::NoError => Ok(arg_data_raw()),
+                n => Err((n, reject_message())),
+            });
+        }
+        let w = state.write().unwrap().waker.take();
+        if let Some(waker) = w {
+            // This is all to protect this little guy here which will call the poll() which
+            // borrow_mut() the state as well. So we need to be careful to not double-borrow_mut.
+            waker.wake()
+        }
     }
 }
 
@@ -158,26 +163,28 @@ unsafe fn callback(state_ptr: *const RwLock<CallFutureState>) {
 ///
 /// # Safety
 ///
-/// This function must only be passed to the IC with a pointer from Arc::into_raw as userdata.
-unsafe fn cleanup(state_ptr: *const RwLock<CallFutureState>) {
-    // SAFETY: This function is only ever called by the IC, and we only ever pass a Arc as userdata.
-    let state = unsafe { Arc::from_raw(state_ptr) };
-    // We set the call result, even though it won't be read on the
-    // default executor, because we can't guarantee it was called on
-    // our executor. However, we are not allowed to inspect
-    // reject_code() inside of a cleanup callback, so always set the
-    // result to a reject.
-    //
-    // Borrowing does not trap - the rollback from the
-    // previous trap ensures that the RwLock can be borrowed again.
-    state.write().unwrap().result = Some(Err((RejectionCode::NoError, "cleanup".to_string())));
-    let w = state.write().unwrap().waker.take();
-    if let Some(waker) = w {
-        // Flag that we do not want to actually wake the task - we
-        // want to drop it *without* executing it.
-        crate::futures::CLEANUP.store(true, Ordering::Relaxed);
-        waker.wake();
-        crate::futures::CLEANUP.store(false, Ordering::Relaxed);
+/// This function must only be passed to the IC with a pointer from Weak::into_raw as userdata.
+unsafe fn cleanup<T: AsRef<[u8]>>(state_ptr: *const RwLock<CallFutureState<T>>) {
+    // SAFETY: This function is only ever called by the IC, and we only ever pass a Weak as userdata.
+    let state = unsafe { Weak::from_raw(state_ptr) };
+    if let Some(state) = state.upgrade() {
+        // We set the call result, even though it won't be read on the
+        // default executor, because we can't guarantee it was called on
+        // our executor. However, we are not allowed to inspect
+        // reject_code() inside of a cleanup callback, so always set the
+        // result to a reject.
+        //
+        // Borrowing does not trap - the rollback from the
+        // previous trap ensures that the RwLock can be borrowed again.
+        state.write().unwrap().result = Some(Err((RejectionCode::NoError, "cleanup".to_string())));
+        let w = state.write().unwrap().waker.take();
+        if let Some(waker) = w {
+            // Flag that we do not want to actually wake the task - we
+            // want to drop it *without* executing it.
+            crate::futures::CLEANUP.store(true, Ordering::Relaxed);
+            waker.wake();
+            crate::futures::CLEANUP.store(false, Ordering::Relaxed);
+        }
     }
 }
 
@@ -275,31 +282,31 @@ pub fn notify_raw(
 }
 
 /// Similar to `call`, but without serialization.
-pub fn call_raw(
+pub fn call_raw<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
     id: Principal,
     method: &str,
-    args_raw: Vec<u8>,
+    args_raw: T,
     payment: u64,
-) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync {
+) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync + 'a {
     call_raw_internal(id, method, args_raw, payment.into())
 }
 
 /// Similar to `call128`, but without serialization.
-pub fn call_raw128(
+pub fn call_raw128<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
     id: Principal,
     method: &str,
-    args_raw: Vec<u8>,
+    args_raw: T,
     payment: u128,
-) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync {
+) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync + 'a {
     call_raw_internal(id, method, args_raw, payment)
 }
 
-fn call_raw_internal(
+fn call_raw_internal<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
     id: Principal,
     method: &str,
-    args_raw: Vec<u8>,
+    args_raw: T,
     payment: u128,
-) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync {
+) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync + 'a {
     let state = Arc::new(RwLock::new(CallFutureState {
         result: None,
         waker: None,

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -137,7 +137,7 @@ impl<T: AsRef<[u8]>> Future for CallFuture<T> {
 /// # Safety
 ///
 /// This function must only be passed to the IC with a pointer from Weak::into_raw as userdata.
-unsafe fn callback<T: AsRef<[u8]>>(state_ptr: *const RwLock<CallFutureState<T>>) {
+unsafe extern "C" fn callback<T: AsRef<[u8]>>(state_ptr: *const RwLock<CallFutureState<T>>) {
     // SAFETY: This function is only ever called by the IC, and we only ever pass a Weak as userdata.
     let state = unsafe { Weak::from_raw(state_ptr) };
     if let Some(state) = state.upgrade() {
@@ -164,7 +164,7 @@ unsafe fn callback<T: AsRef<[u8]>>(state_ptr: *const RwLock<CallFutureState<T>>)
 /// # Safety
 ///
 /// This function must only be passed to the IC with a pointer from Weak::into_raw as userdata.
-unsafe fn cleanup<T: AsRef<[u8]>>(state_ptr: *const RwLock<CallFutureState<T>>) {
+unsafe extern "C" fn cleanup<T: AsRef<[u8]>>(state_ptr: *const RwLock<CallFutureState<T>>) {
     // SAFETY: This function is only ever called by the IC, and we only ever pass a Weak as userdata.
     let state = unsafe { Weak::from_raw(state_ptr) };
     if let Some(state) = state.upgrade() {


### PR DESCRIPTION
This PR is a modification to #391 that allows argument data to be borrowed. It does so by changing our userdata pointer from an Arc to a Weak; if the caller drops the borrowed data, the Weak will fail to upgrade, preventing a dangling pointer.
@lwshang @mraszyk