### PR TITLE
feat: set sender_canister_version and support canister_info

### DIFF
--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -37,6 +37,11 @@ path = "canisters/api_call.rs"
 name = "timers"
 path = "canisters/timers.rs"
 
+[[bin]]
+name = "canister_info"
+path = "canisters/canister_info.rs"
+
 [dev-dependencies]
 candid = "0.8"
+hex = "0.4.3"
 ic-test-state-machine-client = "1"

--- a/e2e-tests/canisters/canister_info.rs
+++ b/e2e-tests/canisters/canister_info.rs
@@ -1,7 +1,8 @@
 use ic_cdk::api::management_canister::main::{
-    create_canister, install_code, uninstall_code, update_settings, CanisterIdRecord,
-    CanisterInfoRequest, CanisterInfoResponse, CanisterInstallMode::*, CanisterSettings,
-    CreateCanisterArgument, InstallCodeArgument, UpdateSettingsArgument,
+    canister_info, create_canister, install_code, uninstall_code, update_settings,
+    CanisterIdRecord, CanisterInfoRequest, CanisterInfoResponse,
+    CanisterInstallMode::{Install, Reinstall, Upgrade},
+    CanisterSettings, CreateCanisterArgument, InstallCodeArgument, UpdateSettingsArgument,
 };
 use ic_cdk::export::Principal;
 
@@ -11,14 +12,7 @@ async fn info(canister_id: Principal) -> CanisterInfoResponse {
         canister_id,
         num_requested_changes: Some(20),
     };
-    ic_cdk::api::call::call::<(CanisterInfoRequest,), (CanisterInfoResponse,)>(
-        Principal::management_canister(),
-        "canister_info",
-        (request,),
-    )
-    .await
-    .unwrap()
-    .0
+    canister_info(request).await.unwrap().0
 }
 
 #[ic_cdk_macros::update]

--- a/e2e-tests/canisters/canister_info.rs
+++ b/e2e-tests/canisters/canister_info.rs
@@ -1,0 +1,85 @@
+use ic_cdk::api::management_canister::main::{
+    create_canister, install_code, uninstall_code, update_settings, CanisterIdRecord,
+    CanisterInfoRequest, CanisterInfoResponse, CanisterInstallMode::*, CanisterSettings,
+    CreateCanisterArgument, InstallCodeArgument, UpdateSettingsArgument,
+};
+use ic_cdk::export::Principal;
+
+#[ic_cdk::update]
+async fn info(canister_id: Principal) -> CanisterInfoResponse {
+    let request = CanisterInfoRequest {
+        canister_id,
+        num_requested_changes: Some(20),
+    };
+    ic_cdk::api::call::call::<(CanisterInfoRequest,), (CanisterInfoResponse,)>(
+        Principal::management_canister(),
+        "canister_info",
+        (request,),
+    )
+    .await
+    .unwrap()
+    .0
+}
+
+#[ic_cdk_macros::update]
+async fn canister_lifecycle() -> Principal {
+    let canister_id = create_canister(CreateCanisterArgument { settings: None })
+        .await
+        .unwrap()
+        .0;
+    install_code(InstallCodeArgument {
+        mode: Install,
+        arg: vec![],
+        wasm_module: vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00],
+        canister_id: canister_id.canister_id,
+    })
+    .await
+    .unwrap();
+    uninstall_code(CanisterIdRecord {
+        canister_id: canister_id.canister_id,
+    })
+    .await
+    .unwrap();
+    install_code(InstallCodeArgument {
+        mode: Install,
+        arg: vec![],
+        wasm_module: vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00],
+        canister_id: canister_id.canister_id,
+    })
+    .await
+    .unwrap();
+    install_code(InstallCodeArgument {
+        mode: Reinstall,
+        arg: vec![],
+        wasm_module: vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00],
+        canister_id: canister_id.canister_id,
+    })
+    .await
+    .unwrap();
+    install_code(InstallCodeArgument {
+        mode: Upgrade,
+        arg: vec![],
+        wasm_module: vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00],
+        canister_id: canister_id.canister_id,
+    })
+    .await
+    .unwrap();
+    update_settings(UpdateSettingsArgument {
+        settings: CanisterSettings {
+            controllers: Some(vec![
+                ic_cdk::id(),
+                canister_id.canister_id,
+                Principal::anonymous(),
+            ]),
+            compute_allocation: None,
+            memory_allocation: None,
+            freezing_threshold: None,
+        },
+        canister_id: canister_id.canister_id,
+    })
+    .await
+    .unwrap();
+    canister_id.canister_id
+}
+
+fn main() {}

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -2,12 +2,11 @@ use std::time::Duration;
 
 use candid::{Encode, Principal};
 use ic_cdk::api::management_canister::main::{
-    CanisterChange, CanisterChangeDetails, CanisterChangeFromCanisterRecord,
-    CanisterChangeFromUserRecord, CanisterChangeOrigin, CanisterCodeDeploymentRecord,
-    CanisterControllersChangeRecord, CanisterCreationRecord, CanisterIdRecord,
+    CanisterChange, CanisterChangeDetails, CanisterChangeOrigin, CanisterIdRecord,
     CanisterInfoResponse,
     CanisterInstallMode::{Install, Reinstall, Upgrade},
-    InstallCodeArgument,
+    CodeDeploymentRecord, ControllersChangeRecord, CreationRecord, FromCanisterRecord,
+    FromUserRecord, InstallCodeArgument,
 };
 use ic_cdk_e2e_tests::cargo_build_canister;
 use ic_test_state_machine_client::{
@@ -321,145 +320,115 @@ fn test_canister_info() {
                 CanisterChange {
                     timestamp_nanos,
                     canister_version: 0,
-                    origin: CanisterChangeOrigin::CanisterChangeFromCanister(
-                        CanisterChangeFromCanisterRecord {
-                            canister_id,
-                            canister_version: Some(1)
-                        }
-                    ),
-                    details: CanisterChangeDetails::CanisterCreation(CanisterCreationRecord {
+                    origin: CanisterChangeOrigin::FromCanister(FromCanisterRecord {
+                        canister_id,
+                        canister_version: Some(1)
+                    }),
+                    details: CanisterChangeDetails::Creation(CreationRecord {
                         controllers: vec![canister_id]
                     }),
                 },
                 CanisterChange {
                     timestamp_nanos,
                     canister_version: 1,
-                    origin: CanisterChangeOrigin::CanisterChangeFromCanister(
-                        CanisterChangeFromCanisterRecord {
-                            canister_id,
-                            canister_version: Some(2)
-                        }
-                    ),
-                    details: CanisterChangeDetails::CanisterCodeDeployment(
-                        CanisterCodeDeploymentRecord {
-                            mode: Install,
-                            module_hash: hex::decode(
-                                "93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476"
-                            )
-                            .unwrap(),
-                        }
-                    ),
+                    origin: CanisterChangeOrigin::FromCanister(FromCanisterRecord {
+                        canister_id,
+                        canister_version: Some(2)
+                    }),
+                    details: CanisterChangeDetails::CodeDeployment(CodeDeploymentRecord {
+                        mode: Install,
+                        module_hash: hex::decode(
+                            "93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476"
+                        )
+                        .unwrap(),
+                    }),
                 },
                 CanisterChange {
                     timestamp_nanos,
                     canister_version: 2,
-                    origin: CanisterChangeOrigin::CanisterChangeFromCanister(
-                        CanisterChangeFromCanisterRecord {
-                            canister_id,
-                            canister_version: Some(3)
-                        }
-                    ),
-                    details: CanisterChangeDetails::CanisterCodeUninstall,
+                    origin: CanisterChangeOrigin::FromCanister(FromCanisterRecord {
+                        canister_id,
+                        canister_version: Some(3)
+                    }),
+                    details: CanisterChangeDetails::CodeUninstall,
                 },
                 CanisterChange {
                     timestamp_nanos,
                     canister_version: 3,
-                    origin: CanisterChangeOrigin::CanisterChangeFromCanister(
-                        CanisterChangeFromCanisterRecord {
-                            canister_id,
-                            canister_version: Some(4)
-                        }
-                    ),
-                    details: CanisterChangeDetails::CanisterCodeDeployment(
-                        CanisterCodeDeploymentRecord {
-                            mode: Install,
-                            module_hash: hex::decode(
-                                "93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476"
-                            )
-                            .unwrap(),
-                        }
-                    ),
+                    origin: CanisterChangeOrigin::FromCanister(FromCanisterRecord {
+                        canister_id,
+                        canister_version: Some(4)
+                    }),
+                    details: CanisterChangeDetails::CodeDeployment(CodeDeploymentRecord {
+                        mode: Install,
+                        module_hash: hex::decode(
+                            "93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476"
+                        )
+                        .unwrap(),
+                    }),
                 },
                 CanisterChange {
                     timestamp_nanos,
                     canister_version: 4,
-                    origin: CanisterChangeOrigin::CanisterChangeFromCanister(
-                        CanisterChangeFromCanisterRecord {
-                            canister_id,
-                            canister_version: Some(5)
-                        }
-                    ),
-                    details: CanisterChangeDetails::CanisterCodeDeployment(
-                        CanisterCodeDeploymentRecord {
-                            mode: Reinstall,
-                            module_hash: hex::decode(
-                                "93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476"
-                            )
-                            .unwrap(),
-                        }
-                    ),
+                    origin: CanisterChangeOrigin::FromCanister(FromCanisterRecord {
+                        canister_id,
+                        canister_version: Some(5)
+                    }),
+                    details: CanisterChangeDetails::CodeDeployment(CodeDeploymentRecord {
+                        mode: Reinstall,
+                        module_hash: hex::decode(
+                            "93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476"
+                        )
+                        .unwrap(),
+                    }),
                 },
                 CanisterChange {
                     timestamp_nanos,
                     canister_version: 5,
-                    origin: CanisterChangeOrigin::CanisterChangeFromCanister(
-                        CanisterChangeFromCanisterRecord {
-                            canister_id,
-                            canister_version: Some(6)
-                        }
-                    ),
-                    details: CanisterChangeDetails::CanisterCodeDeployment(
-                        CanisterCodeDeploymentRecord {
-                            mode: Upgrade,
-                            module_hash: hex::decode(
-                                "93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476"
-                            )
-                            .unwrap(),
-                        }
-                    ),
+                    origin: CanisterChangeOrigin::FromCanister(FromCanisterRecord {
+                        canister_id,
+                        canister_version: Some(6)
+                    }),
+                    details: CanisterChangeDetails::CodeDeployment(CodeDeploymentRecord {
+                        mode: Upgrade,
+                        module_hash: hex::decode(
+                            "93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476"
+                        )
+                        .unwrap(),
+                    }),
                 },
                 CanisterChange {
                     timestamp_nanos,
                     canister_version: 6,
-                    origin: CanisterChangeOrigin::CanisterChangeFromCanister(
-                        CanisterChangeFromCanisterRecord {
-                            canister_id,
-                            canister_version: Some(7)
-                        }
-                    ),
-                    details: CanisterChangeDetails::CanisterControllersChange(
-                        CanisterControllersChangeRecord {
-                            controllers: vec![Principal::anonymous(), canister_id, new_canister.0]
-                        }
-                    ),
+                    origin: CanisterChangeOrigin::FromCanister(FromCanisterRecord {
+                        canister_id,
+                        canister_version: Some(7)
+                    }),
+                    details: CanisterChangeDetails::ControllersChange(ControllersChangeRecord {
+                        controllers: vec![Principal::anonymous(), canister_id, new_canister.0]
+                    }),
                 },
                 CanisterChange {
                     timestamp_nanos,
                     canister_version: 7,
-                    origin: CanisterChangeOrigin::CanisterChangeFromUser(
-                        CanisterChangeFromUserRecord {
-                            user_id: Principal::anonymous(),
-                        }
-                    ),
-                    details: CanisterChangeDetails::CanisterCodeUninstall,
+                    origin: CanisterChangeOrigin::FromUser(FromUserRecord {
+                        user_id: Principal::anonymous(),
+                    }),
+                    details: CanisterChangeDetails::CodeUninstall,
                 },
                 CanisterChange {
                     timestamp_nanos,
                     canister_version: 8,
-                    origin: CanisterChangeOrigin::CanisterChangeFromUser(
-                        CanisterChangeFromUserRecord {
-                            user_id: Principal::anonymous(),
-                        }
-                    ),
-                    details: CanisterChangeDetails::CanisterCodeDeployment(
-                        CanisterCodeDeploymentRecord {
-                            mode: Install,
-                            module_hash: hex::decode(
-                                "93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476"
-                            )
-                            .unwrap(),
-                        }
-                    ),
+                    origin: CanisterChangeOrigin::FromUser(FromUserRecord {
+                        user_id: Principal::anonymous(),
+                    }),
+                    details: CanisterChangeDetails::CodeDeployment(CodeDeploymentRecord {
+                        mode: Install,
+                        module_hash: hex::decode(
+                            "93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476"
+                        )
+                        .unwrap(),
+                    }),
                 },
             ],
             module_hash: Some(

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -1,11 +1,20 @@
 use std::time::Duration;
 
 use candid::{Encode, Principal};
+use ic_cdk::api::management_canister::main::{
+    CanisterChange, CanisterChangeDetails, CanisterChangeFromCanisterRecord,
+    CanisterChangeFromUserRecord, CanisterChangeOrigin, CanisterCodeDeploymentRecord,
+    CanisterControllersChangeRecord, CanisterCreationRecord, CanisterIdRecord,
+    CanisterInfoResponse,
+    CanisterInstallMode::{Install, Reinstall, Upgrade},
+    InstallCodeArgument,
+};
 use ic_cdk_e2e_tests::cargo_build_canister;
 use ic_test_state_machine_client::{
-    call_candid, query_candid, CallError, ErrorCode, StateMachine, WasmResult,
+    call_candid, call_candid_as, query_candid, CallError, ErrorCode, StateMachine, WasmResult,
 };
 use serde_bytes::ByteBuf;
+use std::time::SystemTime;
 
 pub static STATE_MACHINE_BINARY: &str = "../ic-test-state-machine";
 
@@ -259,4 +268,205 @@ fn advance_seconds(env: &StateMachine, seconds: u32) {
         env.advance_time(Duration::from_secs(1));
         env.tick();
     }
+}
+
+#[test]
+fn test_canister_info() {
+    let env = env();
+    let wasm = cargo_build_canister("canister_info");
+    let canister_id = env.create_canister();
+    env.add_cycles(canister_id, 1_000_000_000_000);
+    env.install_canister(canister_id, wasm, vec![]);
+
+    let new_canister: (Principal,) = call_candid(&env, canister_id, "canister_lifecycle", ())
+        .expect("Error calling canister_lifecycle");
+
+    let () = call_candid_as(
+        &env,
+        Principal::management_canister(),
+        Principal::anonymous(),
+        "uninstall_code",
+        (CanisterIdRecord {
+            canister_id: new_canister.0,
+        },),
+    )
+    .expect("Error calling uninstall_code");
+    let () = call_candid_as(
+        &env,
+        Principal::management_canister(),
+        Principal::anonymous(),
+        "install_code",
+        (InstallCodeArgument {
+            mode: Install,
+            arg: vec![],
+            wasm_module: vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00],
+            canister_id: new_canister.0,
+        },),
+    )
+    .expect("Error calling install_code");
+
+    let info: (CanisterInfoResponse,) = call_candid(&env, canister_id, "info", (new_canister.0,))
+        .expect("Error calling canister_info");
+
+    let timestamp_nanos = env
+        .time()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64;
+    assert_eq!(
+        info.0,
+        CanisterInfoResponse {
+            total_num_changes: 9,
+            recent_changes: vec![
+                CanisterChange {
+                    timestamp_nanos,
+                    canister_version: 0,
+                    origin: CanisterChangeOrigin::CanisterChangeFromCanister(
+                        CanisterChangeFromCanisterRecord {
+                            canister_id,
+                            canister_version: Some(1)
+                        }
+                    ),
+                    details: CanisterChangeDetails::CanisterCreation(CanisterCreationRecord {
+                        controllers: vec![canister_id]
+                    }),
+                },
+                CanisterChange {
+                    timestamp_nanos,
+                    canister_version: 1,
+                    origin: CanisterChangeOrigin::CanisterChangeFromCanister(
+                        CanisterChangeFromCanisterRecord {
+                            canister_id,
+                            canister_version: Some(2)
+                        }
+                    ),
+                    details: CanisterChangeDetails::CanisterCodeDeployment(
+                        CanisterCodeDeploymentRecord {
+                            mode: Install,
+                            module_hash: hex::decode(
+                                "93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476"
+                            )
+                            .unwrap(),
+                        }
+                    ),
+                },
+                CanisterChange {
+                    timestamp_nanos,
+                    canister_version: 2,
+                    origin: CanisterChangeOrigin::CanisterChangeFromCanister(
+                        CanisterChangeFromCanisterRecord {
+                            canister_id,
+                            canister_version: Some(3)
+                        }
+                    ),
+                    details: CanisterChangeDetails::CanisterCodeUninstall,
+                },
+                CanisterChange {
+                    timestamp_nanos,
+                    canister_version: 3,
+                    origin: CanisterChangeOrigin::CanisterChangeFromCanister(
+                        CanisterChangeFromCanisterRecord {
+                            canister_id,
+                            canister_version: Some(4)
+                        }
+                    ),
+                    details: CanisterChangeDetails::CanisterCodeDeployment(
+                        CanisterCodeDeploymentRecord {
+                            mode: Install,
+                            module_hash: hex::decode(
+                                "93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476"
+                            )
+                            .unwrap(),
+                        }
+                    ),
+                },
+                CanisterChange {
+                    timestamp_nanos,
+                    canister_version: 4,
+                    origin: CanisterChangeOrigin::CanisterChangeFromCanister(
+                        CanisterChangeFromCanisterRecord {
+                            canister_id,
+                            canister_version: Some(5)
+                        }
+                    ),
+                    details: CanisterChangeDetails::CanisterCodeDeployment(
+                        CanisterCodeDeploymentRecord {
+                            mode: Reinstall,
+                            module_hash: hex::decode(
+                                "93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476"
+                            )
+                            .unwrap(),
+                        }
+                    ),
+                },
+                CanisterChange {
+                    timestamp_nanos,
+                    canister_version: 5,
+                    origin: CanisterChangeOrigin::CanisterChangeFromCanister(
+                        CanisterChangeFromCanisterRecord {
+                            canister_id,
+                            canister_version: Some(6)
+                        }
+                    ),
+                    details: CanisterChangeDetails::CanisterCodeDeployment(
+                        CanisterCodeDeploymentRecord {
+                            mode: Upgrade,
+                            module_hash: hex::decode(
+                                "93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476"
+                            )
+                            .unwrap(),
+                        }
+                    ),
+                },
+                CanisterChange {
+                    timestamp_nanos,
+                    canister_version: 6,
+                    origin: CanisterChangeOrigin::CanisterChangeFromCanister(
+                        CanisterChangeFromCanisterRecord {
+                            canister_id,
+                            canister_version: Some(7)
+                        }
+                    ),
+                    details: CanisterChangeDetails::CanisterControllersChange(
+                        CanisterControllersChangeRecord {
+                            controllers: vec![Principal::anonymous(), canister_id, new_canister.0]
+                        }
+                    ),
+                },
+                CanisterChange {
+                    timestamp_nanos,
+                    canister_version: 7,
+                    origin: CanisterChangeOrigin::CanisterChangeFromUser(
+                        CanisterChangeFromUserRecord {
+                            user_id: Principal::anonymous(),
+                        }
+                    ),
+                    details: CanisterChangeDetails::CanisterCodeUninstall,
+                },
+                CanisterChange {
+                    timestamp_nanos,
+                    canister_version: 8,
+                    origin: CanisterChangeOrigin::CanisterChangeFromUser(
+                        CanisterChangeFromUserRecord {
+                            user_id: Principal::anonymous(),
+                        }
+                    ),
+                    details: CanisterChangeDetails::CanisterCodeDeployment(
+                        CanisterCodeDeploymentRecord {
+                            mode: Install,
+                            module_hash: hex::decode(
+                                "93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476"
+                            )
+                            .unwrap(),
+                        }
+                    ),
+                },
+            ],
+            module_hash: Some(
+                hex::decode("93a44bbb96c751218e4c00d479e4c14358122a389acca16205b1e4d0dc5f9476")
+                    .unwrap()
+            ),
+            controllers: vec![Principal::anonymous(), canister_id, new_canister.0],
+        }
+    );
 }

--- a/scripts/download_state_machine_binary.sh
+++ b/scripts/download_state_machine_binary.sh
@@ -8,7 +8,7 @@ cd "$SCRIPTS_DIR/.."
 
 uname_sys=$(uname -s | tr '[:upper:]' '[:lower:]')
 echo "uname_sys: $uname_sys"
-commit_sha="d0ea9d15cc51bd5bba16c8f1be3a6dfc8ec7dc24"
+commit_sha="4bffd861d15a28682761c97bd0e6608bf324c5c2"
 
 curl -sLO "https://download.dfinity.systems/ic/$commit_sha/binaries/x86_64-$uname_sys/ic-test-state-machine.gz"
 gzip -d ic-test-state-machine.gz

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+- Set caller's canister version in the field `sender_canister_version` of management canister call payloads.
+- Add management canister types for `canister_info` management canister call (`CanisterInfoRequest` and `CanisterInfoResponse`).
+
 ## [0.8.0] - 2023-05-26
 
 ### Added

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -30,6 +30,16 @@ pub struct CreateCanisterArgument {
     pub settings: Option<CanisterSettings>,
 }
 
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default,
+)]
+pub(crate) struct CreateCanisterArgumentExtended {
+    /// See [CanisterSettings].
+    pub settings: Option<CanisterSettings>,
+    /// sender_canister_version must be set to ic_cdk::api::canister_version()
+    pub sender_canister_version: Option<u64>,
+}
+
 /// Argument type of [update_settings](super::update_settings).
 #[derive(
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
@@ -39,6 +49,18 @@ pub struct UpdateSettingsArgument {
     pub canister_id: CanisterId,
     /// See [CanisterSettings].
     pub settings: CanisterSettings,
+}
+
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub(crate) struct UpdateSettingsArgumentExtended {
+    /// Principle of the canister.
+    pub canister_id: CanisterId,
+    /// See [CanisterSettings].
+    pub settings: CanisterSettings,
+    /// sender_canister_version must be set to ic_cdk::api::canister_version()
+    pub sender_canister_version: Option<u64>,
 }
 
 /// The mode with which a canister is installed.
@@ -76,6 +98,22 @@ pub struct InstallCodeArgument {
     pub arg: Vec<u8>,
 }
 
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub(crate) struct InstallCodeArgumentExtended {
+    /// See [CanisterInstallMode].
+    pub mode: CanisterInstallMode,
+    /// Principle of the canister.
+    pub canister_id: CanisterId,
+    /// Code to be installed.
+    pub wasm_module: WasmModule,
+    /// The argument to be passed to `canister_init` or `canister_post_upgrade`.
+    pub arg: Vec<u8>,
+    /// sender_canister_version must be set to ic_cdk::api::canister_version()
+    pub sender_canister_version: Option<u64>,
+}
+
 /// A wrapper of canister id.
 #[derive(
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy,
@@ -83,6 +121,16 @@ pub struct InstallCodeArgument {
 pub struct CanisterIdRecord {
     /// Principle of the canister.
     pub canister_id: CanisterId,
+}
+
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy,
+)]
+pub(crate) struct CanisterIdRecordExtended {
+    /// Principle of the canister.
+    pub canister_id: CanisterId,
+    /// sender_canister_version must be set to ic_cdk::api::canister_version()
+    pub sender_canister_version: Option<u64>,
 }
 
 /// Status of a canister.
@@ -134,4 +182,132 @@ pub struct CanisterStatusResponse {
     pub cycles: Nat,
     /// Amount of cycles burned per day.
     pub idle_cycles_burned_per_day: Nat,
+}
+
+/// Details about a canister change initiated by a user.
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub struct CanisterChangeFromUserRecord {
+    /// Principle of the user.
+    pub user_id: Principal,
+}
+
+/// Details about a canister change initiated by a canister (called _originator_).
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub struct CanisterChangeFromCanisterRecord {
+    /// Principle of the originator.
+    pub canister_id: Principal,
+    /// Canister version of the originator when the originator initiated the change.
+    /// This is null if the original does not include its canister version
+    /// in the field `sender_canister_version` of the management canister payload.
+    pub canister_version: Option<u64>,
+}
+
+/// Provides details on who initiated a canister change.
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub enum CanisterChangeOrigin {
+    /// See [CanisterChangeFromUserRecord].
+    #[serde(rename = "from_user")]
+    CanisterChangeFromUser(CanisterChangeFromUserRecord),
+    /// See [CanisterChangeFromCanisterRecord].
+    #[serde(rename = "from_canister")]
+    CanisterChangeFromCanister(CanisterChangeFromCanisterRecord),
+}
+
+/// Details about a canister creation.
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub struct CanisterCreationRecord {
+    /// Initial set of canister controllers.
+    pub controllers: Vec<Principal>,
+}
+
+/// Details about a canister code deployment.
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub struct CanisterCodeDeploymentRecord {
+    /// See [CanisterInstallMode].
+    pub mode: CanisterInstallMode,
+    /// A SHA256 hash of the new module installed on the canister.
+    pub module_hash: Vec<u8>,
+}
+
+/// Details about updating canister controllers.
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub struct CanisterControllersChangeRecord {
+    /// The full new set of canister controllers.
+    pub controllers: Vec<Principal>,
+}
+
+/// Provides details on the respective canister change.
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub enum CanisterChangeDetails {
+    /// See [CanisterCreationRecord].
+    #[serde(rename = "creation")]
+    CanisterCreation(CanisterCreationRecord),
+    /// Uninstalling canister's module.
+    #[serde(rename = "code_uninstall")]
+    CanisterCodeUninstall,
+    /// See [CanisterCodeDeploymentRecord].
+    #[serde(rename = "code_deployment")]
+    CanisterCodeDeployment(CanisterCodeDeploymentRecord),
+    /// See [CanisterControllersChangeRecord].
+    #[serde(rename = "controllers_change")]
+    CanisterControllersChange(CanisterControllersChangeRecord),
+}
+
+/// Represents a canister change as stored in the canister history.
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub struct CanisterChange {
+    /// The system timestamp (in nanoseconds since Unix Epoch) at which the change was performed
+    pub timestamp_nanos: u64,
+    /// The canister version after performing the change.
+    pub canister_version: u64,
+    /// The change's origin (a user or a canister).
+    pub origin: CanisterChangeOrigin,
+    /// The change's details.
+    pub details: CanisterChangeDetails,
+}
+
+/// Argument type of [canister_info](super::canister_info).
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub struct CanisterInfoRequest {
+    /// Principle of the canister.
+    pub canister_id: Principal,
+    /// Number of most recent changes requested to be retrieved from canister history.
+    /// No changes are retrieved if this field is null.
+    pub num_requested_changes: Option<u64>,
+}
+
+/// Return type of [canister_info](super::canister_info).
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub struct CanisterInfoResponse {
+    /// Total number of changes ever recorded in canister history.
+    /// This might be higher than the number of canister changes in `recent_changes`
+    /// because the IC might drop old canister changes from its history
+    /// (with `20` most recent canister changes to always remain in the list).
+    pub total_num_changes: u64,
+    /// The canister changes stored in the order from the oldest to the most recent.
+    pub recent_changes: Vec<CanisterChange>,
+    /// A SHA256 hash of the module installed on the canister. This is null if the canister is empty.
+    pub module_hash: Option<Vec<u8>>,
+    /// Controllers of the canister.
+    pub controllers: Vec<Principal>,
 }

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -188,7 +188,7 @@ pub struct CanisterStatusResponse {
 #[derive(
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
-pub struct CanisterChangeFromUserRecord {
+pub struct FromUserRecord {
     /// Principle of the user.
     pub user_id: Principal,
 }
@@ -197,7 +197,7 @@ pub struct CanisterChangeFromUserRecord {
 #[derive(
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
-pub struct CanisterChangeFromCanisterRecord {
+pub struct FromCanisterRecord {
     /// Principle of the originator.
     pub canister_id: Principal,
     /// Canister version of the originator when the originator initiated the change.
@@ -211,19 +211,19 @@ pub struct CanisterChangeFromCanisterRecord {
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
 pub enum CanisterChangeOrigin {
-    /// See [CanisterChangeFromUserRecord].
+    /// See [FromUserRecord].
     #[serde(rename = "from_user")]
-    CanisterChangeFromUser(CanisterChangeFromUserRecord),
-    /// See [CanisterChangeFromCanisterRecord].
+    FromUser(FromUserRecord),
+    /// See [FromCanisterRecord].
     #[serde(rename = "from_canister")]
-    CanisterChangeFromCanister(CanisterChangeFromCanisterRecord),
+    FromCanister(FromCanisterRecord),
 }
 
 /// Details about a canister creation.
 #[derive(
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
-pub struct CanisterCreationRecord {
+pub struct CreationRecord {
     /// Initial set of canister controllers.
     pub controllers: Vec<Principal>,
 }
@@ -232,7 +232,7 @@ pub struct CanisterCreationRecord {
 #[derive(
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
-pub struct CanisterCodeDeploymentRecord {
+pub struct CodeDeploymentRecord {
     /// See [CanisterInstallMode].
     pub mode: CanisterInstallMode,
     /// A SHA256 hash of the new module installed on the canister.
@@ -243,7 +243,7 @@ pub struct CanisterCodeDeploymentRecord {
 #[derive(
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
-pub struct CanisterControllersChangeRecord {
+pub struct ControllersChangeRecord {
     /// The full new set of canister controllers.
     pub controllers: Vec<Principal>,
 }
@@ -253,18 +253,18 @@ pub struct CanisterControllersChangeRecord {
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
 pub enum CanisterChangeDetails {
-    /// See [CanisterCreationRecord].
+    /// See [CreationRecord].
     #[serde(rename = "creation")]
-    CanisterCreation(CanisterCreationRecord),
+    Creation(CreationRecord),
     /// Uninstalling canister's module.
     #[serde(rename = "code_uninstall")]
-    CanisterCodeUninstall,
-    /// See [CanisterCodeDeploymentRecord].
+    CodeUninstall,
+    /// See [CodeDeploymentRecord].
     #[serde(rename = "code_deployment")]
-    CanisterCodeDeployment(CanisterCodeDeploymentRecord),
-    /// See [CanisterControllersChangeRecord].
+    CodeDeployment(CodeDeploymentRecord),
+    /// See [ControllersChangeRecord].
     #[serde(rename = "controllers_change")]
-    CanisterControllersChange(CanisterControllersChangeRecord),
+    ControllersChange(ControllersChangeRecord),
 }
 
 /// Represents a canister change as stored in the canister history.


### PR DESCRIPTION
# Description

This PR makes the following changes:

- Set caller's canister version in the field `sender_canister_version` of management canister call payloads so that the caller's canister version is recorded in the canister history.
- Add management canister types and call function for `canister_info` management canister call (`CanisterInfoRequest` and `CanisterInfoResponse`)  to support this new management canister call.

# How Has This Been Tested?

This PR adds a new test canister and integration test against `StateMachine`.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
