### PR TITLE
chore: unify Rust toolchain version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.rust-version }}
+          override: true
           target: wasm32-unknown-unknown
       - name: Run builds
         run: |
@@ -67,6 +68,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.rust-version }}
+          override: true
       - name: Install protoc
         run: |
           sudo apt-get install -y protobuf-compiler
@@ -100,6 +102,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.rust-version }}
+          override: true
           components: rustfmt
       - name: Check formatting
         run: |
@@ -128,6 +131,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.rust-version }}
+          override: true
           components: clippy
       - name: Install protoc
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           bash scripts/download_state_machine_binary.sh
       - name: Run tests
         run: |
-          cargo test --exclude candid-extractor --all-targets
+          cargo test --workspace --exclude candid-extractor --all-targets
 
   fmt:
     name: cargo fmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,9 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.rust-version }}
-          override: true
           target: wasm32-unknown-unknown
+      - name: Override Rust
+        run: rustup override set ${{ env.rust-version }}
       - name: Run builds
         run: |
           cargo build --workspace --exclude ic-cdk-e2e-tests --exclude candid-extractor --target wasm32-unknown-unknown
@@ -71,7 +72,8 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.rust-version }}
-          override: true
+      - name: Override Rust
+        run: rustup override set ${{ env.rust-version }}
       - name: Install protoc
         run: |
           sudo apt-get install -y protobuf-compiler
@@ -105,8 +107,9 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.rust-version }}
-          override: true
           components: rustfmt
+      - name: Override Rust
+        run: rustup override set ${{ env.rust-version }}
       - name: Check formatting
         run: |
           cargo fmt --all -- --check
@@ -134,8 +137,9 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.rust-version }}
-          override: true
           components: clippy
+      - name: Override Rust
+        run: rustup override set ${{ env.rust-version }}
       - name: Install protoc
         run: |
           sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # MSRV
+  # should be the same as in Cargo.toml
+  # not rust-toolchain.toml
   rust-version: 1.65.0
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  # MSRV
-  # should be the same as in Cargo.toml
-  # not rust-toolchain.toml
-  rust-version: 1.65.0
-
 jobs:
   build:
     name: cargo build
@@ -32,17 +26,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-build-${{ hashFiles('**/Cargo.toml', 'rust-toolchain.toml') }}
+          key: ${{ runner.os }}-build-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
           restore-keys: |
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: ${{ env.rust-version }}
-          target: wasm32-unknown-unknown
-      - name: Override Rust
-        run: rustup override set ${{ env.rust-version }}
       - name: Run builds
         run: |
           cargo build --workspace --exclude ic-cdk-e2e-tests --exclude candid-extractor --target wasm32-unknown-unknown
@@ -64,25 +51,16 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-test-${{ hashFiles('**/Cargo.toml', 'rust-toolchain.toml') }}
+          key: ${{ runner.os }}-test-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
           restore-keys: |
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: ${{ env.rust-version }}
-      - name: Override Rust
-        run: rustup override set ${{ env.rust-version }}
-      - name: Install protoc
-        run: |
-          sudo apt-get install -y protobuf-compiler
       - name: Download ic-test-state-machine
         run: |
           bash scripts/download_state_machine_binary.sh
       - name: Run tests
         run: |
-          cargo test --all-targets
+          cargo test --exclude candid-extractor --all-targets
 
   fmt:
     name: cargo fmt
@@ -99,17 +77,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-fmt-${{ hashFiles('**/Cargo.toml', 'rust-toolchain.toml') }}
+          key: ${{ runner.os }}-fmt-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
           restore-keys: |
             ${{ runner.os }}-fmt-
             ${{ runner.os }}-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: ${{ env.rust-version }}
-          components: rustfmt
-      - name: Override Rust
-        run: rustup override set ${{ env.rust-version }}
       - name: Check formatting
         run: |
           cargo fmt --all -- --check
@@ -129,20 +100,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-clippy-${{ hashFiles('**/Cargo.toml', 'rust-toolchain.toml') }}
+          key: ${{ runner.os }}-clippy-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
           restore-keys: |
             ${{ runner.os }}-clippy-
             ${{ runner.os }}-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: ${{ env.rust-version }}
-          components: clippy
-      - name: Override Rust
-        run: rustup override set ${{ env.rust-version }}
-      - name: Install protoc
-        run: |
-          sudo apt-get install -y protobuf-compiler
       - name: Run clippy
         run: |
           cargo clippy --tests --benches -- -D warnings

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -11,6 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # MSRV
+  # should be the same as in Cargo.toml
+  # not rust-toolchain.toml
   rust-version: 1.65.0
   dfx-version: 0.14.1
   ic-wasm-version: 0.4.0

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -65,7 +65,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             examples/${{ matrix.project-name }}/target/
-          key: ${{ runner.os }}-${{ matrix.project-name }}-${{ hashFiles('rust-toolchain.toml') }}
+          key: ${{ runner.os }}-${{ matrix.project-name }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.project-name }}-
             ${{ runner.os }}-

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -120,7 +120,7 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
-      - name: cargo fmt # no clippy because #[import] makes it fail
+      - name: cargo fmt # no clippy because build.rs using ic-cdk-bindgen would fail
         run: |
           pushd examples/${{ matrix.project-name }}
           cargo fmt --check

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -11,10 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # MSRV
-  # should be the same as in Cargo.toml
-  # not rust-toolchain.toml
-  rust-version: 1.65.0
   dfx-version: 0.14.1
   ic-wasm-version: 0.4.0
 
@@ -34,18 +30,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-candid-extractor-${{ hashFiles('**/Cargo.toml', 'rust-toolchain.toml') }}
+          key: ${{ runner.os }}-candid-extractor-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
           restore-keys: |
             ${{ runner.os }}-candid-extractor-
             ${{ runner.os }}-
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: ${{ env.rust-version }}
-
-      - name: Override Rust
-        run: rustup override set ${{ env.rust-version }}
 
       - name: Build candid-extractor
         run: cargo build -p candid-extractor --release
@@ -77,20 +65,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             examples/${{ matrix.project-name }}/target/
-          key: ${{ runner.os }}-${{ matrix.project-name }}-${{ hashFiles('**/Cargo.toml', 'rust-toolchain.toml') }}
+          key: ${{ runner.os }}-${{ matrix.project-name }}-${{ hashFiles('rust-toolchain.toml') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.project-name }}-
             ${{ runner.os }}-
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: ${{ env.rust-version }}
-          target: wasm32-unknown-unknown
-          components: rustfmt
-
-      - name: Override Rust
-        run: rustup override set ${{ env.rust-version }}
 
       - name: Install ic-wasm
         # might already in cache

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -43,7 +43,9 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.rust-version }}
-          override: true
+
+      - name: Override Rust
+        run: rustup override set ${{ env.rust-version }}
 
       - name: Build candid-extractor
         run: cargo build -p candid-extractor --release
@@ -84,9 +86,11 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.rust-version }}
-          override: true
           target: wasm32-unknown-unknown
           components: rustfmt
+
+      - name: Override Rust
+        run: rustup override set ${{ env.rust-version }}
 
       - name: Install ic-wasm
         # might already in cache

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -40,6 +40,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.rust-version }}
+          override: true
 
       - name: Build candid-extractor
         run: cargo build -p candid-extractor --release
@@ -80,6 +81,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.rust-version }}
+          override: true
           target: wasm32-unknown-unknown
           components: rustfmt
 

--- a/.github/workflows/release-candid-extractor.yml
+++ b/.github/workflows/release-candid-extractor.yml
@@ -5,6 +5,9 @@ on:
       - "candid-extractor-*"
 
 env:
+  # MSRV
+  # should be the same as in Cargo.toml
+  # not rust-toolchain.toml
   rust-version: 1.65.0
 
 jobs:

--- a/.github/workflows/release-candid-extractor.yml
+++ b/.github/workflows/release-candid-extractor.yml
@@ -4,12 +4,6 @@ on:
     tags:
       - "candid-extractor-*"
 
-env:
-  # MSRV
-  # should be the same as in Cargo.toml
-  # not rust-toolchain.toml
-  rust-version: 1.65.0
-
 jobs:
   release:
     runs-on: ${{ matrix.os }}
@@ -37,19 +31,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-release-${{ hashFiles('**/Cargo.toml', 'rust-toolchain.toml') }}
+          key: ${{ runner.os }}-candid-extractor-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
           restore-keys: |
-            ${{ runner.os }}-release-
+            ${{ runner.os }}-candid-extractor-
             ${{ runner.os }}-
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: ${{ env.rust-version }}
-
-      - name: Override Rust
-        run: rustup override set ${{ env.rust-version }}
-
       - name: Build
         run: |
           cargo build -p candid-extractor --release --locked

--- a/.github/workflows/release-candid-extractor.yml
+++ b/.github/workflows/release-candid-extractor.yml
@@ -46,7 +46,9 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.rust-version }}
-          override: true
+
+      - name: Override Rust
+        run: rustup override set ${{ env.rust-version }}
 
       - name: Build
         run: |

--- a/.github/workflows/release-candid-extractor.yml
+++ b/.github/workflows/release-candid-extractor.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-            # The indirect dependency `zstd-safe` (introduced by `wasmtime`) needs higher version of GLIBC.
-            # using ubuntu-20.04 will fail to compile
+          # The indirect dependency `zstd-safe` (introduced by `wasmtime`) needs higher version of GLIBC.
+          # using ubuntu-20.04 will fail to compile
           - os: ubuntu-22.04
             binstall_pkg: candid-extractor-x86_64-unknown-linux-gnu.tar.gz
           - os: macos-12
@@ -43,6 +43,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.rust-version }}
+          override: true
 
       - name: Build
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,8 @@ dependencies = [
 [[package]]
 name = "ic-test-state-machine-client"
 version = "3.0.0"
-source = "git+https://github.com/lwshang/test-state-machine-client?branch=lwshang/candid_0.9#1bb17d8d2d7ecb762dc9fd6621ff105d12ed5107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cadf6ac4a193a8a45287da67c6c385f118d9266f46d6d98e40fbbd469d3822e"
 dependencies = [
  "candid",
  "ciborium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 repository = "https://github.com/dfinity/cdk-rs"
 # MSRV
 # Avoid updating this field unless we use new Rust features
+# Sync with rust-toolchain.toml
 rust-version = "1.66.0"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ repository = "https://github.com/dfinity/cdk-rs"
 # Sync rust-version in following CI files:
 # .github/workflows/ci.yml
 # .github/workflows/examples.yml
-rust-version = "1.65.0"
+rust-version = "1.66.0"
 license = "Apache-2.0"
 
 [profile.canister-release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,7 @@
 [workspace]
 members = [
-    "src/ic0",
-    "src/ic-cdk",
-    "src/ic-cdk-bindgen",
-    "src/ic-cdk-macros",
-    "src/ic-cdk-timers",
-    "src/candid-extractor",
-    "library/ic-certified-map",
-    "library/ic-ledger-types",
+    "src/*",
+    "library/*",
     "e2e-tests",
 ]
 
@@ -17,9 +11,6 @@ edition = "2021"
 repository = "https://github.com/dfinity/cdk-rs"
 # MSRV
 # Avoid updating this field unless we use new Rust features
-# Sync rust-version in following CI files:
-# .github/workflows/ci.yml
-# .github/workflows/examples.yml
 rust-version = "1.66.0"
 license = "Apache-2.0"
 

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -43,5 +43,4 @@ path = "canisters/canister_info.rs"
 
 [dev-dependencies]
 hex.workspace = true
-# TODO: Use the public crate when this [PR](https://github.com/dfinity/test-state-machine-client/pull/19) merge.
-ic-test-state-machine-client = { git = "https://github.com/lwshang/test-state-machine-client", branch = "lwshang/candid_0.9" }
+ic-test-state-machine-client = "3"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,4 @@
 [toolchain]
-channel = "1.71.1"
+channel = "1.66.0"
 targets = ["wasm32-unknown-unknown"]
 components = ["rustfmt", "clippy"]
-
-# The version only influences the local develop environment.
-# No need to sync with Cargo.toml and CI.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.66.0"
+channel = "1.66.0" # sync with rust-version in root Cargo.toml
 targets = ["wasm32-unknown-unknown"]
 components = ["rustfmt", "clippy"]

--- a/src/candid-extractor/Cargo.toml
+++ b/src/candid-extractor/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
-rust-version.workspace = true
 repository.workspace = true
 description = "CLI tool to extract candid definition from canister WASM."
 readme = "README.md"

--- a/src/candid-extractor/Cargo.toml
+++ b/src/candid-extractor/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 description = "CLI tool to extract candid definition from canister WASM."
 readme = "README.md"

--- a/src/candid-extractor/src/main.rs
+++ b/src/candid-extractor/src/main.rs
@@ -25,7 +25,7 @@ where
 
     let memory = canister
         .get_memory(&mut store, "memory")
-        .ok_or(anyhow::format_err!("failed to find `memory` export"))?;
+        .ok_or_else(|| anyhow::format_err!("failed to find `memory` export"))?;
     let memory_buffer = memory.data(&store);
 
     let mut i = candid_pointer as usize;


### PR DESCRIPTION
# Description

MSRV is increased to 1.66.0 because `candid-extractor`'s dependency `wasmtime` requires it.

There will be only two places specify Rust toolchain version:
* Cargo.toml
* rust-toolchain.toml

They should sync with each other.

# How Has This Been Tested?

Check the actions log.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
