### PR TITLE
feat: Hardcodes the fee for `sign_with_ecdsa`.

### DIFF
--- a/examples/management_canister/src/caller/lib.rs
+++ b/examples/management_canister/src/caller/lib.rs
@@ -177,14 +177,14 @@ mod bitcoin {
             network,
             min_confirmations: Some(1),
         };
-        let _balance = bitcoin_get_balance(arg).await.unwrap().0;
+        let _balance = get_balance(arg).await.unwrap().0;
 
         let arg = GetUtxosRequest {
             address: address.clone(),
             network,
             filter: Some(UtxoFilter::MinConfirmations(1)),
         };
-        let mut response = bitcoin_get_utxos(arg).await.unwrap().0;
+        let mut response = get_utxos(arg).await.unwrap().0;
 
         while let Some(page) = response.next_page {
             ic_cdk::println!("bitcoin_get_utxos next page");
@@ -193,17 +193,17 @@ mod bitcoin {
                 network,
                 filter: Some(UtxoFilter::Page(page)),
             };
-            response = bitcoin_get_utxos(arg).await.unwrap().0;
+            response = get_utxos(arg).await.unwrap().0;
         }
 
         let arg = GetCurrentFeePercentilesRequest { network };
-        let _percentiles = bitcoin_get_current_fee_percentiles(arg).await.unwrap().0;
+        let _percentiles = get_current_fee_percentiles(arg).await.unwrap().0;
 
         let arg = SendTransactionRequest {
             transaction: vec![],
             network,
         };
-        let response = bitcoin_send_transaction(arg).await;
+        let response = send_transaction(arg).await;
         assert!(response.is_err());
         if let Err((rejection_code, rejection_reason)) = response {
             assert_eq!(rejection_code, RejectionCode::CanisterReject);

--- a/examples/management_canister/src/caller/lib.rs
+++ b/examples/management_canister/src/caller/lib.rs
@@ -155,10 +155,7 @@ mod ecdsa {
             derivation_path,
             key_id,
         };
-        let SignWithEcdsaResponse { signature } = sign_with_ecdsa(arg, 10_000_000_000u128 / 13)
-            .await
-            .unwrap()
-            .0;
+        let SignWithEcdsaResponse { signature } = sign_with_ecdsa(arg).await.unwrap().0;
         assert_eq!(signature.len(), 64);
     }
 }

--- a/examples/management_canister/src/caller/lib.rs
+++ b/examples/management_canister/src/caller/lib.rs
@@ -177,14 +177,14 @@ mod bitcoin {
             network,
             min_confirmations: Some(1),
         };
-        let _balance = get_balance(arg).await.unwrap().0;
+        let _balance = bitcoin_get_balance(arg).await.unwrap().0;
 
         let arg = GetUtxosRequest {
             address: address.clone(),
             network,
             filter: Some(UtxoFilter::MinConfirmations(1)),
         };
-        let mut response = get_utxos(arg).await.unwrap().0;
+        let mut response = bitcoin_get_utxos(arg).await.unwrap().0;
 
         while let Some(page) = response.next_page {
             ic_cdk::println!("bitcoin_get_utxos next page");
@@ -193,17 +193,17 @@ mod bitcoin {
                 network,
                 filter: Some(UtxoFilter::Page(page)),
             };
-            response = get_utxos(arg).await.unwrap().0;
+            response = bitcoin_get_utxos(arg).await.unwrap().0;
         }
 
         let arg = GetCurrentFeePercentilesRequest { network };
-        let _percentiles = get_current_fee_percentiles(arg).await.unwrap().0;
+        let _percentiles = bitcoin_get_current_fee_percentiles(arg).await.unwrap().0;
 
         let arg = SendTransactionRequest {
             transaction: vec![],
             network,
         };
-        let response = send_transaction(arg).await;
+        let response = bitcoin_send_transaction(arg).await;
         assert!(response.is_err());
         if let Err((rejection_code, rejection_reason)) = response {
             assert_eq!(rejection_code, RejectionCode::CanisterReject);

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,7 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-## [0.9.1] - 2023-06-21
+## [0.9.2] - 2023-06-22
+
+### Changed
+
+- ECDSA API handles cycles cost under the hood. (#407)
+
+## [0.9.1] - 2023-06-21 (yanked)
 
 ### Changed
 

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- ECDSA API handles cycles cost under the hood. (#407)
+- Hardcodes the fee for `sign_with_ecdsa`. (#407)
 
 ## [0.9.1] - 2023-06-21 (yanked)
 

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Canister Developer Kit for the Internet Computer."

--- a/src/ic-cdk/src/api/management_canister/bitcoin/mod.rs
+++ b/src/ic-cdk/src/api/management_canister/bitcoin/mod.rs
@@ -28,7 +28,7 @@ const SEND_TRANSACTION_PAYLOAD_TESTNET: u128 = 8_000_000;
 /// This call requires cycles payment.
 /// This method handles the cycles cost under the hood.
 /// Check [API fees & Pricing](https://internetcomputer.org/docs/current/developer-docs/integrations/bitcoin/bitcoin-how-it-works/#api-fees--pricing) for more details.
-pub async fn get_balance(arg: GetBalanceRequest) -> CallResult<(Satoshi,)> {
+pub async fn bitcoin_get_balance(arg: GetBalanceRequest) -> CallResult<(Satoshi,)> {
     let cycles = match arg.network {
         BitcoinNetwork::Mainnet => GET_BALANCE_MAINNET,
         BitcoinNetwork::Testnet => GET_BALANCE_TESTNET,
@@ -48,7 +48,7 @@ pub async fn get_balance(arg: GetBalanceRequest) -> CallResult<(Satoshi,)> {
 /// This call requires cycles payment.
 /// This method handles the cycles cost under the hood.
 /// Check [API fees & Pricing](https://internetcomputer.org/docs/current/developer-docs/integrations/bitcoin/bitcoin-how-it-works/#api-fees--pricing) for more details.
-pub async fn get_utxos(arg: GetUtxosRequest) -> CallResult<(GetUtxosResponse,)> {
+pub async fn bitcoin_get_utxos(arg: GetUtxosRequest) -> CallResult<(GetUtxosResponse,)> {
     let cycles = match arg.network {
         BitcoinNetwork::Mainnet => GET_UTXO_MAINNET,
         BitcoinNetwork::Testnet => GET_UTXO_TESTNET,
@@ -83,7 +83,7 @@ fn send_transaction_fee(arg: &SendTransactionRequest) -> u128 {
 /// This call requires cycles payment.
 /// This method handles the cycles cost under the hood.
 /// Check [API fees & Pricing](https://internetcomputer.org/docs/current/developer-docs/integrations/bitcoin/bitcoin-how-it-works/#api-fees--pricing) for more details.
-pub async fn send_transaction(arg: SendTransactionRequest) -> CallResult<()> {
+pub async fn bitcoin_send_transaction(arg: SendTransactionRequest) -> CallResult<()> {
     let cycles = send_transaction_fee(&arg);
     call_with_payment128(
         Principal::management_canister(),
@@ -99,7 +99,7 @@ pub async fn send_transaction(arg: SendTransactionRequest) -> CallResult<()> {
 /// This call requires cycles payment.
 /// This method handles the cycles cost under the hood.
 /// Check [API fees & Pricing](https://internetcomputer.org/docs/current/developer-docs/integrations/bitcoin/bitcoin-how-it-works/#api-fees--pricing) for more details.
-pub async fn get_current_fee_percentiles(
+pub async fn bitcoin_get_current_fee_percentiles(
     arg: GetCurrentFeePercentilesRequest,
 ) -> CallResult<(Vec<MillisatoshiPerByte>,)> {
     let cycles = match arg.network {

--- a/src/ic-cdk/src/api/management_canister/bitcoin/mod.rs
+++ b/src/ic-cdk/src/api/management_canister/bitcoin/mod.rs
@@ -28,7 +28,7 @@ const SEND_TRANSACTION_PAYLOAD_TESTNET: u128 = 8_000_000;
 /// This call requires cycles payment.
 /// This method handles the cycles cost under the hood.
 /// Check [API fees & Pricing](https://internetcomputer.org/docs/current/developer-docs/integrations/bitcoin/bitcoin-how-it-works/#api-fees--pricing) for more details.
-pub async fn bitcoin_get_balance(arg: GetBalanceRequest) -> CallResult<(Satoshi,)> {
+pub async fn get_balance(arg: GetBalanceRequest) -> CallResult<(Satoshi,)> {
     let cycles = match arg.network {
         BitcoinNetwork::Mainnet => GET_BALANCE_MAINNET,
         BitcoinNetwork::Testnet => GET_BALANCE_TESTNET,
@@ -48,7 +48,7 @@ pub async fn bitcoin_get_balance(arg: GetBalanceRequest) -> CallResult<(Satoshi,
 /// This call requires cycles payment.
 /// This method handles the cycles cost under the hood.
 /// Check [API fees & Pricing](https://internetcomputer.org/docs/current/developer-docs/integrations/bitcoin/bitcoin-how-it-works/#api-fees--pricing) for more details.
-pub async fn bitcoin_get_utxos(arg: GetUtxosRequest) -> CallResult<(GetUtxosResponse,)> {
+pub async fn get_utxos(arg: GetUtxosRequest) -> CallResult<(GetUtxosResponse,)> {
     let cycles = match arg.network {
         BitcoinNetwork::Mainnet => GET_UTXO_MAINNET,
         BitcoinNetwork::Testnet => GET_UTXO_TESTNET,
@@ -83,7 +83,7 @@ fn send_transaction_fee(arg: &SendTransactionRequest) -> u128 {
 /// This call requires cycles payment.
 /// This method handles the cycles cost under the hood.
 /// Check [API fees & Pricing](https://internetcomputer.org/docs/current/developer-docs/integrations/bitcoin/bitcoin-how-it-works/#api-fees--pricing) for more details.
-pub async fn bitcoin_send_transaction(arg: SendTransactionRequest) -> CallResult<()> {
+pub async fn send_transaction(arg: SendTransactionRequest) -> CallResult<()> {
     let cycles = send_transaction_fee(&arg);
     call_with_payment128(
         Principal::management_canister(),
@@ -99,7 +99,7 @@ pub async fn bitcoin_send_transaction(arg: SendTransactionRequest) -> CallResult
 /// This call requires cycles payment.
 /// This method handles the cycles cost under the hood.
 /// Check [API fees & Pricing](https://internetcomputer.org/docs/current/developer-docs/integrations/bitcoin/bitcoin-how-it-works/#api-fees--pricing) for more details.
-pub async fn bitcoin_get_current_fee_percentiles(
+pub async fn get_current_fee_percentiles(
     arg: GetCurrentFeePercentilesRequest,
 ) -> CallResult<(Vec<MillisatoshiPerByte>,)> {
     let cycles = match arg.network {

--- a/src/ic-cdk/src/api/management_canister/ecdsa/mod.rs
+++ b/src/ic-cdk/src/api/management_canister/ecdsa/mod.rs
@@ -21,7 +21,8 @@ pub async fn ecdsa_public_key(
 ///
 /// See [IC method `sign_with_ecdsa`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_ecdsa).
 ///
-/// This call requires cycles payment. The required cycles varies according to the subnet size (number of nodes).
+/// This call requires cycles payment. 
+/// This method handles the cycles cost under the hood.
 /// Check [Gas and cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost) for more details.
 pub async fn sign_with_ecdsa(arg: SignWithEcdsaArgument) -> CallResult<(SignWithEcdsaResponse,)> {
     call_with_payment128(

--- a/src/ic-cdk/src/api/management_canister/ecdsa/mod.rs
+++ b/src/ic-cdk/src/api/management_canister/ecdsa/mod.rs
@@ -21,7 +21,7 @@ pub async fn ecdsa_public_key(
 ///
 /// See [IC method `sign_with_ecdsa`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_ecdsa).
 ///
-/// This call requires cycles payment. 
+/// This call requires cycles payment.
 /// This method handles the cycles cost under the hood.
 /// Check [Gas and cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost) for more details.
 pub async fn sign_with_ecdsa(arg: SignWithEcdsaArgument) -> CallResult<(SignWithEcdsaResponse,)> {

--- a/src/ic-cdk/src/api/management_canister/ecdsa/mod.rs
+++ b/src/ic-cdk/src/api/management_canister/ecdsa/mod.rs
@@ -23,9 +23,7 @@ pub async fn ecdsa_public_key(
 ///
 /// This call requires cycles payment. The required cycles varies according to the subnet size (number of nodes).
 /// Check [Gas and cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost) for more details.
-pub async fn sign_with_ecdsa(
-    arg: SignWithEcdsaArgument,
-) -> CallResult<(SignWithEcdsaResponse,)> {
+pub async fn sign_with_ecdsa(arg: SignWithEcdsaArgument) -> CallResult<(SignWithEcdsaResponse,)> {
     call_with_payment128(
         Principal::management_canister(),
         "sign_with_ecdsa",

--- a/src/ic-cdk/src/api/management_canister/ecdsa/mod.rs
+++ b/src/ic-cdk/src/api/management_canister/ecdsa/mod.rs
@@ -6,6 +6,8 @@ use candid::Principal;
 mod types;
 pub use types::*;
 
+const SIGN_WITH_ECDSA_FEE: u128 = 26_153_846_153;
+
 /// Return a SEC1 encoded ECDSA public key for the given canister using the given derivation path.
 ///
 /// See [IC method `ecdsa_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-ecdsa_public_key).
@@ -23,13 +25,12 @@ pub async fn ecdsa_public_key(
 /// Check [Gas and cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost) for more details.
 pub async fn sign_with_ecdsa(
     arg: SignWithEcdsaArgument,
-    cycles: u128,
 ) -> CallResult<(SignWithEcdsaResponse,)> {
     call_with_payment128(
         Principal::management_canister(),
         "sign_with_ecdsa",
         (arg,),
-        cycles,
+        SIGN_WITH_ECDSA_FEE,
     )
     .await
 }


### PR DESCRIPTION
* Hardcodes the fee for `sign_with_ecdsa`, as it is a constant that will not change.
* ~Removes the `bitcoin_` prefix from the bitcoin method endpoints. These methods are already encapsulated in a `bitcoin` module, so the prefix is redundant.~