### PR TITLE
docs: replace deprecated URLs

### DIFF
--- a/src/ic-cdk-macros/src/lib.rs
+++ b/src/ic-cdk-macros/src/lib.rs
@@ -267,7 +267,7 @@ pub fn update(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// In this case, the argument will be read from `ic0.msg_arg_data_size/copy` and passed to the
 /// init function upon successful deserialization.
-/// Refer to the [`canister_init` Specification](https://smartcontracts.org/docs/interface-spec/index.html#system-api-init) for more information.
+/// Refer to the [`canister_init` Specification](https://internetcomputer.org/docs/current/references/ic-interface-spec/#system-api-init) for more information.
 #[proc_macro_attribute]
 pub fn init(attr: TokenStream, item: TokenStream) -> TokenStream {
     handle_debug_and_errors(export::ic_init, "ic_init", attr, item)

--- a/src/ic-cdk/src/api/stable/mod.rs
+++ b/src/ic-cdk/src/api/stable/mod.rs
@@ -1,6 +1,6 @@
 //! APIs to manage stable memory.
 //!
-//! You can check the [Internet Computer Specification](https://smartcontracts.org/docs/interface-spec/index.html#system-api-stable-memory)
+//! You can check the [Internet Computer Specification](https://internetcomputer.org/docs/current/references/ic-interface-spec/#system-api-stable-memory)
 //! for a in-depth explanation of stable memory.
 mod canister;
 mod private;


### PR DESCRIPTION
# Description

Replace `https://smartcontracts.org` with `https://internetcomputer.org`.

Fix #460 