### PR TITLE
fix: Remove global state from `ic-cdk-macros`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "5907a1b7c277254a8b15170f6e7c97cfa60ee7872a3217663bb81151e48184bb"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "candid",
  "ic-cdk",

--- a/src/ic-cdk-macros/CHANGELOG.md
+++ b/src/ic-cdk-macros/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.8.1] - 2023-10-02
+
+### Fixed
+
+- Macros no longer use global state in the names of functions. JetBrains IDEs should no longer produce spurious errors. (#430)
+
 ## [0.8.0] - 2023-09-18
 
 ### Changed

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-macros"
-version = "0.8.0" # no need to sync with ic-cdk
+version = "0.8.1" # no need to sync with ic-cdk
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/src/ic-cdk-macros/src/export.rs
+++ b/src/ic-cdk-macros/src/export.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Ident, Span, TokenStream};
-use quote::quote;
+use quote::{format_ident, quote};
 use serde::Deserialize;
 use serde_tokenstream::from_tokenstream;
 use std::fmt::Formatter;
@@ -57,7 +57,7 @@ impl std::fmt::Display for MethodType {
 fn get_args(method: MethodType, signature: &Signature) -> Result<Vec<(Ident, Box<Type>)>, Error> {
     // We only need the tuple of arguments, not their types. Magic of type inference.
     let mut args = vec![];
-    for ref arg in &signature.inputs {
+    for (i, arg) in signature.inputs.iter().enumerate() {
         let (ident, ty) = match arg {
             FnArg::Receiver(r) => {
                 return Err(Error::new(
@@ -73,7 +73,7 @@ fn get_args(method: MethodType, signature: &Signature) -> Result<Vec<(Ident, Box
                     (ident.clone(), ty.clone())
                 } else {
                     (
-                        syn::Ident::new(&format!("arg_{}", crate::id()), pat.span()),
+                        format_ident!("__unnamed_arg_{i}", span = pat.span()),
                         ty.clone(),
                     )
                 }
@@ -133,7 +133,7 @@ fn dfn_macro(
         get_args(method, signature)?.iter().cloned().unzip();
     let name = &signature.ident;
 
-    let outer_function_ident = Ident::new(&format!("{}_{}_", name, crate::id()), Span::call_site());
+    let outer_function_ident = format_ident!("__canister_method_{name}");
 
     let function_name = attrs.name.unwrap_or_else(|| name.to_string());
     let export_name = if method.is_lifecycle() {

--- a/src/ic-cdk-macros/src/lib.rs
+++ b/src/ic-cdk-macros/src/lib.rs
@@ -30,16 +30,9 @@
 )]
 
 use proc_macro::TokenStream;
-use std::sync::atomic::{AtomicU32, Ordering};
 use syn::Error;
 
 mod export;
-
-// To generate unique identifiers for functions and arguments
-static NEXT_ID: AtomicU32 = AtomicU32::new(0);
-pub(crate) fn id() -> u32 {
-    NEXT_ID.fetch_add(1, Ordering::SeqCst)
-}
 
 fn handle_debug_and_errors<F>(
     cb: F,


### PR DESCRIPTION
Stateful macro crates can cause IDE errors when the IDE keeps a single instance of the macro crate loaded and runs it multiple times. This PR removes the last remaining global state from the macros.