### PR TITLE
chore(ci): remove temporary fix for bitcoin integration canister

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -92,8 +92,6 @@ jobs:
 
       - name: Install DFX
         uses: dfinity/setup-dfx@main
-        with:
-          dfx-version: "0.19.0-beta.1"
 
       - name: Install bitcoin
         if: ${{ matrix.project-name == 'management_canister' }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -92,6 +92,8 @@ jobs:
 
       - name: Install DFX
         uses: dfinity/setup-dfx@main
+        with:
+          dfx-version: "0.19.0-beta.1"
 
       - name: Install bitcoin
         if: ${{ matrix.project-name == 'management_canister' }}

--- a/examples/management_canister/tests/basic.bats
+++ b/examples/management_canister/tests/basic.bats
@@ -30,8 +30,9 @@ teardown() {
   # The bitcoin canister bundled with dfx 0.18.0 doesn't work with application replica
   # As a temporary remedy, we download a previous release.
   # TODO: remove when dfx fix, SDKTG-296
-  wget -O ic-btc-canister.wasm.gz https://github.com/dfinity/bitcoin-canister/releases/download/release%2F2023-10-13/ic-btc-canister.wasm.gz
-  DFX_BITCOIN_WASM=ic-btc-canister.wasm.gz dfx start --clean --background --enable-bitcoin
+  # wget -O ic-btc-canister.wasm.gz https://github.com/dfinity/bitcoin-canister/releases/download/release%2F2023-10-13/ic-btc-canister.wasm.gz
+  # DFX_BITCOIN_WASM=ic-btc-canister.wasm.gz dfx start --clean --background --enable-bitcoin
+  dfx start --clean --background --enable-bitcoin
 
   dfx deploy
   run dfx canister call caller execute_bitcoin_methods

--- a/examples/management_canister/tests/basic.bats
+++ b/examples/management_canister/tests/basic.bats
@@ -27,11 +27,6 @@ teardown() {
 @test "bitcoin methods succeed" {
   bitcoind -regtest -daemonwait
 
-  # The bitcoin canister bundled with dfx 0.18.0 doesn't work with application replica
-  # As a temporary remedy, we download a previous release.
-  # TODO: remove when dfx fix, SDKTG-296
-  # wget -O ic-btc-canister.wasm.gz https://github.com/dfinity/bitcoin-canister/releases/download/release%2F2023-10-13/ic-btc-canister.wasm.gz
-  # DFX_BITCOIN_WASM=ic-btc-canister.wasm.gz dfx start --clean --background --enable-bitcoin
   dfx start --clean --background --enable-bitcoin
 
   dfx deploy


### PR DESCRIPTION
SDK-1549

# Description

dfx v0.18.0 bundled bitcoin canister didn't work locally (also in CI).

I made a temp fix for CI in #473.

Now dfx v0.19.0 is released without the issue.
