### PR TITLE
feat: Add `reserved_cycles` and `reserved_cycles_limit`

### DIFF
--- a/e2e-tests/canisters/canister_info.rs
+++ b/e2e-tests/canisters/canister_info.rs
@@ -71,6 +71,7 @@ async fn canister_lifecycle() -> Principal {
             compute_allocation: None,
             memory_allocation: None,
             freezing_threshold: None,
+            reserved_cycles_limit: None,
         },
         canister_id: canister_id.canister_id,
     })

--- a/e2e-tests/canisters/management_caller.rs
+++ b/e2e-tests/canisters/management_caller.rs
@@ -11,7 +11,7 @@ mod main {
                 compute_allocation: Some(0u8.into()),
                 memory_allocation: Some(10000u16.into()),
                 freezing_threshold: Some(10000u16.into()),
-                reserved_cycles_limit: Some(10000.into()),
+                reserved_cycles_limit: Some(10000u16.into()),
             }),
         };
         let canister_id = create_canister(arg, 100_000_000_000u128 / 13)
@@ -41,6 +41,7 @@ mod main {
         stop_canister(arg).await.unwrap();
         let response = canister_status(arg).await.unwrap().0;
         assert_eq!(response.status, CanisterStatusType::Stopped);
+        assert_eq!(response.reserved_cycles.0, 0u128.into());
         deposit_cycles(arg, 1_000_000_000_000u128).await.unwrap();
         delete_canister(arg).await.unwrap();
         let response = raw_rand().await.unwrap().0;

--- a/e2e-tests/canisters/management_caller.rs
+++ b/e2e-tests/canisters/management_caller.rs
@@ -11,6 +11,7 @@ mod main {
                 compute_allocation: Some(0u8.into()),
                 memory_allocation: Some(10000u16.into()),
                 freezing_threshold: Some(10000u16.into()),
+                reserved_cycles_limit: Some(10000.into()),
             }),
         };
         let canister_id = create_canister(arg, 100_000_000_000u128 / 13)
@@ -58,6 +59,7 @@ mod provisional {
             compute_allocation: Some(50u8.into()),
             memory_allocation: Some(10000u16.into()),
             freezing_threshold: Some(10000u16.into()),
+            reserved_cycles_limit: Some(10000u16.into()),
         };
         let arg = ProvisionalCreateCanisterWithCyclesArgument {
             amount: Some(1_000_000_000u64.into()),

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+- Add `reserved_cycles` and `reserved_cycles_limit` to the management canister.
+
 ## [0.12.0] - 2023-11-23
 
 ### Changed

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -21,7 +21,7 @@ pub struct CanisterSettings {
     pub freezing_threshold: Option<Nat>,
     /// Must be a number between 0 and 2^128^-1, inclusively, and indicates the
     /// upper limit on cycles in the `reserved_cycles` balance of the canister.
-    pub reserved_cycles_limit: Option<Nat>.
+    pub reserved_cycles_limit: Option<Nat>,
 }
 
 /// Argument type of [create_canister](super::create_canister).

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -19,6 +19,9 @@ pub struct CanisterSettings {
     pub memory_allocation: Option<Nat>,
     /// Must be a number between 0 and 2^64^-1, inclusively, and indicates a length of time in seconds.
     pub freezing_threshold: Option<Nat>,
+    /// Must be a number between 0 and 2^128^-1, inclusively, and indicates the
+    /// upper limit on cycles in the `reserved_cycles` balance of the canister.
+    pub reserved_cycles_limit: Option<Nat>.
 }
 
 /// Argument type of [create_canister](super::create_canister).
@@ -162,6 +165,8 @@ pub struct DefiniteCanisterSettings {
     pub memory_allocation: Nat,
     /// Freezing threshold.
     pub freezing_threshold: Nat,
+    /// Reserved cycles limit.
+    pub reserved_cycles_limit: Nat,
 }
 
 /// Query statistics, returned by [canister_status](super::canister_status).
@@ -194,6 +199,11 @@ pub struct CanisterStatusResponse {
     pub idle_cycles_burned_per_day: Nat,
     /// Query statistics
     pub query_stats: QueryStats,
+    /// The reserved cycles balance of the canister.
+    /// These are cycles that are reserved by the resource reservation mechanism
+    /// on storage allocation. See also the `reserved_cycles_limit` parameter in
+    /// canister settings.
+    pub reserved_cycles: candid::Nat,
 }
 
 /// Details about a canister change initiated by a user.


### PR DESCRIPTION
This adds the new fields to the API of the management canister:
- `reserved_cycles` to `CanisterStatusResponse`.
- `reserved_cycles_limit` to `CanisterSettings` and `DefiniteCanisterSettings`.

More information:
- https://forum.dfinity.org/t/23447
- https://dashboard.internetcomputer.org/proposal/126094

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [] I have made corresponding changes to the documentation.
