### PR TITLE
feat: add management canister methods for interacting with the chunk store

### DIFF
--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -47,6 +47,10 @@ path = "canisters/canister_info.rs"
 name = "management_caller"
 path = "canisters/management_caller.rs"
 
+[[bin]]
+name = "chunk"
+path = "canisters/chunk.rs"
+
 [dev-dependencies]
 hex.workspace = true
 ic-test-state-machine-client = "3"

--- a/e2e-tests/canisters/canister_info.rs
+++ b/e2e-tests/canisters/canister_info.rs
@@ -54,7 +54,7 @@ async fn canister_lifecycle() -> Principal {
     .await
     .unwrap();
     install_code(InstallCodeArgument {
-        mode: Upgrade,
+        mode: Upgrade(None),
         arg: vec![],
         wasm_module: vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00],
         canister_id: canister_id.canister_id,

--- a/e2e-tests/canisters/chunk.rs
+++ b/e2e-tests/canisters/chunk.rs
@@ -1,7 +1,7 @@
 use candid::Principal;
 use ic_cdk::api::management_canister::main::{
     clear_chunk_store, create_canister, install_chunked_code, stored_chunks, upload_chunk,
-    CanisterInstallMode, ChunkHash, ClearChunkStoreArgument, CreateCanisterArgument,
+    CanisterInstallMode, ClearChunkStoreArgument, CreateCanisterArgument,
     InstallChunkedCodeArgument, StoredChunksArgument, UploadChunkArgument,
 };
 use ic_cdk::update;
@@ -43,17 +43,13 @@ async fn call_clear_chunk_store(canister_id: Principal) {
 #[update]
 async fn call_install_chunked_code(
     canister_id: Principal,
-    chunk_hashes: Vec<Vec<u8>>,
+    chunk_hashes_list: Vec<Vec<u8>>,
     wasm_module_hash: Vec<u8>,
 ) {
-    let chunk_hashes_list = chunk_hashes
-        .into_iter()
-        .map(|hash| ChunkHash { hash })
-        .collect();
     let arg = InstallChunkedCodeArgument {
         mode: CanisterInstallMode::Install,
         target_canister: canister_id,
-        storage_canister: None,
+        store_canister: None,
         chunk_hashes_list,
         wasm_module_hash,
         arg: vec![],

--- a/e2e-tests/canisters/chunk.rs
+++ b/e2e-tests/canisters/chunk.rs
@@ -9,12 +9,12 @@ use ic_cdk::update;
 #[update]
 async fn call_create_canister() -> Principal {
     let arg = CreateCanisterArgument::default();
-    let canister_id = create_canister(arg, 100_000_000_000u128)
+
+    create_canister(arg, 100_000_000_000u128)
         .await
         .unwrap()
         .0
-        .canister_id;
-    canister_id
+        .canister_id
 }
 
 #[update]
@@ -23,8 +23,8 @@ async fn call_upload_chunk(canister_id: Principal, chunk: Vec<u8>) -> Vec<u8> {
         canister_id,
         chunk: chunk.to_vec(),
     };
-    let hash = upload_chunk(arg).await.unwrap().0.hash;
-    hash
+
+    upload_chunk(arg).await.unwrap().0.hash
 }
 
 #[update]

--- a/e2e-tests/canisters/chunk.rs
+++ b/e2e-tests/canisters/chunk.rs
@@ -1,7 +1,7 @@
 use candid::Principal;
 use ic_cdk::api::management_canister::main::{
     clear_chunk_store, create_canister, install_chunked_code, stored_chunks, upload_chunk,
-    CanisterInstallMode, ClearChunkStoreArgument, CreateCanisterArgument,
+    CanisterInstallMode, ChunkHash, ClearChunkStoreArgument, CreateCanisterArgument,
     InstallChunkedCodeArgument, StoredChunksArgument, UploadChunkArgument,
 };
 use ic_cdk::update;
@@ -46,6 +46,10 @@ async fn call_install_chunked_code(
     chunk_hashes_list: Vec<Vec<u8>>,
     wasm_module_hash: Vec<u8>,
 ) {
+    let chunk_hashes_list = chunk_hashes_list
+        .iter()
+        .map(|v| ChunkHash { hash: v.clone() })
+        .collect();
     let arg = InstallChunkedCodeArgument {
         mode: CanisterInstallMode::Install,
         target_canister: canister_id,

--- a/e2e-tests/canisters/chunk.rs
+++ b/e2e-tests/canisters/chunk.rs
@@ -1,0 +1,64 @@
+use candid::Principal;
+use ic_cdk::api::management_canister::main::{
+    clear_chunk_store, create_canister, install_chunked_code, stored_chunks, upload_chunk,
+    CanisterInstallMode, ChunkHash, ClearChunkStoreArgument, CreateCanisterArgument,
+    InstallChunkedCodeArgument, StoredChunksArgument, UploadChunkArgument,
+};
+use ic_cdk::update;
+
+#[update]
+async fn call_create_canister() -> Principal {
+    let arg = CreateCanisterArgument::default();
+    let canister_id = create_canister(arg, 100_000_000_000u128)
+        .await
+        .unwrap()
+        .0
+        .canister_id;
+    canister_id
+}
+
+#[update]
+async fn call_upload_chunk(canister_id: Principal, chunk: Vec<u8>) -> Vec<u8> {
+    let arg = UploadChunkArgument {
+        canister_id,
+        chunk: chunk.to_vec(),
+    };
+    let hash = upload_chunk(arg).await.unwrap().0.hash;
+    hash
+}
+
+#[update]
+async fn call_stored_chunks(canister_id: Principal) -> Vec<Vec<u8>> {
+    let arg = StoredChunksArgument { canister_id };
+    let hashes = stored_chunks(arg).await.unwrap().0;
+    hashes.into_iter().map(|v| v.hash).collect()
+}
+
+#[update]
+async fn call_clear_chunk_store(canister_id: Principal) {
+    let arg = ClearChunkStoreArgument { canister_id };
+    clear_chunk_store(arg).await.unwrap();
+}
+
+#[update]
+async fn call_install_chunked_code(
+    canister_id: Principal,
+    chunk_hashes: Vec<Vec<u8>>,
+    wasm_module_hash: Vec<u8>,
+) {
+    let chunk_hashes_list = chunk_hashes
+        .into_iter()
+        .map(|hash| ChunkHash { hash })
+        .collect();
+    let arg = InstallChunkedCodeArgument {
+        mode: CanisterInstallMode::Install,
+        target_canister: canister_id,
+        storage_canister: None,
+        chunk_hashes_list,
+        wasm_module_hash,
+        arg: vec![],
+    };
+    install_chunked_code(arg).await.unwrap();
+}
+
+fn main() {}

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -526,14 +526,14 @@ fn test_chunk() {
         &env,
         canister_id,
         "call_upload_chunk",
-        (target_canister_id, chunk1.clone()),
+        (target_canister_id, chunk1),
     )
     .expect("Error calling call_upload_chunk");
     let (_hash2_return,): (Vec<u8>,) = call_candid(
         &env,
         canister_id,
         "call_upload_chunk",
-        (target_canister_id, chunk2.clone()),
+        (target_canister_id, chunk2),
     )
     .expect("Error calling call_upload_chunk");
 

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -519,7 +519,8 @@ fn test_chunk() {
         canister_id,
         "call_clear_chunk_store",
         (target_canister_id,),
-    ).expect("Error calling call_clear_chunk_store");
+    )
+    .expect("Error calling call_clear_chunk_store");
 
     let (_hash1_return,): (Vec<u8>,) = call_candid(
         &env,
@@ -536,9 +537,13 @@ fn test_chunk() {
     )
     .expect("Error calling call_upload_chunk");
 
-    let (hashes,): (Vec<Vec<u8>>,) =
-        call_candid(&env, canister_id, "call_stored_chunks", (target_canister_id,))
-            .expect("Error calling call_stored_chunks");
+    let (hashes,): (Vec<Vec<u8>>,) = call_candid(
+        &env,
+        canister_id,
+        "call_stored_chunks",
+        (target_canister_id,),
+    )
+    .expect("Error calling call_stored_chunks");
     assert_eq!(hashes.len(), 2);
     assert!(hashes.contains(&hash1_expected));
     assert!(hashes.contains(&hash2_expected));
@@ -548,6 +553,6 @@ fn test_chunk() {
         canister_id,
         "call_install_chunked_code",
         (target_canister_id, hashes, wasm_module_hash),
-    ).expect("Error calling call_install_chunked_code");
-    
+    )
+    .expect("Error calling call_install_chunked_code");
 }

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -544,6 +544,7 @@ fn test_chunk() {
         (target_canister_id,),
     )
     .expect("Error calling call_stored_chunks");
+    // the hashes returned are not guaranteed to be in order
     assert_eq!(hashes.len(), 2);
     assert!(hashes.contains(&hash1_expected));
     assert!(hashes.contains(&hash2_expected));
@@ -552,7 +553,12 @@ fn test_chunk() {
         &env,
         canister_id,
         "call_install_chunked_code",
-        (target_canister_id, hashes, wasm_module_hash),
+        (
+            target_canister_id,
+            // the order of the hashes matters
+            vec![hash1_expected, hash2_expected],
+            wasm_module_hash,
+        ),
     )
     .expect("Error calling call_install_chunked_code");
 }

--- a/scripts/download_state_machine_binary.sh
+++ b/scripts/download_state_machine_binary.sh
@@ -10,7 +10,7 @@ uname_sys=$(uname -s | tr '[:upper:]' '[:lower:]')
 echo "uname_sys: $uname_sys"
 # Check https://gitlab.com/dfinity-lab/public/ic/-/commits/master
 # Find the most recent commit with a green check mark (the artifacts were built successfully)
-commit_sha="ac2c69d86ff0ba6852bbf675b0e025010dd950f3"
+commit_sha="ba6d8b136549f0acf8a2eafddab031156d53accd"
 
 curl -sLO "https://download.dfinity.systems/ic/$commit_sha/binaries/x86_64-$uname_sys/ic-test-state-machine.gz"
 gzip -d ic-test-state-machine.gz

--- a/scripts/download_state_machine_binary.sh
+++ b/scripts/download_state_machine_binary.sh
@@ -10,7 +10,7 @@ uname_sys=$(uname -s | tr '[:upper:]' '[:lower:]')
 echo "uname_sys: $uname_sys"
 # Check https://gitlab.com/dfinity-lab/public/ic/-/commits/master
 # Find the most recent commit with a green check mark (the artifacts were built successfully)
-commit_sha="f3216c1d7d83a366b4af0cf24708f84819880246"
+commit_sha="ac2c69d86ff0ba6852bbf675b0e025010dd950f3"
 
 curl -sLO "https://download.dfinity.systems/ic/$commit_sha/binaries/x86_64-$uname_sys/ic-test-state-machine.gz"
 gzip -d ic-test-state-machine.gz

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `is_recovering_from_trap` function for implementing trap cleanup logic
+- Add management canister methods for interacting with the chunk store
 
 ## [0.12.1] - 2024-01-12
 

--- a/src/ic-cdk/src/api/management_canister/main/mod.rs
+++ b/src/ic-cdk/src/api/management_canister/main/mod.rs
@@ -98,7 +98,7 @@ pub async fn install_chunked_code(arg: InstallChunkedCodeArgument) -> CallResult
     let extended_arg = InstallChunkedCodeArgumentExtended {
         mode: arg.mode,
         target_canister: arg.target_canister,
-        storage_canister: arg.storage_canister,
+        store_canister: arg.store_canister,
         chunk_hashes_list: arg.chunk_hashes_list,
         wasm_module_hash: arg.wasm_module_hash,
         arg: arg.arg,

--- a/src/ic-cdk/src/api/management_canister/main/mod.rs
+++ b/src/ic-cdk/src/api/management_canister/main/mod.rs
@@ -59,7 +59,12 @@ pub async fn upload_chunk(arg: UploadChunkArgument) -> CallResult<(UploadChunkRe
 
 /// See [IC method `clear_chunk_store`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-clear_chunk_store).
 pub async fn clear_chunk_store(arg: ClearChunkStoreArgument) -> CallResult<()> {
-    call(Principal::management_canister(), "clear_chunk_store", (arg,)).await
+    call(
+        Principal::management_canister(),
+        "clear_chunk_store",
+        (arg,),
+    )
+    .await
 }
 
 /// See [IC method `stored_chunks`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-stored_chunks).
@@ -104,7 +109,7 @@ pub async fn install_chunked_code(arg: InstallChunkedCodeArgument) -> CallResult
         "install_chunked_code",
         (extended_arg,),
     )
-        .await
+    .await
 }
 
 /// Remove a canister's code and state, making the canister empty again.

--- a/src/ic-cdk/src/api/management_canister/main/mod.rs
+++ b/src/ic-cdk/src/api/management_canister/main/mod.rs
@@ -98,7 +98,7 @@ pub async fn install_chunked_code(arg: InstallChunkedCodeArgument) -> CallResult
     let extended_arg = InstallChunkedCodeArgumentExtended {
         mode: arg.mode,
         target_canister: arg.target_canister,
-        store_canister: arg.store_canister,
+        storage_canister: arg.storage_canister,
         chunk_hashes_list: arg.chunk_hashes_list,
         wasm_module_hash: arg.wasm_module_hash,
         arg: arg.arg,

--- a/src/ic-cdk/src/api/management_canister/main/mod.rs
+++ b/src/ic-cdk/src/api/management_canister/main/mod.rs
@@ -52,6 +52,21 @@ pub async fn update_settings(arg: UpdateSettingsArgument) -> CallResult<()> {
     .await
 }
 
+/// See [IC method `upload_chunk`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-upload_chunk).
+pub async fn upload_chunk(arg: UploadChunkArgument) -> CallResult<(UploadChunkResponse,)> {
+    call(Principal::management_canister(), "upload_chunk", (arg,)).await
+}
+
+/// See [IC method `clear_chunk_store`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-clear_chunk_store).
+pub async fn clear_chunk_store(arg: ClearChunkStoreArgument) -> CallResult<()> {
+    call(Principal::management_canister(), "clear_chunk_store", (arg,)).await
+}
+
+/// See [IC method `stored_chunks`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-stored_chunks).
+pub async fn stored_chunks(arg: StoredChunksArgument) -> CallResult<(Vec<Vec<u8>>,)> {
+    call(Principal::management_canister(), "stored_chunks", (arg,)).await
+}
+
 /// Install code into a canister.
 ///
 /// See [IC method `install_code`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-install_code).
@@ -69,6 +84,27 @@ pub async fn install_code(arg: InstallCodeArgument) -> CallResult<()> {
         (extended_arg,),
     )
     .await
+}
+
+/// Install code into a canister where the code has previously been uploaded in chunks.
+///
+/// See [IC method `install_chunked_code`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-install_chunked_code).
+pub async fn install_chunked_code(arg: InstallChunkedCodeArgument) -> CallResult<()> {
+    let extended_arg = InstallChunkedCodeArgumentExtended {
+        mode: arg.mode,
+        target_canister: arg.target_canister,
+        store_canister: arg.store_canister,
+        chunk_hashes_list: arg.chunk_hashes_list,
+        wasm_module_hash: arg.wasm_module_hash,
+        arg: arg.arg,
+        sender_canister_version: Some(canister_version()),
+    };
+    call(
+        Principal::management_canister(),
+        "install_chunked_code",
+        (extended_arg,),
+    )
+        .await
 }
 
 /// Remove a canister's code and state, making the canister empty again.

--- a/src/ic-cdk/src/api/management_canister/main/mod.rs
+++ b/src/ic-cdk/src/api/management_canister/main/mod.rs
@@ -53,7 +53,7 @@ pub async fn update_settings(arg: UpdateSettingsArgument) -> CallResult<()> {
 }
 
 /// See [IC method `upload_chunk`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-upload_chunk).
-pub async fn upload_chunk(arg: UploadChunkArgument) -> CallResult<(UploadChunkResponse,)> {
+pub async fn upload_chunk(arg: UploadChunkArgument) -> CallResult<(ChunkHash,)> {
     call(Principal::management_canister(), "upload_chunk", (arg,)).await
 }
 
@@ -68,7 +68,7 @@ pub async fn clear_chunk_store(arg: ClearChunkStoreArgument) -> CallResult<()> {
 }
 
 /// See [IC method `stored_chunks`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-stored_chunks).
-pub async fn stored_chunks(arg: StoredChunksArgument) -> CallResult<(Vec<Vec<u8>>,)> {
+pub async fn stored_chunks(arg: StoredChunksArgument) -> CallResult<(Vec<ChunkHash>,)> {
     call(Principal::management_canister(), "stored_chunks", (arg,)).await
 }
 

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -85,6 +85,7 @@ pub struct UploadChunkArgument {
 )]
 pub struct ChunkHash {
     /// The hash of an uploaded chunk
+    #[serde(with = "serde_bytes")]
     pub hash: Vec<u8>,
 }
 

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -68,7 +68,9 @@ pub(crate) struct UpdateSettingsArgumentExtended {
 }
 
 /// Argument type of [update_chunk](super::update_chunk).
-#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
 pub struct UploadChunkArgument {
     /// The canister whose chunk store the chunk will be uploaded to
     pub canister_id: CanisterId,
@@ -78,21 +80,27 @@ pub struct UploadChunkArgument {
 }
 
 /// Return type of [upload_chunk](super::upload_chunk).
-#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
 pub struct UploadChunkResponse {
     /// The hash of the uploaded chunk
     pub hash: Vec<u8>,
 }
 
 /// Argument type of [clear_chunk_store](super::clear_chunk_store).
-#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
 pub struct ClearChunkStoreArgument {
     /// The canister whose chunk store will be cleared
     pub canister_id: CanisterId,
 }
 
 /// Argument type of [stored_chunks](super::stored_chunks).
-#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
 pub struct StoredChunksArgument {
     /// The canister whose chunk store will be queried
     pub canister_id: CanisterId,
@@ -119,7 +127,20 @@ pub enum CanisterInstallMode {
 ///
 /// This second version of the mode allows someone to specify the
 /// optional `SkipPreUpgrade` parameter in case of an upgrade
-#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Default)]
+#[derive(
+    CandidType,
+    Serialize,
+    Deserialize,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Clone,
+    Copy,
+    Default,
+)]
 pub enum CanisterInstallModeV2 {
     /// A fresh install of a new canister.
     #[serde(rename = "install")]
@@ -134,7 +155,20 @@ pub enum CanisterInstallModeV2 {
 }
 
 /// If set to true, the pre_upgrade step will be skipped during the canister upgrade
-#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Default)]
+#[derive(
+    CandidType,
+    Serialize,
+    Deserialize,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Clone,
+    Copy,
+    Default,
+)]
 pub struct SkipPreUpgrade(pub Option<bool>);
 
 /// WASM module.
@@ -172,7 +206,9 @@ pub(crate) struct InstallCodeArgumentExtended {
 }
 
 /// Argument type of [install_chunked_code](super::install_chunked_code).
-#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,)]
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
 pub struct InstallChunkedCodeArgument {
     /// See [CanisterInstallModeV2].
     pub mode: CanisterInstallModeV2,
@@ -190,7 +226,9 @@ pub struct InstallChunkedCodeArgument {
     pub arg: Vec<u8>,
 }
 
-#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,)]
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
 pub(crate) struct InstallChunkedCodeArgumentExtended {
     /// See [CanisterInstallModeV2].
     pub mode: CanisterInstallModeV2,

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -79,12 +79,12 @@ pub struct UploadChunkArgument {
     pub chunk: Vec<u8>,
 }
 
-/// Return type of [upload_chunk](super::upload_chunk).
+/// Return type of [upload_chunk](super::upload_chunk) and [stored_chunks](super::stored_chunks).
 #[derive(
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
-pub struct UploadChunkResponse {
-    /// The hash of the uploaded chunk
+pub struct ChunkHash {
+    /// The hash of an uploaded chunk
     pub hash: Vec<u8>,
 }
 

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -200,7 +200,7 @@ pub struct InstallChunkedCodeArgument {
     /// The canister in whose chunk storage the chunks are stored (defaults to target_canister if not specified)
     pub store_canister: Option<CanisterId>,
     /// The list of chunks that make up the canister wasm
-    pub chunk_hashes_list: Vec<Vec<u8>>,
+    pub chunk_hashes_list: Vec<ChunkHash>,
     /// The sha256 hash of the wasm
     #[serde(with = "serde_bytes")]
     pub wasm_module_hash: Vec<u8>,
@@ -220,7 +220,7 @@ pub(crate) struct InstallChunkedCodeArgumentExtended {
     /// The canister in whose chunk storage the chunks are stored (defaults to target_canister if not specified)
     pub store_canister: Option<CanisterId>,
     /// The list of chunks that make up the canister wasm
-    pub chunk_hashes_list: Vec<Vec<u8>>,
+    pub chunk_hashes_list: Vec<ChunkHash>,
     /// The sha256 hash of the wasm
     #[serde(with = "serde_bytes")]
     pub wasm_module_hash: Vec<u8>,

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -198,9 +198,9 @@ pub struct InstallChunkedCodeArgument {
     /// Principal of the canister being installed
     pub target_canister: CanisterId,
     /// The canister in whose chunk storage the chunks are stored (defaults to target_canister if not specified)
-    pub storage_canister: Option<CanisterId>,
+    pub store_canister: Option<CanisterId>,
     /// The list of chunks that make up the canister wasm
-    pub chunk_hashes_list: Vec<ChunkHash>,
+    pub chunk_hashes_list: Vec<Vec<u8>>,
     /// The sha256 hash of the wasm
     #[serde(with = "serde_bytes")]
     pub wasm_module_hash: Vec<u8>,
@@ -218,9 +218,9 @@ pub(crate) struct InstallChunkedCodeArgumentExtended {
     /// Principal of the canister being installed
     pub target_canister: CanisterId,
     /// The canister in whose chunk storage the chunks are stored (defaults to target_canister if not specified)
-    pub storage_canister: Option<CanisterId>,
+    pub store_canister: Option<CanisterId>,
     /// The list of chunks that make up the canister wasm
-    pub chunk_hashes_list: Vec<ChunkHash>,
+    pub chunk_hashes_list: Vec<Vec<u8>>,
     /// The sha256 hash of the wasm
     #[serde(with = "serde_bytes")]
     pub wasm_module_hash: Vec<u8>,

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -1,6 +1,5 @@
 use candid::{CandidType, Nat, Principal};
 use serde::{Deserialize, Serialize};
-use serde_bytes::ByteBuf;
 
 /// Canister ID is Principal.
 pub type CanisterId = Principal;
@@ -108,23 +107,6 @@ pub struct StoredChunksArgument {
 }
 
 /// The mode with which a canister is installed.
-#[derive(
-    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy,
-)]
-// #[serde(rename_all = "lowercase")]
-pub enum CanisterInstallMode {
-    /// A fresh install of a new canister.
-    #[serde(rename = "install")]
-    Install,
-    /// Reinstalling a canister that was already installed.
-    #[serde(rename = "reinstall")]
-    Reinstall,
-    /// Upgrade an existing canister.
-    #[serde(rename = "upgrade")]
-    Upgrade,
-}
-
-/// The mode with which a canister is installed.
 ///
 /// This second version of the mode allows someone to specify the
 /// optional `SkipPreUpgrade` parameter in case of an upgrade
@@ -142,7 +124,7 @@ pub enum CanisterInstallMode {
     Copy,
     Default,
 )]
-pub enum CanisterInstallModeV2 {
+pub enum CanisterInstallMode {
     /// A fresh install of a new canister.
     #[serde(rename = "install")]
     #[default]
@@ -211,14 +193,14 @@ pub(crate) struct InstallCodeArgumentExtended {
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
 pub struct InstallChunkedCodeArgument {
-    /// See [CanisterInstallModeV2].
-    pub mode: CanisterInstallModeV2,
+    /// See [CanisterInstallMode].
+    pub mode: CanisterInstallMode,
     /// Principal of the canister being installed
     pub target_canister: CanisterId,
     /// The canister in whose chunk storage the chunks are stored (defaults to target_canister if not specified)
-    pub store_canister: Option<CanisterId>,
+    pub storage_canister: Option<CanisterId>,
     /// The list of chunks that make up the canister wasm
-    pub chunk_hashes_list: Vec<ByteBuf>,
+    pub chunk_hashes_list: Vec<ChunkHash>,
     /// The sha256 hash of the wasm
     #[serde(with = "serde_bytes")]
     pub wasm_module_hash: Vec<u8>,
@@ -231,14 +213,14 @@ pub struct InstallChunkedCodeArgument {
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
 pub(crate) struct InstallChunkedCodeArgumentExtended {
-    /// See [CanisterInstallModeV2].
-    pub mode: CanisterInstallModeV2,
+    /// See [CanisterInstallMode].
+    pub mode: CanisterInstallMode,
     /// Principal of the canister being installed
     pub target_canister: CanisterId,
     /// The canister in whose chunk storage the chunks are stored (defaults to target_canister if not specified)
-    pub store_canister: Option<CanisterId>,
+    pub storage_canister: Option<CanisterId>,
     /// The list of chunks that make up the canister wasm
-    pub chunk_hashes_list: Vec<ByteBuf>,
+    pub chunk_hashes_list: Vec<ChunkHash>,
     /// The sha256 hash of the wasm
     #[serde(with = "serde_bytes")]
     pub wasm_module_hash: Vec<u8>,
@@ -386,13 +368,30 @@ pub struct CreationRecord {
     pub controllers: Vec<Principal>,
 }
 
+/// The mode with which a canister is installed.
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy,
+)]
+// #[serde(rename_all = "lowercase")]
+pub enum CodeDeploymentMode {
+    /// A fresh install of a new canister.
+    #[serde(rename = "install")]
+    Install,
+    /// Reinstalling a canister that was already installed.
+    #[serde(rename = "reinstall")]
+    Reinstall,
+    /// Upgrade an existing canister.
+    #[serde(rename = "upgrade")]
+    Upgrade,
+}
+
 /// Details about a canister code deployment.
 #[derive(
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
 pub struct CodeDeploymentRecord {
-    /// See [CanisterInstallMode].
-    pub mode: CanisterInstallMode,
+    /// See [CodeDeploymentMode].
+    pub mode: CodeDeploymentMode,
     /// A SHA256 hash of the new module installed on the canister.
     pub module_hash: Vec<u8>,
 }

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -1,5 +1,6 @@
 use candid::{CandidType, Nat, Principal};
 use serde::{Deserialize, Serialize};
+use serde_bytes::ByteBuf;
 
 /// Canister ID is Principal.
 pub type CanisterId = Principal;
@@ -48,7 +49,7 @@ pub(crate) struct CreateCanisterArgumentExtended {
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
 pub struct UpdateSettingsArgument {
-    /// Principle of the canister.
+    /// Principal of the canister.
     pub canister_id: CanisterId,
     /// See [CanisterSettings].
     pub settings: CanisterSettings,
@@ -58,12 +59,43 @@ pub struct UpdateSettingsArgument {
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
 pub(crate) struct UpdateSettingsArgumentExtended {
-    /// Principle of the canister.
+    /// Principal of the canister.
     pub canister_id: CanisterId,
     /// See [CanisterSettings].
     pub settings: CanisterSettings,
     /// sender_canister_version must be set to ic_cdk::api::canister_version()
     pub sender_canister_version: Option<u64>,
+}
+
+/// Argument type of [update_chunk](super::update_chunk).
+#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct UploadChunkArgument {
+    /// The canister whose chunk store the chunk will be uploaded to
+    pub canister_id: CanisterId,
+    /// The chunk bytes (max size 1MB)
+    #[serde(with = "serde_bytes")]
+    pub chunk: Vec<u8>,
+}
+
+/// Return type of [upload_chunk](super::upload_chunk).
+#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct UploadChunkResponse {
+    /// The hash of the uploaded chunk
+    pub hash: Vec<u8>,
+}
+
+/// Argument type of [clear_chunk_store](super::clear_chunk_store).
+#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct ClearChunkStoreArgument {
+    /// The canister whose chunk store will be cleared
+    pub canister_id: CanisterId,
+}
+
+/// Argument type of [stored_chunks](super::stored_chunks).
+#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct StoredChunksArgument {
+    /// The canister whose chunk store will be queried
+    pub canister_id: CanisterId,
 }
 
 /// The mode with which a canister is installed.
@@ -83,6 +115,28 @@ pub enum CanisterInstallMode {
     Upgrade,
 }
 
+/// The mode with which a canister is installed.
+///
+/// This second version of the mode allows someone to specify the
+/// optional `SkipPreUpgrade` parameter in case of an upgrade
+#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Default)]
+pub enum CanisterInstallModeV2 {
+    /// A fresh install of a new canister.
+    #[serde(rename = "install")]
+    #[default]
+    Install,
+    /// Reinstalling a canister that was already installed.
+    #[serde(rename = "reinstall")]
+    Reinstall,
+    /// Upgrade an existing canister.
+    #[serde(rename = "upgrade")]
+    Upgrade(Option<SkipPreUpgrade>),
+}
+
+/// If set to true, the pre_upgrade step will be skipped during the canister upgrade
+#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Default)]
+pub struct SkipPreUpgrade(pub Option<bool>);
+
 /// WASM module.
 pub type WasmModule = Vec<u8>;
 
@@ -93,7 +147,7 @@ pub type WasmModule = Vec<u8>;
 pub struct InstallCodeArgument {
     /// See [CanisterInstallMode].
     pub mode: CanisterInstallMode,
-    /// Principle of the canister.
+    /// Principal of the canister.
     pub canister_id: CanisterId,
     /// Code to be installed.
     pub wasm_module: WasmModule,
@@ -107,11 +161,50 @@ pub struct InstallCodeArgument {
 pub(crate) struct InstallCodeArgumentExtended {
     /// See [CanisterInstallMode].
     pub mode: CanisterInstallMode,
-    /// Principle of the canister.
+    /// Principal of the canister.
     pub canister_id: CanisterId,
     /// Code to be installed.
     pub wasm_module: WasmModule,
     /// The argument to be passed to `canister_init` or `canister_post_upgrade`.
+    pub arg: Vec<u8>,
+    /// sender_canister_version must be set to ic_cdk::api::canister_version()
+    pub sender_canister_version: Option<u64>,
+}
+
+/// Argument type of [install_chunked_code](super::install_chunked_code).
+#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,)]
+pub struct InstallChunkedCodeArgument {
+    /// See [CanisterInstallModeV2].
+    pub mode: CanisterInstallModeV2,
+    /// Principal of the canister being installed
+    pub target_canister: CanisterId,
+    /// The canister in whose chunk storage the chunks are stored (defaults to target_canister if not specified)
+    pub store_canister: Option<CanisterId>,
+    /// The list of chunks that make up the canister wasm
+    pub chunk_hashes_list: Vec<ByteBuf>,
+    /// The sha256 hash of the wasm
+    #[serde(with = "serde_bytes")]
+    pub wasm_module_hash: Vec<u8>,
+    /// The argument to be passed to `canister_init` or `canister_post_upgrade`
+    #[serde(with = "serde_bytes")]
+    pub arg: Vec<u8>,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,)]
+pub(crate) struct InstallChunkedCodeArgumentExtended {
+    /// See [CanisterInstallModeV2].
+    pub mode: CanisterInstallModeV2,
+    /// Principal of the canister being installed
+    pub target_canister: CanisterId,
+    /// The canister in whose chunk storage the chunks are stored (defaults to target_canister if not specified)
+    pub store_canister: Option<CanisterId>,
+    /// The list of chunks that make up the canister wasm
+    pub chunk_hashes_list: Vec<ByteBuf>,
+    /// The sha256 hash of the wasm
+    #[serde(with = "serde_bytes")]
+    pub wasm_module_hash: Vec<u8>,
+    /// The argument to be passed to `canister_init` or `canister_post_upgrade`.
+    #[serde(with = "serde_bytes")]
     pub arg: Vec<u8>,
     /// sender_canister_version must be set to ic_cdk::api::canister_version()
     pub sender_canister_version: Option<u64>,
@@ -122,7 +215,7 @@ pub(crate) struct InstallCodeArgumentExtended {
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy,
 )]
 pub struct CanisterIdRecord {
-    /// Principle of the canister.
+    /// Principal of the canister.
     pub canister_id: CanisterId,
 }
 
@@ -130,7 +223,7 @@ pub struct CanisterIdRecord {
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy,
 )]
 pub(crate) struct CanisterIdRecordExtended {
-    /// Principle of the canister.
+    /// Principal of the canister.
     pub canister_id: CanisterId,
     /// sender_canister_version must be set to ic_cdk::api::canister_version()
     pub sender_canister_version: Option<u64>,
@@ -184,7 +277,7 @@ pub struct QueryStats {
     pub response_payload_bytes_total: candid::Nat,
 }
 
-/// Argument type of [canister_status](super::canister_status).
+/// Return type of [canister_status](super::canister_status).
 #[derive(
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
@@ -215,7 +308,7 @@ pub struct CanisterStatusResponse {
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
 pub struct FromUserRecord {
-    /// Principle of the user.
+    /// Principal of the user.
     pub user_id: Principal,
 }
 
@@ -224,7 +317,7 @@ pub struct FromUserRecord {
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
 pub struct FromCanisterRecord {
-    /// Principle of the originator.
+    /// Principal of the originator.
     pub canister_id: Principal,
     /// Canister version of the originator when the originator initiated the change.
     /// This is null if the original does not include its canister version
@@ -313,7 +406,7 @@ pub struct CanisterChange {
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
 pub struct CanisterInfoRequest {
-    /// Principle of the canister.
+    /// Principal of the canister.
     pub canister_id: Principal,
     /// Number of most recent changes requested to be retrieved from canister history.
     /// No changes are retrieved if this field is null.


### PR DESCRIPTION
# Description

Adds `upload_chunk`, `stored_chunks`, `clear_chunk_store` and `install_chunked_code` to the management canister API.

# How Has This Been Tested?

I have tested this locally by uploading a wasm comprised of 3 chunks, the I queried `stored_chunks` which returned the chunks, then I called `install_chunked_code` which completed successfully, then I called `clear_chunk_store`, then I queried `stored_chunks` again and this time it was empty.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
