### PR TITLE
fix: trap with 'Call already trapped' when using futures::stream

### DIFF
--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -153,6 +153,8 @@ unsafe extern "C" fn callback<T: AsRef<[u8]>>(state_ptr: *const RwLock<CallFutur
             // borrow_mut() the state as well. So we need to be careful to not double-borrow_mut.
             waker.wake()
         }
+    } else {
+        crate::trap("Call already trapped");
     }
 }
 


### PR DESCRIPTION
This MR fixes the following issue with polling multiple futures using `futures::stream`: when invoking the method `bar` of the following canister code
```
async fn status() {
    let arg = CanisterIdRecord {
        canister_id: ic_cdk::id(),
    };
    let bytes = Encode!(&arg).unwrap();
    let _raw_resp = call_raw(
        Principal::management_canister(),
        "canister_status",
        bytes,
        0,
    )
    .await;
    ic_cdk::trap("trapping");
}

#[ic_cdk::update]
async fn bar() {
    let mut futs = vec![];
    for _ in 0..3 {
        futs.push(status());
    }
    let stream = futures::stream::iter(futs).buffer_unordered(10);
    stream.collect::<Vec<_>>().await;
}
```
the call fails with "Canister did not reply to the call" instead of the expected "Call already trapped". 

[This](https://docs.rs/futures-util/0.3.29/src/futures_util/stream/futures_unordered/mod.rs.html#95) is the root cause I believe. Since the current context's waker (a.k.a. cdk-rs' waker) is replaced by another one, the new waker will be invoked [here](https://github.com/dfinity/cdk-rs/blob/5440fec8136ebec641cf997c9a7670be99af8f5b/src/ic-cdk/src/api/call.rs#L154) or [here](https://github.com/dfinity/cdk-rs/blob/5440fec8136ebec641cf997c9a7670be99af8f5b/src/ic-cdk/src/api/call.rs#L184) and then the new waker will wake the cdk-rs' waker (see [here](https://github.com/rust-lang/futures-rs/blob/970e0888dfb34c984ddea4a83c85eb646c701951/futures-util/src/stream/futures_unordered/task.rs#L73)). Afterwards, it's the cdk-rs' waker [responsibility](https://github.com/rust-lang/futures-rs/blob/970e0888dfb34c984ddea4a83c85eb646c701951/futures-util/src/stream/futures_unordered/task.rs#L63) to [poll](https://github.com/dfinity/cdk-rs/blob/5440fec8136ebec641cf997c9a7670be99af8f5b/src/ic-cdk/src/futures.rs#L102) again. However, we [don't want](https://github.com/dfinity/cdk-rs/blob/5440fec8136ebec641cf997c9a7670be99af8f5b/src/ic-cdk/src/futures.rs#L89) to poll again after a trap and thus the cdk-rs' waker will never be woken again after a trap and thus we won't keep [trapping](https://github.com/dfinity/cdk-rs/blob/5440fec8136ebec641cf997c9a7670be99af8f5b/src/ic-cdk/src/futures.rs#L91) for subsequent callbacks. Consequently, the overall update call will fail with with "Canister did not reply to the call" instead of "Call already trapped". Moreover, the state of the outstanding futures will be dropped after the cleanup callback of the trapped future (since we won't poll the parent update call's future) and thus we can trap with "Call already trapped" if we don't find the call future's state in the callback handler which is exactly what this PR implements.