### PR TITLE
chore: release ic-cdk v0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,7 +875,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "ic-cdk"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "candid",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "candid",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "ic-ledger-types"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "candid",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ opt-level = 'z'
 
 [workspace.dependencies]
 ic0 = { path = "src/ic0", version = "0.21.1" }
-ic-cdk = { path = "src/ic-cdk", version = "0.12.1" }
+ic-cdk = { path = "src/ic-cdk", version = "0.13.0" }
 ic-cdk-timers = { path = "src/ic-cdk-timers", version = "0.6.0" }
 
 candid = "0.10.4"

--- a/library/ic-ledger-types/CHANGELOG.md
+++ b/library/ic-ledger-types/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.10.0] - 2024-03-01
+
+### Changed
+- Upgrade `ic-cdk` to v0.13.
+
 ## [0.9.0] - 2023-11-23
 
 ### Changed

--- a/library/ic-ledger-types/Cargo.toml
+++ b/library/ic-ledger-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-ledger-types"
-version = "0.9.0"
+version = "0.10.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/src/ic-cdk-macros/CHANGELOG.md
+++ b/src/ic-cdk-macros/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.8.5] - 2024-03-01
+
+### Added
+
+- Allow setting decoding quota for canister endpoints and inter-canister calls. (#465)
+
 ## [0.8.4] - 2024-01-12
 
 ### Fixed

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-macros"
-version = "0.8.4" # no need to sync with ic-cdk
+version = "0.8.5" # no need to sync with ic-cdk
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,10 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.13.0] - 2024-03-01
+
 ### Added
 
-- Add `is_recovering_from_trap` function for implementing trap cleanup logic
-- Allow setting decoding quota for canister endpoints and inter-canister calls.
+- Add `is_recovering_from_trap` function for implementing trap cleanup logic. (#456)
+- Allow setting decoding quota for canister endpoints and inter-canister calls. (#465)
   * When defining canister endpoints, we add the following attributes: `#[update(decoding_quota = 10000, skipping_quota = 100, debug = true)]`
     - `skipping_quota` limits the amount of work allowed for skipping unneeded data on the wire. If this attributes is not present, we set a default quota of `10_000`. This affects ALL existing canisters, and is mainly used to improve canister throughput. See [docs on the Candid library](https://docs.rs/candid/latest/candid/de/struct.DecoderConfig.html#method.set_skipping_quota) to understand the skipping cost.
     - `decoding_quota` limits the total amount of work the deserializer can perform. See [docs on the Candid library](https://docs.rs/candid/latest/candid/de/struct.DecoderConfig.html#method.set_decoding_quota) to understand the cost model.
@@ -18,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `ic_cdk::api::call::arg_data` takes `ArgDecoderConfig` as argument.
+- `ic_cdk::api::call::arg_data` takes `ArgDecoderConfig` as argument. (#465)
 
 ## [0.12.1] - 2024-01-12
 

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.12.1"
+version = "0.13.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -22,7 +22,7 @@ include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 [dependencies]
 candid.workspace = true
 ic0.workspace = true
-ic-cdk-macros = { path = "../ic-cdk-macros", version = "0.8.4" }
+ic-cdk-macros = { path = "../ic-cdk-macros", version = "0.8.5" }
 serde.workspace = true
 serde_bytes.workspace = true
 slotmap = { workspace = true, optional = true }


### PR DESCRIPTION
Also release:
- `ic-cdk-macros` v0.8.5
- `ic-ledger-types` v0.10.0

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
