### PR TITLE
chore: Release ic-cdk-timers@0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-timers"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "futures",
  "ic-cdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ opt-level = 'z'
 [workspace.dependencies]
 ic0 = { path = "src/ic0", version = "0.21.1" }
 ic-cdk = { path = "src/ic-cdk", version = "0.11.2" }
-ic-cdk-timers = { path = "src/ic-cdk-timers", version = "0.5.0" }
+ic-cdk-timers = { path = "src/ic-cdk-timers", version = "0.5.1" }
 
 candid = "0.9.6"
 futures = "0.3"

--- a/src/ic-cdk-timers/Cargo.toml
+++ b/src/ic-cdk-timers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-timers"
-version = "0.5.0"
+version = "0.5.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Should have been part of #433. Fixes #436.