### PR TITLE
feat!: ic-cdk-bindgen rewrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,6 +948,7 @@ dependencies = [
  "candid_parser",
  "convert_case",
  "pretty",
+ "thiserror",
 ]
 
 [[package]]

--- a/examples/counter/src/counter_rs/lib.rs
+++ b/examples/counter/src/counter_rs/lib.rs
@@ -4,7 +4,7 @@ use std::cell::{Cell, RefCell};
 
 thread_local! {
     static COUNTER: RefCell<candid::Nat> = RefCell::new(candid::Nat::from(0u8));
-    static OWNER: Cell<Principal> = Cell::new(Principal::from_slice(&[]));
+    static OWNER: Cell<Principal> = const {Cell::new(Principal::from_slice(&[]))};
 }
 
 #[init]

--- a/examples/counter/src/inter2_rs/build.rs
+++ b/examples/counter/src/inter2_rs/build.rs
@@ -1,11 +1,6 @@
-use ic_cdk_bindgen::{Builder, Config};
-use std::path::PathBuf;
-
 fn main() {
-    let manifest_dir =
-        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("Cannot find manifest dir"));
-    let inter_mo = Config::new("inter_mo");
-    let mut builder = Builder::new();
-    builder.add(inter_mo);
-    builder.build(Some(manifest_dir.join("declarations")));
+    println!("cargo:rerun-if-changed=build.rs");
+    ic_cdk_bindgen::Builder::new("inter_mo")
+        .generate_consumer()
+        .unwrap();
 }

--- a/examples/counter/src/inter2_rs/lib.rs
+++ b/examples/counter/src/inter2_rs/lib.rs
@@ -1,7 +1,9 @@
 use ic_cdk::update;
 
-mod declarations;
-use declarations::inter_mo::inter_mo;
+mod inter_mo {
+    include!(concat!(env!("OUT_DIR"), "/consumer/inter_mo.rs"));
+}
+use inter_mo::inter_mo;
 
 #[update]
 async fn read() -> candid::Nat {

--- a/examples/counter/src/inter_rs/build.rs
+++ b/examples/counter/src/inter_rs/build.rs
@@ -1,11 +1,6 @@
-use ic_cdk_bindgen::{Builder, Config};
-use std::path::PathBuf;
-
 fn main() {
-    let manifest_dir =
-        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("Cannot find manifest dir"));
-    let counter = Config::new("counter_mo");
-    let mut builder = Builder::new();
-    builder.add(counter);
-    builder.build(Some(manifest_dir.join("declarations")));
+    println!("cargo:rerun-if-changed=build.rs");
+    ic_cdk_bindgen::Builder::new("counter_mo")
+        .generate_consumer()
+        .unwrap();
 }

--- a/examples/counter/src/inter_rs/lib.rs
+++ b/examples/counter/src/inter_rs/lib.rs
@@ -1,7 +1,9 @@
 use ic_cdk::update;
 
-mod declarations;
-use declarations::counter_mo::counter_mo;
+mod counter_mo {
+    include!(concat!(env!("OUT_DIR"), "/consumer/counter_mo.rs"));
+}
+use counter_mo::counter_mo;
 
 #[update]
 async fn read() -> candid::Nat {

--- a/examples/profile/src/profile_inter_rs/build.rs
+++ b/examples/profile/src/profile_inter_rs/build.rs
@@ -1,6 +1,7 @@
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     ic_cdk_bindgen::Builder::new("profile_rs")
+        .candid_path("../profile_rs/profile.did")
         .generate_consumer()
         .unwrap();
 }

--- a/examples/profile/src/profile_inter_rs/build.rs
+++ b/examples/profile/src/profile_inter_rs/build.rs
@@ -1,13 +1,6 @@
-use ic_cdk_bindgen::{Builder, Config};
-use std::path::PathBuf;
-
 fn main() {
-    // A workaround to force always rerun build.rs
-    println!("cargo:rerun-if-changed=NULL");
-    let manifest_dir =
-        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("Cannot find manifest dir"));
-    let profile_rs = Config::new("profile_rs");
-    let mut builder = Builder::new();
-    builder.add(profile_rs);
-    builder.build(Some(manifest_dir.join("declarations")));
+    println!("cargo:rerun-if-changed=build.rs");
+    ic_cdk_bindgen::Builder::new("profile_rs")
+        .generate_consumer()
+        .unwrap();
 }

--- a/examples/profile/src/profile_inter_rs/lib.rs
+++ b/examples/profile/src/profile_inter_rs/lib.rs
@@ -1,7 +1,9 @@
 use ic_cdk::update;
 
-mod declarations;
-use declarations::profile_rs::{profile_rs, Profile};
+mod profile_rs {
+    include!(concat!(env!("OUT_DIR"), "/consumer/profile_rs.rs"));
+}
+use profile_rs::{profile_rs, Profile};
 
 #[update(name = "getSelf")]
 async fn get_self() -> Profile {

--- a/src/ic-cdk-bindgen/Cargo.toml
+++ b/src/ic-cdk-bindgen/Cargo.toml
@@ -17,3 +17,4 @@ candid.workspace = true
 candid_parser.workspace = true
 convert_case = "0.6"
 pretty = "0.12"
+thiserror = "1.0"

--- a/src/ic-cdk-bindgen/src/code_generator.rs
+++ b/src/ic-cdk-bindgen/src/code_generator.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeSet;
 pub enum Target {
     Consumer,
     Provider,
-    TypeOnly,
+    Type,
 }
 
 #[derive(Clone)]
@@ -304,7 +304,7 @@ fn pp_function<'a>(config: &Config, id: &'a str, func: &'a Function) -> RcDoc<'a
     let arg_prefix = str(match config.target {
         Target::Consumer => "&self",
         Target::Provider => unimplemented!(),
-        Target::TypeOnly => unimplemented!(),
+        Target::Type => unimplemented!(),
     });
     let args = concat(
         std::iter::once(arg_prefix).chain(
@@ -322,7 +322,7 @@ fn pp_function<'a>(config: &Config, id: &'a str, func: &'a Function) -> RcDoc<'a
             ")",
         ),
         Target::Provider => unimplemented!(),
-        Target::TypeOnly => unimplemented!(),
+        Target::Type => unimplemented!(),
     };
     let sig = kwd("pub async fn")
         .append(name)
@@ -340,14 +340,14 @@ fn pp_function<'a>(config: &Config, id: &'a str, func: &'a Function) -> RcDoc<'a
                 .append(").await")
         }
         Target::Provider => unimplemented!(),
-        Target::TypeOnly => unimplemented!(),
+        Target::Type => unimplemented!(),
     };
     sig.append(enclose_space("{", body, "}"))
 }
 
 fn pp_actor<'a>(config: &'a Config, env: &'a TypeEnv, actor: &'a Type) -> RcDoc<'a> {
     // TODO: currently we only generate actor for consumer
-    if matches!(config.target, Target::TypeOnly | Target::Provider) {
+    if matches!(config.target, Target::Type | Target::Provider) {
         return RcDoc::nil();
     }
     let serv = env.as_service(actor).unwrap();
@@ -362,12 +362,12 @@ fn pp_actor<'a>(config: &'a Config, env: &'a TypeEnv, actor: &'a Type) -> RcDoc<
     let service_def = match config.target {
         Target::Consumer => format!("pub struct {}(pub Principal);", struct_name),
         Target::Provider => unimplemented!(),
-        Target::TypeOnly => unimplemented!(),
+        Target::Type => unimplemented!(),
     };
     let service_impl = match config.target {
         Target::Consumer => format!("impl {} ", struct_name),
         Target::Provider => unimplemented!(),
-        Target::TypeOnly => unimplemented!(),
+        Target::Type => unimplemented!(),
     };
     let res = RcDoc::text(service_def)
         .append(RcDoc::hardline())
@@ -391,7 +391,7 @@ fn pp_actor<'a>(config: &'a Config, env: &'a TypeEnv, actor: &'a Type) -> RcDoc<
                 config.service_name, struct_name, struct_name
             ),
             Target::Provider => unimplemented!(),
-            Target::TypeOnly => unimplemented!(),
+            Target::Type => unimplemented!(),
         };
         res.append(id).append(RcDoc::hardline()).append(instance)
     } else {
@@ -412,7 +412,7 @@ use {}::{{self, CandidType, Deserialize, Principal, Encode, Decode}};
         + match &config.target {
             Target::Consumer => "use ic_cdk::api::call::CallResult as Result;\n",
             Target::Provider => "",
-            Target::TypeOnly => "",
+            Target::Type => "",
         };
     let (env, actor) = nominalize_all(env, actor);
     let def_list: Vec<_> = if let Some(actor) = &actor {

--- a/src/ic-cdk-bindgen/src/error.rs
+++ b/src/ic-cdk-bindgen/src/error.rs
@@ -1,4 +1,3 @@
-
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/src/ic-cdk-bindgen/src/error.rs
+++ b/src/ic-cdk-bindgen/src/error.rs
@@ -1,0 +1,11 @@
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum IcCdkBindgenError {
+    #[error("Custom error: {0}")]
+    Custom(String),
+
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+}

--- a/src/ic-cdk-bindgen/src/lib.rs
+++ b/src/ic-cdk-bindgen/src/lib.rs
@@ -88,6 +88,14 @@ impl Builder {
         file.write_all(content.as_bytes())?;
         Ok(())
     }
+
+    pub fn generate_provider(&self) -> Result<(), IcCdkBindgenError> {
+        unimplemented!()
+    }
+
+    pub fn generate_type(&self) -> Result<(), IcCdkBindgenError> {
+        unimplemented!()
+    }
 }
 
 /// Resolve the candid path and canister id from environment variables.


### PR DESCRIPTION
SDK-1622

# Description

The current API of `ic-cdk-bindgen` crate exposes many types from the dependency `candid_parser`. 

This rewrite is necessary for the upcoming "Trait-Bound Canister Development" feature. which will need Candid to Rust bindgen for various targets.

The targets will be supported:
- `Consumer`
- `Provider`
- `Type`

Now, the main entry point to the `ic-cdk-bindgen` library is `ic_cdk_bindgen::Builder`.

This PR focuses on changing the existing bindgen for inter-canister calls. In the context of Rust CDK, such usage is named `consumer`.

```rs
// build.rs
fn main() {
    ic_cdk_bindgen::Builder::new("profile_rs")
        .generate_consumer()
        .unwrap();
}
```

Then in `lib.rs` of the consumer canister:

```rs
mod profile_rs {
    include!(concat!(env!("OUT_DIR"), "/consumer/profile_rs.rs"));
}
use profile_rs::{profile_rs, Profile};

#[update(name = "getSelf")]
async fn get_self() -> Profile {
    profile_rs.get_self().await.unwrap().0
}
```

## Note

This PR is just a intermediate state of the "Trait-Bound Canister Development" feature. The base branch of this PR is not `main` but a dedicated `bindgen_next` branch.

Support for provider and type will be implemented in the following PRs.

Docs and Changelog will be added when this overall feature is completed and before merge into the `main` branch.

# How Has This Been Tested?

examples: counter, profile

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] ~I have edited the CHANGELOG accordingly.~
- [ ] ~I have made corresponding changes to the documentation.~
