### PR TITLE
chore: release ic-cdk v0.13.1 and ic-cdk-macros v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,7 +875,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "ic-cdk"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "candid",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "candid",
  "proc-macro2",

--- a/src/ic-cdk-macros/CHANGELOG.md
+++ b/src/ic-cdk-macros/CHANGELOG.md
@@ -6,7 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-## [0.8.5] - 2024-03-01
+## [0.9.0] - 2024-03-01
+
+### Fixed
+
+- The change in yanked version v0.8.5 contains breaking change.
+
+## [0.8.5] - 2024-03-01 (yanked)
 
 ### Added
 

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-macros"
-version = "0.8.5" # no need to sync with ic-cdk
+version = "0.9.0" # no need to sync with ic-cdk
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,7 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-## [0.13.0] - 2024-03-01
+## [0.13.1] - 2024-03-01
+
+### Changed
+
+- Upgrade `ic-cdk-macros` to v0.9.0.
+
+## [0.13.0] - 2024-03-01 (yanked)
 
 ### Added
 

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -22,7 +22,12 @@ include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 [dependencies]
 candid.workspace = true
 ic0.workspace = true
-ic-cdk-macros = { path = "../ic-cdk-macros", version = "0.9.0" }
+# Pin ic-cdk-macros to a specific version.
+# This actually create a 1-to-1 mapping between ic-cdk and ic-cdk-macros.
+# Dependents won't accidentaly upgrading ic-cdk-macros only but not ic-cdk.
+# ic-cdk-macros is a hidden dependency, re-exported by ic-cdk.
+# It should not be included by users direcly.
+ic-cdk-macros = { path = "../ic-cdk-macros", version = "=0.9.0" }
 serde.workspace = true
 serde_bytes.workspace = true
 slotmap = { workspace = true, optional = true }

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.13.0"
+version = "0.13.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -22,7 +22,7 @@ include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 [dependencies]
 candid.workspace = true
 ic0.workspace = true
-ic-cdk-macros = { path = "../ic-cdk-macros", version = "0.8.5" }
+ic-cdk-macros = { path = "../ic-cdk-macros", version = "0.9.0" }
 serde.workspace = true
 serde_bytes.workspace = true
 slotmap = { workspace = true, optional = true }


### PR DESCRIPTION
# Description

`ic-cdk-macros` should have been bumped to `0.9.0` when released as `0.8.5`.

It caused the projects using `ic-cdk` v0.12 and `ic-cdk-macros` v0.8 broken. Because, `ic-cdk-macros` v0.8.5 actually generated code for `ic-cdk` v0.13.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
