### PR TITLE
fix: query stats: make members public

### DIFF
--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -174,9 +174,13 @@ pub struct DefiniteCanisterSettings {
     CandidType, Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
 )]
 pub struct QueryStats {
+    /// Total number of query calls.
     pub num_calls_total: candid::Nat,
+    /// Total number of instructions executed by query calls.
     pub num_instructions_total: candid::Nat,
+    /// Total number of payload bytes use for query call requests.
     pub request_payload_bytes_total: candid::Nat,
+    /// Total number of payload bytes use for query call responses.
     pub response_payload_bytes_total: candid::Nat,
 }
 

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -174,10 +174,10 @@ pub struct DefiniteCanisterSettings {
     CandidType, Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
 )]
 pub struct QueryStats {
-    num_calls_total: candid::Nat,
-    num_instructions_total: candid::Nat,
-    request_payload_bytes_total: candid::Nat,
-    response_payload_bytes_total: candid::Nat,
+    pub num_calls_total: candid::Nat,
+    pub num_instructions_total: candid::Nat,
+    pub request_payload_bytes_total: candid::Nat,
+    pub response_payload_bytes_total: candid::Nat,
 }
 
 /// Argument type of [canister_status](super::canister_status).


### PR DESCRIPTION
It seems we forgot to make the members public when adding query stats to the `cdk`.

In order for the `struct` to be useful in canister code, those have to be pub.