### PR TITLE
fix: Fix docs.rs build

### DIFF
--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit for the Internet Computer."

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -34,5 +34,6 @@ rstest = "0.12.0"
 transform-closure = ["dep:slotmap"]
 
 [package.metadata.docs.rs]
+all-features = true
 default-target = "wasm32-unknown-unknown"
 rustdoc-args = ["--cfg=docsrs"]

--- a/src/ic-cdk/src/api/management_canister/http_request.rs
+++ b/src/ic-cdk/src/api/management_canister/http_request.rs
@@ -212,7 +212,7 @@ pub async fn http_request(arg: CanisterHttpRequestArgument) -> CallResult<(HttpR
 /// If the canister is on a 34-node Application Subnets, you may have to compute the cost by yourself and call [`http_request_with_cycles_with`] instead.
 ///
 /// Check [this page](https://internetcomputer.org/docs/current/developer-docs/production/computation-and-storage-costs) for more details.
-#[cfg(any(docsrs, feature = "transform-closure"))]
+#[cfg(feature = "transform-closure")]
 #[cfg_attr(docsrs, doc(cfg(feature = "transform-closure")))]
 pub async fn http_request_with(
     arg: CanisterHttpRequestArgument,
@@ -253,7 +253,7 @@ pub async fn http_request_with_cycles(
 /// Check [this page](https://internetcomputer.org/docs/current/developer-docs/production/computation-and-storage-costs) for more details.
 ///
 /// If the canister is on a 13-node Application Subnet, you can call [`http_request_with`] instead which handles cycles cost calculation under the hood.
-#[cfg(any(docsrs, feature = "transform-closure"))]
+#[cfg(feature = "transform-closure")]
 #[cfg_attr(docsrs, doc(cfg(feature = "transform-closure")))]
 pub async fn http_request_with_cycles_with(
     arg: CanisterHttpRequestArgument,


### PR DESCRIPTION
This fixes the cfgs to no longer pretend the feature is enabled when being documented (as this is incompatible with the feature requiring optional dependencies) and instead just adds `--all-features` to the doc build to get the same effect.