### PR TITLE
feat: Bitcoin API handles cycles cost under the hood.

### DIFF
--- a/examples/management_canister/src/caller/lib.rs
+++ b/examples/management_canister/src/caller/lib.rs
@@ -177,14 +177,14 @@ mod bitcoin {
             network,
             min_confirmations: Some(1),
         };
-        let _balance = bitcoin_get_balance(arg, 40_000_000u128).await.unwrap().0;
+        let _balance = bitcoin_get_balance(arg).await.unwrap().0;
 
         let arg = GetUtxosRequest {
             address: address.clone(),
             network,
             filter: Some(UtxoFilter::MinConfirmations(1)),
         };
-        let mut response = bitcoin_get_utxos(arg, 4_000_000_000u128).await.unwrap().0;
+        let mut response = bitcoin_get_utxos(arg).await.unwrap().0;
 
         while let Some(page) = response.next_page {
             ic_cdk::println!("bitcoin_get_utxos next page");
@@ -193,20 +193,17 @@ mod bitcoin {
                 network,
                 filter: Some(UtxoFilter::Page(page)),
             };
-            response = bitcoin_get_utxos(arg, 4_000_000_000u128).await.unwrap().0;
+            response = bitcoin_get_utxos(arg).await.unwrap().0;
         }
 
         let arg = GetCurrentFeePercentilesRequest { network };
-        let _percentiles = bitcoin_get_current_fee_percentiles(arg, 4_000_000u128)
-            .await
-            .unwrap()
-            .0;
+        let _percentiles = bitcoin_get_current_fee_percentiles(arg).await.unwrap().0;
 
         let arg = SendTransactionRequest {
             transaction: vec![],
             network,
         };
-        let response = bitcoin_send_transaction(arg, 2_000_000_000u128).await;
+        let response = bitcoin_send_transaction(arg).await;
         assert!(response.is_err());
         if let Err((rejection_code, rejection_reason)) = response {
             assert_eq!(rejection_code, RejectionCode::CanisterReject);

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,7 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-## [0.9.0] - 2023-06-20
+## [0.9.1] - 2023-06-21
+
+### Changed
+
+- Bitcoin API handles cycles cost under the hood. (#406)
+
+## [0.9.0] - 2023-06-20 (yanked)
 
 ### Added
 

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit for the Internet Computer."

--- a/src/ic-cdk/src/api/management_canister/bitcoin/mod.rs
+++ b/src/ic-cdk/src/api/management_canister/bitcoin/mod.rs
@@ -1,4 +1,6 @@
 //! The IC Bitcoin API.
+//!
+//! Check [Bitcoin integration](https://internetcomputer.org/docs/current/developer-docs/integrations/bitcoin/bitcoin-how-it-works/#api) for more details.
 
 use crate::api::call::{call_with_payment128, CallResult};
 use candid::Principal;
@@ -6,11 +8,32 @@ use candid::Principal;
 mod types;
 pub use types::*;
 
+const GET_UTXO_MAINNET: u128 = 10_000_000_000;
+const GET_UTXO_TESTNET: u128 = 4_000_000_000;
+
+const GET_CURRENT_FEE_PERCENTILES_MAINNET: u128 = 100_000_000;
+const GET_CURRENT_FEE_PERCENTILES_TESTNET: u128 = 40_000_000;
+
+const GET_BALANCE_MAINNET: u128 = 100_000_000;
+const GET_BALANCE_TESTNET: u128 = 40_000_000;
+
+const SEND_TRANSACTION_SUBMISSION_MAINNET: u128 = 5_000_000_000;
+const SEND_TRANSACTION_SUBMISSION_TESTNET: u128 = 2_000_000_000;
+
+const SEND_TRANSACTION_PAYLOAD_MAINNET: u128 = 20_000_000;
+const SEND_TRANSACTION_PAYLOAD_TESTNET: u128 = 8_000_000;
+
 /// See [IC method `bitcoin_get_balance`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_get_balance).
 ///
-/// This call requires cycles payment. The required cycles varies according to the subnet size (number of nodes).
-/// Check [Gas and cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost) for more details.
-pub async fn bitcoin_get_balance(arg: GetBalanceRequest, cycles: u128) -> CallResult<(Satoshi,)> {
+/// This call requires cycles payment.
+/// This method handles the cycles cost under the hood.
+/// Check [API fees & Pricing](https://internetcomputer.org/docs/current/developer-docs/integrations/bitcoin/bitcoin-how-it-works/#api-fees--pricing) for more details.
+pub async fn bitcoin_get_balance(arg: GetBalanceRequest) -> CallResult<(Satoshi,)> {
+    let cycles = match arg.network {
+        BitcoinNetwork::Mainnet => GET_BALANCE_MAINNET,
+        BitcoinNetwork::Testnet => GET_BALANCE_TESTNET,
+        BitcoinNetwork::Regtest => 0,
+    };
     call_with_payment128(
         Principal::management_canister(),
         "bitcoin_get_balance",
@@ -22,12 +45,15 @@ pub async fn bitcoin_get_balance(arg: GetBalanceRequest, cycles: u128) -> CallRe
 
 /// See [IC method `bitcoin_get_utxos`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_get_utxos).
 ///
-/// This call requires cycles payment. The required cycles varies according to the subnet size (number of nodes).
-/// Check [Gas and cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost) for more details.
-pub async fn bitcoin_get_utxos(
-    arg: GetUtxosRequest,
-    cycles: u128,
-) -> CallResult<(GetUtxosResponse,)> {
+/// This call requires cycles payment.
+/// This method handles the cycles cost under the hood.
+/// Check [API fees & Pricing](https://internetcomputer.org/docs/current/developer-docs/integrations/bitcoin/bitcoin-how-it-works/#api-fees--pricing) for more details.
+pub async fn bitcoin_get_utxos(arg: GetUtxosRequest) -> CallResult<(GetUtxosResponse,)> {
+    let cycles = match arg.network {
+        BitcoinNetwork::Mainnet => GET_UTXO_MAINNET,
+        BitcoinNetwork::Testnet => GET_UTXO_TESTNET,
+        BitcoinNetwork::Regtest => 0,
+    };
     call_with_payment128(
         Principal::management_canister(),
         "bitcoin_get_utxos",
@@ -37,11 +63,28 @@ pub async fn bitcoin_get_utxos(
     .await
 }
 
+fn send_transaction_fee(arg: &SendTransactionRequest) -> u128 {
+    let (submission, payload) = match arg.network {
+        BitcoinNetwork::Mainnet => (
+            SEND_TRANSACTION_SUBMISSION_MAINNET,
+            SEND_TRANSACTION_PAYLOAD_MAINNET,
+        ),
+        BitcoinNetwork::Testnet => (
+            SEND_TRANSACTION_SUBMISSION_TESTNET,
+            SEND_TRANSACTION_PAYLOAD_TESTNET,
+        ),
+        BitcoinNetwork::Regtest => (0, 0),
+    };
+    submission + payload * arg.transaction.len() as u128
+}
+
 /// See [IC method `bitcoin_send_transaction`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_send_transaction).
 ///
-/// This call requires cycles payment. The required cycles varies according to the subnet size (number of nodes).
-/// Check [Gas and cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost) for more details.
-pub async fn bitcoin_send_transaction(arg: SendTransactionRequest, cycles: u128) -> CallResult<()> {
+/// This call requires cycles payment.
+/// This method handles the cycles cost under the hood.
+/// Check [API fees & Pricing](https://internetcomputer.org/docs/current/developer-docs/integrations/bitcoin/bitcoin-how-it-works/#api-fees--pricing) for more details.
+pub async fn bitcoin_send_transaction(arg: SendTransactionRequest) -> CallResult<()> {
+    let cycles = send_transaction_fee(&arg);
     call_with_payment128(
         Principal::management_canister(),
         "bitcoin_send_transaction",
@@ -53,12 +96,17 @@ pub async fn bitcoin_send_transaction(arg: SendTransactionRequest, cycles: u128)
 
 /// See [IC method `bitcoin_get_current_fee_percentiles`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_get_current_fee_percentiles).
 ///
-/// This call requires cycles payment. The required cycles varies according to the subnet size (number of nodes).
-/// Check [Gas and cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost) for more details.
+/// This call requires cycles payment.
+/// This method handles the cycles cost under the hood.
+/// Check [API fees & Pricing](https://internetcomputer.org/docs/current/developer-docs/integrations/bitcoin/bitcoin-how-it-works/#api-fees--pricing) for more details.
 pub async fn bitcoin_get_current_fee_percentiles(
     arg: GetCurrentFeePercentilesRequest,
-    cycles: u128,
 ) -> CallResult<(Vec<MillisatoshiPerByte>,)> {
+    let cycles = match arg.network {
+        BitcoinNetwork::Mainnet => GET_CURRENT_FEE_PERCENTILES_MAINNET,
+        BitcoinNetwork::Testnet => GET_CURRENT_FEE_PERCENTILES_TESTNET,
+        BitcoinNetwork::Regtest => 0,
+    };
     call_with_payment128(
         Principal::management_canister(),
         "bitcoin_get_current_fee_percentiles",


### PR DESCRIPTION
SDK-1142

# Description

Bitcoin API charges the same amount of cycles no matter size of subnet. And the numbers are considering constants.

Handling cycles cost under the hood makes the API more convenient.

Once this PR merged, `ic-cdk` v0.9.1 will be released and v0.9.0 will be yanked from crates.io

# How Has This Been Tested?

Example test

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
