### PR TITLE
feat: Added query stats to canister status endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "ic-cdk"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "candid",
  "ic-cdk-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ opt-level = 'z'
 
 [workspace.dependencies]
 ic0 = { path = "src/ic0", version = "0.21.1" }
-ic-cdk = { path = "src/ic-cdk", version = "0.11.3" }
+ic-cdk = { path = "src/ic-cdk", version = "0.11.4" }
 ic-cdk-timers = { path = "src/ic-cdk-timers", version = "0.5.1" }
 
 candid = "0.9.6"

--- a/scripts/download_state_machine_binary.sh
+++ b/scripts/download_state_machine_binary.sh
@@ -8,7 +8,9 @@ cd "$SCRIPTS_DIR/.."
 
 uname_sys=$(uname -s | tr '[:upper:]' '[:lower:]')
 echo "uname_sys: $uname_sys"
-commit_sha="15e69667ae983fa92c33794a3954d9ca87518af6"
+# Check https://gitlab.com/dfinity-lab/public/ic/-/commits/master
+# Find the most recent commit with a green check mark (the artifacts were built successfully)
+commit_sha="f3216c1d7d83a366b4af0cf24708f84819880246"
 
 curl -sLO "https://download.dfinity.systems/ic/$commit_sha/binaries/x86_64-$uname_sys/ic-test-state-machine.gz"
 gzip -d ic-test-state-machine.gz

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+  - Added support for query statistics in the canister status API (#432)
+
 ## [0.11.0] - 2023-09-18
 
 ### Changed
@@ -174,7 +178,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--  `StableWriter` and `StableReader` are now wrappers around `StableIO`. 
+-  `StableWriter` and `StableReader` are now wrappers around `StableIO`.
 
 ## [0.6.5] - 2022-11-04
 
@@ -280,14 +284,14 @@ BREAKING CHANGE of experimental API:
 - Add Clone and Copy to RejectionCode (#202)
 
 ### Fixed
-- Do not call done() in stable_restore() (#216) 
+- Do not call done() in stable_restore() (#216)
 - Remove out-of-bounds vulnerability (#208)
 - Run inter-canister calls without awaiting (#233)
 
 ## [0.4.0] - 2022-01-26
 ### Changed
-- `candid` is required to be included in `[dependencies]` to use the `#[import]` macro  (#190) 
-- Deprecate block_on in favour of the new spawn function (#189) 
+- `candid` is required to be included in `[dependencies]` to use the `#[import]` macro  (#190)
+- Deprecate block_on in favour of the new spawn function (#189)
 - Trap in setup panic hook (#172)
 
 ## [0.3.3] - 2021-11-17
@@ -296,5 +300,5 @@ BREAKING CHANGE of experimental API:
 
 ## [0.3.2] - 2021-09-16
 ### Added
-- Add support for 64 bit stable memory (#137) 
+- Add support for 64 bit stable memory (#137)
 - Add support for 'heartbeat' and 'inspect_message' (#129)

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,9 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.11.4] - 2023-11-20
+
 ### Added
 
-- `query_stats` in `canister_status` response (#432).
+- `query_stats` in `canister_status` response. (#432)
   
 ## [0.11.3] - 2023-10-12
 

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.11.3"
+version = "0.11.4"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -164,7 +164,7 @@ pub struct DefiniteCanisterSettings {
     pub freezing_threshold: Nat,
 }
 
-/// Argument type of query stats, which are returned by [canister_status](super::canister_status).
+/// Query statistics, returned by [canister_status](super::canister_status).
 #[derive(
     CandidType, Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
 )]
@@ -192,8 +192,8 @@ pub struct CanisterStatusResponse {
     pub cycles: Nat,
     /// Amount of cycles burned per day.
     pub idle_cycles_burned_per_day: Nat,
-    /// Query Stats
-    query_stats: QueryStats,
+    /// Query statistics
+    pub query_stats: QueryStats,
 }
 
 /// Details about a canister change initiated by a user.

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -164,6 +164,17 @@ pub struct DefiniteCanisterSettings {
     pub freezing_threshold: Nat,
 }
 
+/// Argument type of query stats, which are returned by [canister_status](super::canister_status).
+#[derive(
+    CandidType, Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
+)]
+pub struct QueryStats {
+    num_calls: candid::Nat,
+    num_instructions: candid::Nat,
+    ingress_payload_size: candid::Nat,
+    egress_payload_size: candid::Nat,
+}
+
 /// Argument type of [canister_status](super::canister_status).
 #[derive(
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
@@ -181,6 +192,8 @@ pub struct CanisterStatusResponse {
     pub cycles: Nat,
     /// Amount of cycles burned per day.
     pub idle_cycles_burned_per_day: Nat,
+    /// Query Stats
+    query_stats: QueryStats,
 }
 
 /// Details about a canister change initiated by a user.

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -169,10 +169,10 @@ pub struct DefiniteCanisterSettings {
     CandidType, Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
 )]
 pub struct QueryStats {
-    num_calls: candid::Nat,
-    num_instructions: candid::Nat,
-    ingress_payload_size: candid::Nat,
-    egress_payload_size: candid::Nat,
+    num_calls_total: candid::Nat,
+    num_instructions_total: candid::Nat,
+    request_payload_bytes_total: candid::Nat,
+    response_payload_bytes_total: candid::Nat,
 }
 
 /// Argument type of [canister_status](super::canister_status).


### PR DESCRIPTION
# Description

Adds support for [query statistics](https://forum.dfinity.org/t/community-consideration-explore-query-charging/19247/23?u=stefan-kaestle) to the Rust CDK.

The IC will periodically update the query statistics in the canister status as described in the [proposal](https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=123481).

Fixes # (issue)

# How Has This Been Tested?

There are multiple unit, system and e2e tests that test if query statistics are updated.

The canister status endpoint has been extended to contain those new statistics, but no further testing on the canister status side has been added.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
