### PR TITLE
fix(bindgen): look for standardized environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-bindgen"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "candid_parser",
 ]

--- a/examples/profile/dfx.json
+++ b/examples/profile/dfx.json
@@ -1,16 +1,16 @@
 {
   "version": 1,
   "canisters": {
-    "profile_inter_rs": {
+    "profile-inter-rs": {
       "type": "custom",
       "candid": "src/profile_inter_rs/profile.did",
       "wasm": "target/wasm32-unknown-unknown/release/profile_inter_rs-opt.wasm",
       "build": "sh ../build.sh profile profile_inter_rs",
       "dependencies": [
-        "profile_rs"
+        "profile-rs"
       ]
     },
-    "profile_rs": {
+    "profile-rs": {
       "type": "custom",
       "candid": "src/profile_rs/profile.did",
       "wasm": "target/wasm32-unknown-unknown/release/profile_rs-opt.wasm",

--- a/examples/profile/dfx.json
+++ b/examples/profile/dfx.json
@@ -16,15 +16,5 @@
       "wasm": "target/wasm32-unknown-unknown/release/profile_rs-opt.wasm",
       "build": "sh ../build.sh profile profile_rs"
     }
-  },
-  "defaults": {
-    "build": {
-      "output": "canisters/"
-    },
-    "start": {
-      "address": "127.0.0.1",
-      "port": 8000,
-      "serve_root": "canisters/eeoo/assets"
-    }
   }
 }

--- a/examples/profile/src/profile_inter_rs/build.rs
+++ b/examples/profile/src/profile_inter_rs/build.rs
@@ -2,6 +2,8 @@ use ic_cdk_bindgen::{Builder, Config};
 use std::path::PathBuf;
 
 fn main() {
+    // A workaround to force always rerun build.rs 
+    println!("cargo:rerun-if-env-changed=REBUILD");
     let manifest_dir =
         PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("Cannot find manifest dir"));
     let profile_rs = Config::new("profile_rs");

--- a/examples/profile/src/profile_inter_rs/build.rs
+++ b/examples/profile/src/profile_inter_rs/build.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 fn main() {
     // A workaround to force always rerun build.rs 
-    println!("cargo:rerun-if-env-changed=REBUILD");
+    println!("cargo:rerun-if-changed=NULL");
     let manifest_dir =
         PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("Cannot find manifest dir"));
     let profile_rs = Config::new("profile_rs");

--- a/examples/profile/src/profile_inter_rs/build.rs
+++ b/examples/profile/src/profile_inter_rs/build.rs
@@ -2,7 +2,7 @@ use ic_cdk_bindgen::{Builder, Config};
 use std::path::PathBuf;
 
 fn main() {
-    // A workaround to force always rerun build.rs 
+    // A workaround to force always rerun build.rs
     println!("cargo:rerun-if-changed=NULL");
     let manifest_dir =
         PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("Cannot find manifest dir"));

--- a/examples/profile/tests/basic.bats
+++ b/examples/profile/tests/basic.bats
@@ -15,21 +15,29 @@ teardown() {
   dfx start --clean --background
   dfx deploy
 
-  run dfx canister call profile_rs getSelf
-  [ "$output" == '(record { name = ""; description = ""; keywords = vec {} })' ]
-  dfx canister call profile_rs update 'record {"name"= "abc"; "description"="123"; "keywords"= vec {} }'
-  run dfx canister call profile_rs get abc
-  [ "$output" == '(record { name = "abc"; description = "123"; keywords = vec {} })' ]
-  run dfx canister call profile_rs search ab
-  [ "$output" == '(opt record { name = "abc"; description = "123"; keywords = vec {} })' ]
+  run dfx canister call profile-rs getSelf
+  assert_success
+  assert_output '(record { name = ""; description = ""; keywords = vec {} })'
+  run dfx canister call profile-rs update 'record {"name"= "abc"; "description"="123"; "keywords"= vec {} }'
+  assert_success
+  run dfx canister call profile-rs get abc
+  assert_success
+  assert_output '(record { name = "abc"; description = "123"; keywords = vec {} })'
+  run dfx canister call profile-rs search ab
+  assert_success
+  assert_output '(opt record { name = "abc"; description = "123"; keywords = vec {} })'
 
-  run dfx canister call profile_inter_rs getSelf
-  [ "$output" == '(record { name = ""; description = ""; keywords = vec {} })' ]
-  dfx canister call profile_inter_rs update 'record {"name"= "def"; "description"="456"; "keywords"= vec {} }'
-  run dfx canister call profile_inter_rs get def
-  [ "$output" == '(record { name = "def"; description = "456"; keywords = vec {} })' ]
-  run dfx canister call profile_inter_rs search de
-  [ "$output" == '(opt record { name = "def"; description = "456"; keywords = vec {} })' ]
+  run dfx canister call profile-inter-rs getSelf
+  assert_success
+  assert_output '(record { name = ""; description = ""; keywords = vec {} })'
+  run dfx canister call profile-inter-rs update 'record {"name"= "def"; "description"="456"; "keywords"= vec {} }'
+  assert_success
+  run dfx canister call profile-inter-rs get def
+  assert_success
+  assert_output '(record { name = "def"; description = "456"; keywords = vec {} })'
+  run dfx canister call profile-inter-rs search de
+  assert_success
+  assert_output '(opt record { name = "def"; description = "456"; keywords = vec {} })'
 }
 
 @test "ic-cdk-bindgen warns about deprecated env vars when running with dfx v0.13.1" {

--- a/examples/profile/tests/basic.bats
+++ b/examples/profile/tests/basic.bats
@@ -1,8 +1,9 @@
+load ../../bats/bats-support/load.bash
+load ../../bats/bats-assert/load.bash
+
 # Executed before each test.
 setup() {
   cd examples/profile
-  # Make sure the directory is clean.
-  dfx start --clean --background
 }
 
 # executed after each test
@@ -11,6 +12,7 @@ teardown() {
 }
 
 @test "Can get, update, search (profile_rs)" {
+  dfx start --clean --background
   dfx deploy
 
   run dfx canister call profile_rs getSelf
@@ -28,4 +30,12 @@ teardown() {
   [ "$output" == '(record { name = "def"; description = "456"; keywords = vec {} })' ]
   run dfx canister call profile_inter_rs search de
   [ "$output" == '(opt record { name = "def"; description = "456"; keywords = vec {} })' ]
+}
+
+@test "ic-cdk-bindgen warns about deprecated env vars when running with dfx v0.13.0" {
+  dfxvm install 0.13.0
+  run dfx +0.13.0 build --check
+  assert_success
+  assert_regex "$output" "The environment variable CANISTER_CANDID_PATH_profile_rs is deprecated. Please set CANISTER_CANDID_PATH_PROFILE_RS instead. Upgrading dfx may fix this issue."
+  assert_regex "$output" "The environment variable CANISTER_ID_profile_rs is deprecated. Please set CANISTER_ID_PROFILE_RS instead. Upgrading dfx may fix this issue."
 }

--- a/examples/profile/tests/basic.bats
+++ b/examples/profile/tests/basic.bats
@@ -32,9 +32,9 @@ teardown() {
   [ "$output" == '(opt record { name = "def"; description = "456"; keywords = vec {} })' ]
 }
 
-@test "ic-cdk-bindgen warns about deprecated env vars when running with dfx v0.13.0" {
-  dfxvm install 0.13.0
-  run dfx +0.13.0 build --check
+@test "ic-cdk-bindgen warns about deprecated env vars when running with dfx v0.13.1" {
+  dfxvm install 0.13.1
+  run dfx +0.13.1 build --check
   assert_success
   assert_regex "$output" "The environment variable CANISTER_CANDID_PATH_profile_rs is deprecated. Please set CANISTER_CANDID_PATH_PROFILE_RS instead. Upgrading dfx may fix this issue."
   assert_regex "$output" "The environment variable CANISTER_ID_profile_rs is deprecated. Please set CANISTER_ID_PROFILE_RS instead. Upgrading dfx may fix this issue."

--- a/src/ic-cdk-bindgen/CHANGELOG.md
+++ b/src/ic-cdk-bindgen/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.1.3] - 2024-02-27
+
+- Resolve CANISTER_CANDID_PATH and CANISTER_ID from standardized environment variables (uppercase canister names).
+  - The support for legacy (non-uppercase) env vars is kept.
+  - It will be removed in next major release (v0.2).
+
 ## [0.1.2] - 2023-11-23
 
 - Change `candid` dependency to the new `candid_parser` library.

--- a/src/ic-cdk-bindgen/Cargo.toml
+++ b/src/ic-cdk-bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-bindgen"
-version = "0.1.2"
+version = "0.1.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
# Description

- Resolve CANISTER_CANDID_PATH and CANISTER_ID from standardized environment variables (uppercase canister names).
  - The support for legacy (non-uppercase) env vars is kept.
  - It will be removed in next major release (v0.2).

# How Has This Been Tested?

examples/profile checks:
- canister names containing hyphens
- dfx v0.13.0 which only provides deprecated format env vars will cause warnings

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
