### PR TITLE
chore(ci): examples run with latest dfx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -43,9 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -69,9 +69,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -92,9 +92,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -13,7 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  dfx-version: 0.14.1
   ic-wasm-version: 0.4.0
 
 jobs:
@@ -21,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -40,7 +39,7 @@ jobs:
       - name: Build candid-extractor
         run: cargo build -p candid-extractor --release
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: candid-extractor
           path: target/release/candid-extractor
@@ -56,12 +55,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: "recursive"
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -82,7 +81,7 @@ jobs:
           mv ic-wasm-linux64 /usr/local/bin/ic-wasm
 
       - name: Download candid-extractor
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: candid-extractor
 
@@ -93,8 +92,6 @@ jobs:
 
       - name: Install DFX
         uses: dfinity/setup-dfx@main
-        with:
-          dfx-version: "${{ env.dfx-version }}"
 
       - name: Install bitcoin
         if: ${{ matrix.project-name == 'management_canister' }}

--- a/examples/counter/src/inter2_rs/lib.rs
+++ b/examples/counter/src/inter2_rs/lib.rs
@@ -17,3 +17,5 @@ async fn inc() {
 async fn write(input: candid::Nat) {
     inter_mo.write(input).await.unwrap()
 }
+
+ic_cdk::export_candid!();

--- a/examples/counter/src/inter_rs/lib.rs
+++ b/examples/counter/src/inter_rs/lib.rs
@@ -17,3 +17,5 @@ async fn inc() {
 async fn write(input: candid::Nat) {
     counter_mo.write(input).await.unwrap()
 }
+
+ic_cdk::export_candid!();

--- a/examples/profile/src/profile_inter_rs/lib.rs
+++ b/examples/profile/src/profile_inter_rs/lib.rs
@@ -22,3 +22,5 @@ async fn update(profile: Profile) {
 async fn search(text: String) -> Option<Profile> {
     profile_rs.search(text).await.unwrap().0
 }
+
+ic_cdk::export_candid!();

--- a/examples/rust-toolchain.toml
+++ b/examples/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable" # sync with rust-version in root Cargo.toml
+channel = "stable" # intentionally not pinned to a specific version
 targets = ["wasm32-unknown-unknown"]
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
# Description

Always running examples with latest `dfx` will help us find regression/incompatibility earlier.

Also the dependency actions are upgraded so that no more warnings about deprecated Node version.

# How Has This Been Tested?

examples

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
