### PR TITLE
chore: revert MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  rust-version: 1.71.1
+  rust-version: 1.65.0
 
 jobs:
   build:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  rust-version: 1.71.1
+  rust-version: 1.65.0
   dfx-version: 0.14.1
   wasmtime-version: 10.0.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,12 @@ members = [
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 repository = "https://github.com/dfinity/cdk-rs"
-rust-version = "1.71.1"
+# MSRV
+# Avoid updating this field unless we use new Rust features
+# Sync rust-version in following CI files:
+# .github/workflows/ci.yml
+# .github/workflows/examples.yml
+rust-version = "1.65.0"
 license = "Apache-2.0"
 
 [profile.canister-release]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,7 +3,5 @@ channel = "1.71.1"
 targets = ["wasm32-unknown-unknown"]
 components = ["rustfmt", "clippy"]
 
-# Sync rust-version in following files
-# Cargo.toml
-# .github/workflows/ci.yml
-# .github/workflows/examples.yml
+# The version only influences the local develop environment.
+# No need to sync with Cargo.toml and CI.


### PR DESCRIPTION
> For library projects, we should not change the rust-version line in Cargo.toml. Because that field restricts the minimum supported Rust version (MSRV) of the crate which will enforce the dependent crates/projects to upgrade their MSRV too, i.e. the change is contagious. We should avoid updating the field as mush as we can. And we should use the same version in CI to guarantee the MSRV.

Revert MSRV and add some tips for maintenance.