### PR TITLE
chore: Check panic after await freeing resources

### DIFF
--- a/e2e-tests/canisters/async.rs
+++ b/e2e-tests/canisters/async.rs
@@ -23,14 +23,13 @@ fn invocation_count() -> u64 {
 #[update]
 #[allow(clippy::await_holding_lock)]
 async fn panic_after_async() {
-    let value = {
-        let mut lock = RESOURCE
-            .write()
-            .unwrap_or_else(|_| ic_cdk::api::trap("failed to obtain a write lock"));
-        *lock += 1;
-        *lock
-        // Drop the lock before the await point.
-    };
+    let mut lock = RESOURCE
+        .write()
+        .unwrap_or_else(|_| ic_cdk::api::trap("failed to obtain a write lock"));
+    *lock += 1;
+    let value = *lock;
+    // Do not drop the lock before the await point.
+
     let _: (u64,) = ic_cdk::call(ic_cdk::api::id(), "inc", (value,))
         .await
         .expect("failed to call self");

--- a/scripts/download_state_machine_binary.sh
+++ b/scripts/download_state_machine_binary.sh
@@ -8,7 +8,7 @@ cd "$SCRIPTS_DIR/.."
 
 uname_sys=$(uname -s | tr '[:upper:]' '[:lower:]')
 echo "uname_sys: $uname_sys"
-commit_sha="4bffd861d15a28682761c97bd0e6608bf324c5c2"
+commit_sha="b314222935b7d06c70036b0b54aa80a33252d79c"
 
 curl -sLO "https://download.dfinity.systems/ic/$commit_sha/binaries/x86_64-$uname_sys/ic-test-state-machine.gz"
 gzip -d ic-test-state-machine.gz


### PR DESCRIPTION
#365 changed the `panic_after_async` test so that it does not hold a resource open across the await point, but the thing it's supposed to be testing is that resources are freed after await points. This reverts that change.