### PR TITLE
chore: Release ic-cdk@0.11.1, ic0@0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "ic-cdk"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "candid",
  "ic-cdk-macros",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "ic0"
-version = "0.18.12"
+version = "0.21.0"
 dependencies = [
  "quote",
  "syn 1.0.107",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,5 @@
 [workspace]
-members = [
-    "src/*",
-    "library/*",
-    "e2e-tests",
-]
+members = ["src/*", "library/*", "e2e-tests"]
 
 [workspace.package]
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
@@ -23,8 +19,8 @@ lto = true
 opt-level = 'z'
 
 [workspace.dependencies]
-ic0 = { path = "src/ic0", version = "0.18.12" }
-ic-cdk = { path = "src/ic-cdk", version = "0.11" }
+ic0 = { path = "src/ic0", version = "0.21.0" }
+ic-cdk = { path = "src/ic-cdk", version = "0.11.1" }
 ic-cdk-timers = { path = "src/ic-cdk-timers", version = "0.5.0" }
 
 candid = "0.9.6"

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.11.0"
+version = "0.11.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/src/ic0/Cargo.toml
+++ b/src/ic0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic0"
-version = "0.18.12"
+version = "0.21.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
This fixes a semver breakage between ic-cdk@0.10.0 and ic0@0.18.12.