### PR TITLE
feat: Re-generate bindings if canister id or candid path change

### DIFF
--- a/src/ic-cdk-bindgen/CHANGELOG.md
+++ b/src/ic-cdk-bindgen/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+- Re-generate bindings if the canister ids changed (e.g. when switching networks) or when the path to the candid file of a dependency changed.
+
 ## [0.1.3] - 2024-02-27
 
 - Resolve CANISTER_CANDID_PATH and CANISTER_ID from standardized environment variables (uppercase canister names).

--- a/src/ic-cdk-bindgen/src/lib.rs
+++ b/src/ic-cdk-bindgen/src/lib.rs
@@ -53,6 +53,8 @@ fn resolve_candid_path_and_canister_id(canister_name: &str) -> (PathBuf, Princip
 
     let candid_path_var_name = format!("CANISTER_CANDID_PATH_{}", canister_name_upper);
     let candid_path_var_name_legacy = format!("CANISTER_CANDID_PATH_{}", canister_name);
+    println!("cargo:rerun-if-env-changed={candid_path_var_name}");
+    println!("cargo:rerun-if-env-changed={candid_path_var_name_legacy}");
 
     let candid_path_str = if let Ok(candid_path_str) = env::var(&candid_path_var_name) {
         candid_path_str
@@ -69,6 +71,8 @@ fn resolve_candid_path_and_canister_id(canister_name: &str) -> (PathBuf, Princip
 
     let canister_id_var_name = format!("CANISTER_ID_{}", canister_name_upper);
     let canister_id_var_name_legacy = format!("CANISTER_ID_{}", canister_name);
+    println!("cargo:rerun-if-env-changed={canister_id_var_name}");
+    println!("cargo:rerun-if-env-changed={canister_id_var_name_legacy}");
     let canister_id_str = if let Ok(canister_id_str) = env::var(&canister_id_var_name) {
         canister_id_str
     } else if let Ok(canister_id_str) = env::var(&canister_id_var_name_legacy) {


### PR DESCRIPTION
# Description

When switching networks (e.g. `dfx canister build` vs `dfx canister build --ic`) then often the canister ids change, but cargo doesn't notice that the bindings need to be regenerated.

Not using `cargo:rerun-if-changed={candid_path_str}` because dfx likes to point to temporary copies of the files instead of the original ones, resulting in many unnecessary rebuilds.

# How Has This Been Tested?

Tested manually on a local copy

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
