### PR TITLE
feat: Adding icrc1_memo field to the Transaction

### DIFF
--- a/library/ic-ledger-types/src/lib.rs
+++ b/library/ic-ledger-types/src/lib.rs
@@ -502,6 +502,8 @@ pub struct Transaction {
     pub operation: Option<Operation>,
     /// The time at which the client of the ledger constructed the transaction.
     pub created_at_time: Timestamp,
+    /// The memo that was provided to the icrc1_transfer endpoint.
+    pub icrc1_memo: Option<ByteBuf>,
 }
 
 /// A single record in the ledger.


### PR DESCRIPTION
# Description

Adding the `icrc1_memo` field to the `Transaction` struct. The field was previously added to the `Transaction` struct in the ICP ledger.

Closes #444.