### PR TITLE
chore: Raise MSRV to 1.70.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/dfinity/cdk-rs"
 # MSRV
 # Avoid updating this field unless we use new Rust features
 # Sync with rust-toolchain.toml
-rust-version = "1.66.0"
+rust-version = "1.70.0"
 license = "Apache-2.0"
 
 [profile.canister-release]

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 description = "End-to-end tests for the Rust Canister Development Kit"
 license = "Apache-2.0"
 repository = "https://github.com/dfinity/cdk-rs"
+publish = false
 
 [dependencies]
 candid.workspace = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.66.0" # sync with rust-version in root Cargo.toml
+channel = "1.70.0" # sync with rust-version in root Cargo.toml
 targets = ["wasm32-unknown-unknown"]
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Mirrors dfinity/agent-rs#479. Our Cargo.lock works with 1.66.0, but a new user's won't, and this eliminates the legacy crate index.