### PR TITLE
chore: release ic-cdk v0.8.0

### DIFF
--- a/library/ic-ledger-types/CHANGELOG.md
+++ b/library/ic-ledger-types/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.5.0] - 2023-05-26
+### Changed
+- Upgrade `ic-cdk` to v0.8.
+
 ## [0.4.2] - 2023-03-01
 ### Fixed
 - Fill missing docs.

--- a/library/ic-ledger-types/Cargo.toml
+++ b/library/ic-ledger-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-ledger-types"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Types for interacting with the ICP ledger canister."
@@ -17,7 +17,7 @@ rust-version = "1.65.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ic-cdk = { path = "../../src/ic-cdk", version = "0.7" }
+ic-cdk = { path = "../../src/ic-cdk", version = "0.8" }
 candid = "0.8.0"
 crc32fast = "1.2.0"
 hex = "0.4"

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -27,4 +27,4 @@ serde = "1.0.111"
 
 [dev-dependencies]
 trybuild = "1.0"
-ic-cdk = { path = "../ic-cdk", version = "0.7" }
+ic-cdk = { path = "../ic-cdk", version = "0.8" }

--- a/src/ic-cdk-timers/CHANGELOG.md
+++ b/src/ic-cdk-timers/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.2.0] - 2023-05-26
+
+### Changed
+
+- Upgrade `ic-cdk` to v0.8.
+
 ## [0.1.2] - 2023-03-01
 
 ## [0.1.1] - 2023-02-22

--- a/src/ic-cdk-timers/Cargo.toml
+++ b/src/ic-cdk-timers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-timers"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Timers library for the Rust CDK."
@@ -15,7 +15,7 @@ repository = "https://github.com/dfinity/cdk-rs"
 rust-version = "1.60.0"
 
 [dependencies]
-ic-cdk = { path = "../../src/ic-cdk", version = "0.7" }
+ic-cdk = { path = "../../src/ic-cdk", version = "0.8" }
 serde = "1.0.110"
 serde_bytes = "0.11.7"
 ic0 = { path = "../ic0", version = "0.18.9" }

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.7.5] - 2023-05-26
+
 ### Added
 
 - `ic0.is_controller` as a public function. (#383)

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,16 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-## [0.7.5] - 2023-05-26
+## [0.8.0] - 2023-05-26
 
 ### Added
 
 - `ic0.is_controller` as a public function. (#383)
-- `CallFuture` only makes an inter-canister call if it is awaited. (#391)
 
 ### Changed
 
 - `TransformContext::new` has been replaced with dedicated functions that accept closures. (#385)
+- `CallFuture` only makes an inter-canister call if it is awaited. (#391)
 
 ## [0.7.4] - 2023-03-21
 

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.7.5"
+version = "0.8.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit for the Internet Computer."

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit for the Internet Computer."
@@ -21,7 +21,7 @@ rust-version = "1.65.0"
 
 [dependencies]
 candid = "0.8"
-ic0 = { path = "../ic0", version = "0.18.9" }
+ic0 = { path = "../ic0", version = "0.18.10" }
 ic-cdk-macros = { path = "../ic-cdk-macros", version = "0.6.7" }
 serde = "1.0.110"
 serde_bytes = "0.11.7"

--- a/src/ic0/Cargo.toml
+++ b/src/ic0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic0"
-version = "0.18.9"
+version = "0.18.10"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Internet Computer System API Binding."

--- a/src/ic0/ic0.txt
+++ b/src/ic0/ic0.txt
@@ -45,14 +45,14 @@ ic0.call_cycles_add : (amount : i64) -> ();                                 // U
 ic0.call_cycles_add128 : (amount_high : i64, amount_low: i64) -> ();        // U Ry Rt T
 ic0.call_perform : () -> ( err_code : i32 );                                // U Ry Rt T
 
-ic0.stable_size : () -> (page_count : i32);                                 // *
-ic0.stable_grow : (new_pages : i32) -> (old_page_count : i32);              // *
-ic0.stable_write : (offset : i32, src : i32, size : i32) -> ();             // *
-ic0.stable_read : (dst : i32, offset : i32, size : i32) -> ();              // *
-ic0.stable64_size : () -> (page_count : i64);                               // *
-ic0.stable64_grow : (new_pages : i64) -> (old_page_count : i64);            // *
-ic0.stable64_write : (offset : i64, src : i64, size : i64) -> ();           // *
-ic0.stable64_read : (dst : i64, offset : i64, size : i64) -> ();            // *
+ic0.stable_size : () -> (page_count : i32);                                 // * s
+ic0.stable_grow : (new_pages : i32) -> (old_page_count : i32);              // * s
+ic0.stable_write : (offset : i32, src : i32, size : i32) -> ();             // * s
+ic0.stable_read : (dst : i32, offset : i32, size : i32) -> ();              // * s
+ic0.stable64_size : () -> (page_count : i64);                               // * s
+ic0.stable64_grow : (new_pages : i64) -> (old_page_count : i64);            // * s
+ic0.stable64_write : (offset : i64, src : i64, size : i64) -> ();           // * s
+ic0.stable64_read : (dst : i64, offset : i64, size : i64) -> ();            // * s
 
 ic0.certified_data_set : (src: i32, size: i32) -> ();                       // I G U Ry Rt T
 ic0.data_certificate_present : () -> i32;                                   // *
@@ -60,9 +60,9 @@ ic0.data_certificate_size : () -> i32;                                      // *
 ic0.data_certificate_copy : (dst: i32, offset: i32, size: i32) -> ();       // *
 
 ic0.time : () -> (timestamp : i64);                                         // *
-ic0.global_timer_set : (timestamp : i64) -> i64;                            // I U Ry Rt C T
+ic0.global_timer_set : (timestamp : i64) -> i64;                            // I G U Ry Rt C T
 ic0.performance_counter : (counter_type : i32) -> (counter : i64);          // * s
-ic0.is_controller: (src: i32, size: i32) -> (result: i32);                  // * s
+ic0.is_controller: (src: i32, size: i32) -> ( result: i32);                 // * s
 
 ic0.debug_print : (src : i32, size : i32) -> ();                            // * s
 ic0.trap : (src : i32, size : i32) -> ();                                   // * s


### PR DESCRIPTION
~Only bumped the patch version though there is http outcall API change.~

~Projects using the http outcall API will need modify their code accordingly. But other projects will get benefit from this upgrade directly.~

The `interface-spec` hasn't got a new version since v0.18.9 (2022-12). I updated `ic0.txt` as v0.18.10 with the latest content on master branch.

The crates depend on `ic-cdk` also bump minor version.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
