### PR TITLE
feat: generate type only

### DIFF
--- a/examples/profile/src/profile_inter_rs/build.rs
+++ b/examples/profile/src/profile_inter_rs/build.rs
@@ -1,7 +1,13 @@
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
+    // println!("cargo:rerun-if-changed=build.rs");
     ic_cdk_bindgen::Builder::new("profile_rs")
         .candid_path("../profile_rs/profile.did")
         .generate_consumer()
+        .unwrap();
+
+    ic_cdk_bindgen::Builder::new("profile_inter_rs")
+        .candid_path("profile.did")
+        .out_dir("declarations")
+        .generate_type()
         .unwrap();
 }

--- a/examples/profile/tests/basic.bats
+++ b/examples/profile/tests/basic.bats
@@ -39,10 +39,8 @@ teardown() {
   assert_output '(opt record { name = "def"; description = "456"; keywords = vec {} })'
 }
 
-@test "ic-cdk-bindgen warns about deprecated env vars when running with dfx v0.13.1" {
-  dfxvm install 0.13.1
-  run dfx +0.13.1 build --check
+@test "profile_inter_rs build.rs can generate type bindings in specified dir" {
+  dfx build --check
+  run test -f src/profile_inter_rs/declarations/type/profile_inter_rs.rs
   assert_success
-  assert_regex "$output" "The environment variable CANISTER_CANDID_PATH_profile_rs is deprecated. Please set CANISTER_CANDID_PATH_PROFILE_RS instead. Upgrading dfx may fix this issue."
-  assert_regex "$output" "The environment variable CANISTER_ID_profile_rs is deprecated. Please set CANISTER_ID_PROFILE_RS instead. Upgrading dfx may fix this issue."
 }

--- a/src/ic-cdk-bindgen/src/error.rs
+++ b/src/ic-cdk-bindgen/src/error.rs
@@ -5,6 +5,15 @@ pub enum IcCdkBindgenError {
     #[error("Custom error: {0}")]
     Custom(String),
 
-    #[error("IO error: {0}")]
-    IoError(#[from] std::io::Error),
+    #[error("Io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Principal error: {0}")]
+    Principal(#[from] candid::types::principal::PrincipalError),
+
+    #[error("Environment variable not found: {var}")]
+    EnvVarNotFound {
+        var: String,
+        source: std::env::VarError,
+    },
 }

--- a/src/ic-cdk-bindgen/src/lib.rs
+++ b/src/ic-cdk-bindgen/src/lib.rs
@@ -8,7 +8,10 @@ use std::path::PathBuf;
 mod code_generator;
 mod error;
 
+use code_generator::Target;
 pub use error::IcCdkBindgenError;
+
+type Result<T> = std::result::Result<T, IcCdkBindgenError>;
 
 #[derive(Debug, Clone)]
 pub struct Builder {
@@ -18,7 +21,9 @@ pub struct Builder {
     pub(crate) out_dir: Option<PathBuf>,
 }
 
+// Configurations.
 impl Builder {
+    /// Create a new builder with the given canister name.
     pub fn new<S>(canister_name: S) -> Self
     where
         S: Into<String>,
@@ -31,6 +36,11 @@ impl Builder {
         }
     }
 
+    /// Set the canister id.
+    ///
+    /// This is only needed for the consumer target.
+    ///
+    /// If not set, the canister id will be resolved from the environment variable `CANISTER_ID_<CANISTER_NAME>`.
     pub fn canister_id<S>(&mut self, canister_id: S) -> &mut Self
     where
         S: Into<Principal>,
@@ -39,6 +49,9 @@ impl Builder {
         self
     }
 
+    /// Set the path to the candid file.
+    ///
+    /// If not set, the path will be resolved from the environment variable `CANISTER_CANDID_PATH_<CANISTER_NAME>`.
     pub fn candid_path<S>(&mut self, path: S) -> &mut Self
     where
         S: Into<PathBuf>,
@@ -47,6 +60,14 @@ impl Builder {
         self
     }
 
+    /// Set the output directory.
+    ///
+    /// If not set, the output directory will be resolved from the environment variable `OUT_DIR` set by cargo.
+    ///
+    /// The generated files will be placed in a subdirectory of the output directory based on the target:
+    /// - `/consumer/` for the [consumer](Self::generate_consumer) target
+    /// - `/provider/` for the [provider](Self::generate_provider) target
+    /// - `/type/` for the [type](Self::generate_type) target
     pub fn out_dir<S>(&mut self, path: S) -> &mut Self
     where
         S: Into<PathBuf>,
@@ -56,102 +77,92 @@ impl Builder {
     }
 }
 
+// Code generation.
 impl Builder {
-    pub fn generate_consumer(&self) -> Result<(), IcCdkBindgenError> {
-        let (candid_path_env, canister_id_env) =
-            resolve_candid_path_and_canister_id(&self.canister_name);
-        let candid_path = self.candid_path.clone().unwrap_or(candid_path_env);
-        let canister_id = self.canister_id.unwrap_or(canister_id_env);
-
+    fn generate(&self, target: Target) -> Result<()> {
         let mut binding = code_generator::Config::new();
+        if target == Target::Consumer {
+            let canister_id = if let Some(p) = &self.canister_id {
+                *p
+            } else {
+                canister_id_from_env(&self.canister_name)?
+            };
+            binding.set_canister_id(canister_id);
+        }
         binding
-            // User will depend on candid crate directly
-            .set_candid_crate("candid".to_string())
-            .set_canister_id(canister_id)
             .set_service_name(self.canister_name.to_string())
-            .set_target(code_generator::Target::Consumer);
+            .set_target(target);
+
+        let candid_path = if let Some(p) = &self.candid_path {
+            p.clone()
+        } else {
+            candid_path_from_env(&self.canister_name)?
+        };
 
         let (env, actor) = pretty_check_file(&candid_path).expect("Cannot parse candid file");
         let content = code_generator::compile(&binding, &env, &actor);
-        let out_dir = self.out_dir.clone().map(Ok).unwrap_or_else(|| {
-            env::var_os("OUT_DIR")
-                .ok_or_else(|| {
-                    IcCdkBindgenError::Custom("OUT_DIR environment variable is not set".to_string())
-                })
-                .map(PathBuf::from)
-        })?;
-        let consumer_dir = out_dir.join("consumer");
-        fs::create_dir_all(&consumer_dir)?;
 
-        let generated_path = consumer_dir.join(format!("{}.rs", &self.canister_name));
+        let out_dir = if let Some(p) = &self.out_dir {
+            p.clone()
+        } else {
+            out_dir_from_env()?
+        };
+        let sub_dir_str = match target {
+            Target::Consumer => "consumer",
+            Target::Provider => "provider",
+            Target::Type => "type",
+        };
+        let sub_dir = out_dir.join(sub_dir_str);
+        fs::create_dir_all(&sub_dir)?;
+
+        let generated_path = sub_dir.join(format!("{}.rs", &self.canister_name));
         let mut file = fs::File::create(generated_path)?;
         file.write_all(content.as_bytes())?;
         Ok(())
     }
 
-    pub fn generate_provider(&self) -> Result<(), IcCdkBindgenError> {
-        unimplemented!()
+    /// Generate the Rust bindings for consumer (inter-canister calls).
+    pub fn generate_consumer(&self) -> Result<()> {
+        self.generate(Target::Consumer)
     }
 
-    pub fn generate_type(&self) -> Result<(), IcCdkBindgenError> {
-        unimplemented!()
+    /// Generate the Rust bindings for provider (implement canister entry-points).
+    pub fn generate_provider(&self) -> Result<()> {
+        self.generate(Target::Provider)
+    }
+
+    /// Generate the Rust bindings for type only (types used in the candid file).
+    pub fn generate_type(&self) -> Result<()> {
+        self.generate(Target::Type)
     }
 }
 
-/// Resolve the candid path and canister id from environment variables.
-///
-/// The name and format of the environment variables are standardized:
-/// https://github.com/dfinity/sdk/blob/master/docs/cli-reference/dfx-envars.md#canister_id_canistername
-///
-/// We previously used environment variables like`CANISTER_CANDID_PATH_<canister_name>` without to_uppercase.
-/// That is deprecated. To keep backward compatibility, we also check for the old format.
-/// Just in case the user run `ic-cdk-bindgen` outside `dfx`.
-/// If the old format is found, we print a warning to the user.
-/// dfx v0.13.0 only provides the old format, which can be used to check the warning logic.
-/// TODO: remove the support for the old format, in the next major release (v0.2) of `ic-cdk-bindgen`.
-fn resolve_candid_path_and_canister_id(canister_name: &str) -> (PathBuf, Principal) {
-    fn warning_deprecated_env(deprecated_name: &str, new_name: &str) {
-        println!("cargo:warning=The environment variable {} is deprecated. Please set {} instead. Upgrading dfx may fix this issue.", deprecated_name, new_name);
-    }
-
-    let canister_name = canister_name.replace('-', "_");
-    let canister_name_upper = canister_name.to_uppercase();
-
+// https://github.com/dfinity/sdk/blob/master/docs/cli-reference/dfx-envars.mdx#canister_candid_path_canistername
+fn candid_path_from_env(canister_name: &str) -> Result<PathBuf> {
+    let canister_name_upper = canister_name.replace('-', "_").to_uppercase();
     let candid_path_var_name = format!("CANISTER_CANDID_PATH_{}", canister_name_upper);
-    let candid_path_var_name_legacy = format!("CANISTER_CANDID_PATH_{}", canister_name);
+    let candid_path_str = var_from_env(&candid_path_var_name)?;
     println!("cargo:rerun-if-env-changed={candid_path_var_name}");
-    println!("cargo:rerun-if-env-changed={candid_path_var_name_legacy}");
+    Ok(PathBuf::from(candid_path_str))
+}
 
-    let candid_path_str = if let Ok(candid_path_str) = env::var(&candid_path_var_name) {
-        candid_path_str
-    } else if let Ok(candid_path_str) = env::var(&candid_path_var_name_legacy) {
-        warning_deprecated_env(&candid_path_var_name_legacy, &candid_path_var_name);
-        candid_path_str
-    } else {
-        panic!(
-            "Cannot find environment variable: {}",
-            &candid_path_var_name
-        );
-    };
-    let candid_path = PathBuf::from(candid_path_str);
-
+// https://github.com/dfinity/sdk/blob/master/docs/cli-reference/dfx-envars.mdx#canister_id_canistername
+fn canister_id_from_env(canister_name: &str) -> Result<Principal> {
+    let canister_name_upper = canister_name.replace('-', "_").to_uppercase();
     let canister_id_var_name = format!("CANISTER_ID_{}", canister_name_upper);
-    let canister_id_var_name_legacy = format!("CANISTER_ID_{}", canister_name);
+    let canister_id_str = var_from_env(&canister_id_var_name)?;
     println!("cargo:rerun-if-env-changed={canister_id_var_name}");
-    println!("cargo:rerun-if-env-changed={canister_id_var_name_legacy}");
-    let canister_id_str = if let Ok(canister_id_str) = env::var(&canister_id_var_name) {
-        canister_id_str
-    } else if let Ok(canister_id_str) = env::var(&canister_id_var_name_legacy) {
-        warning_deprecated_env(&canister_id_var_name_legacy, &canister_id_var_name);
-        canister_id_str
-    } else {
-        panic!(
-            "Cannot find environment variable: {}",
-            &canister_id_var_name
-        );
-    };
-    let canister_id = Principal::from_text(&canister_id_str)
-        .unwrap_or_else(|_| panic!("Invalid principal: {}", &canister_id_str));
+    Ok(Principal::from_text(canister_id_str)?)
+}
 
-    (candid_path, canister_id)
+fn out_dir_from_env() -> Result<PathBuf> {
+    let out_dir_str = var_from_env("OUT_DIR")?;
+    Ok(PathBuf::from(out_dir_str))
+}
+
+fn var_from_env(var: &str) -> Result<String> {
+    env::var(var).map_err(|e| IcCdkBindgenError::EnvVarNotFound {
+        var: var.to_string(),
+        source: e,
+    })
 }


### PR DESCRIPTION
# Description

`Builder::generate_type()` can generate Rust bindings for type only.

Fixes SDK1557

# How Has This Been Tested?

profile example

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- ~[ ] I have edited the CHANGELOG accordingly.~
- ~[ ] I have made corresponding changes to the documentation.~
