### PR TITLE
fix: Always overwrite waker

### DIFF
--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -122,9 +122,8 @@ impl<T: AsRef<[u8]>> Future for CallFuture<T> {
                     state.result = Some(result.clone());
                     return Poll::Ready(result);
                 }
-
-                state.waker = Some(context.waker().clone());
             }
+            state.waker = Some(context.waker().clone());
             Poll::Pending
         }
     }


### PR DESCRIPTION
Missed 286faae in #391 that should have been reverted. Per the Future docs, if a future needs to be polled multiple times, it should only wake the most recently provided waker.