### PR TITLE
fix: use standard canister id environment variables

### DIFF
--- a/src/ic-cdk-bindgen/CHANGELOG.md
+++ b/src/ic-cdk-bindgen/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+- Look up the `CANISTER_ID_<canister_name_uppercase>` and `CANISTER_CANDID_PATH_<canister_name_uppercase>` 
+  environment variables to get the canister ID for a canister name. Previously the case of the canister
+  name matched the case of the canister, typically lowercase.
+
 ## [0.1.2] - 2023-11-23
 
 - Change `candid` dependency to the new `candid_parser` library.

--- a/src/ic-cdk-bindgen/src/lib.rs
+++ b/src/ic-cdk-bindgen/src/lib.rs
@@ -14,10 +14,11 @@ pub struct Config {
 
 impl Config {
     pub fn new(canister_name: &str) -> Self {
-        let candid_path_var_name = format!("CANISTER_CANDID_PATH_{}", canister_name);
+        let canister_name_upper = canister_name.to_uppercase();
+        let candid_path_var_name = format!("CANISTER_CANDID_PATH_{}", canister_name_upper);
         let candid_path =
             PathBuf::from(env::var(candid_path_var_name).expect("Cannot find candid path"));
-        let canister_id_var_name = format!("CANISTER_ID_{}", canister_name);
+        let canister_id_var_name = format!("CANISTER_ID_{}", canister_name_upper);
         let canister_id =
             Principal::from_text(env::var(canister_id_var_name).expect("Cannot find canister id"))
                 .unwrap();


### PR DESCRIPTION
# Description

Look up the `CANISTER_ID_<canister_name_uppercase>` and `CANISTER_CANDID_PATH_<canister_name_uppercase>` 
  environment variables to get the canister ID for a canister name. Previously the case of the canister
  name matched the case of the canister, typically lowercase.

Needed for https://dfinity.atlassian.net/browse/SDK-1379

# How Has This Been Tested?


# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
