### PR TITLE
chore: update Rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  rust-version: 1.65.0
+  rust-version: 1.71.1
 
 jobs:
   build:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  rust-version: 1.65.0
+  rust-version: 1.71.1
   dfx-version: 0.14.1
   wasmtime-version: 10.0.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 repository = "https://github.com/dfinity/cdk-rs"
-rust-version = "1.65.0"
+rust-version = "1.71.1"
 license = "Apache-2.0"
 
 [profile.canister-release]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.71.1"
 targets = ["wasm32-unknown-unknown"]
 components = ["rustfmt", "clippy"]
 


### PR DESCRIPTION
# Description

ProdSec recommends bumping the Rust version to 1.71.1

# How Has This Been Tested?

CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
