### PR TITLE
chore: Update example http_request_required_cycles

### DIFF
--- a/examples/management_canister/src/caller/lib.rs
+++ b/examples/management_canister/src/caller/lib.rs
@@ -88,7 +88,8 @@ mod http_request {
         };
         let arg_raw = ic_cdk::export::candid::utils::encode_args((arg,))
             .expect("Failed to encode arguments.");
-        (3_000_000u128 + 60_000u128 * 13
+        (3_000_000u128
+            + 60_000u128 * 13
             + (arg_raw.len() as u128 + "http_request".len() as u128) * 400
             + max_response_bytes * 800)
             * 13

--- a/examples/management_canister/src/caller/lib.rs
+++ b/examples/management_canister/src/caller/lib.rs
@@ -88,9 +88,10 @@ mod http_request {
         };
         let arg_raw = ic_cdk::export::candid::utils::encode_args((arg,))
             .expect("Failed to encode arguments.");
-        400_000_000u128 / 13
-            + 100_000u128 / 13
-                * (arg_raw.len() as u128 + "http_request".len() as u128 + max_response_bytes)
+        (3_000_000u128 + 60_000u128 * 13
+            + (arg_raw.len() as u128 + "http_request".len() as u128) * 400
+            + max_response_bytes * 800)
+            * 13
     }
 
     #[update]

--- a/examples/management_canister/src/caller/lib.rs
+++ b/examples/management_canister/src/caller/lib.rs
@@ -88,6 +88,7 @@ mod http_request {
         };
         let arg_raw = ic_cdk::export::candid::utils::encode_args((arg,))
             .expect("Failed to encode arguments.");
+        // The fee is for a 13-node subnet to demonstrate a typical usage.
         (3_000_000u128
             + 60_000u128 * 13
             + (arg_raw.len() as u128 + "http_request".len() as u128) * 400


### PR DESCRIPTION
This PR update the function `http_request_required_cycles` from `examples` to use the new proposed formula specified [here](https://forum.dfinity.org/t/a-new-price-function-for-https-outcalls/20838).
