### PR TITLE
feat: Candid checker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "candid"
 version = "0.10.8"
-source = "git+https://github.com/dfinity/candid.git?branch=configs#221422f495fa7ec12df32bd4e0fd40dd1d9f0704"
+source = "git+https://github.com/dfinity/candid.git?branch=configs#511629bd611b820d449c38f8b4ad96ac0b29a6b8"
 dependencies = [
  "anyhow",
  "binread",
@@ -308,7 +308,7 @@ dependencies = [
 [[package]]
 name = "candid_derive"
 version = "0.6.6"
-source = "git+https://github.com/dfinity/candid.git?branch=configs#221422f495fa7ec12df32bd4e0fd40dd1d9f0704"
+source = "git+https://github.com/dfinity/candid.git?branch=configs#511629bd611b820d449c38f8b4ad96ac0b29a6b8"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -338,7 +338,7 @@ dependencies = [
 [[package]]
 name = "candid_parser"
 version = "0.2.0-beta.0"
-source = "git+https://github.com/dfinity/candid.git?branch=configs#221422f495fa7ec12df32bd4e0fd40dd1d9f0704"
+source = "git+https://github.com/dfinity/candid.git?branch=configs#511629bd611b820d449c38f8b4ad96ac0b29a6b8"
 dependencies = [
  "anyhow",
  "candid 0.10.8",
@@ -351,9 +351,7 @@ dependencies = [
  "logos",
  "num-bigint",
  "pretty",
- "proc-macro2",
  "serde",
- "syn 2.0.60",
  "thiserror",
  "toml",
 ]
@@ -1137,7 +1135,7 @@ dependencies = [
 [[package]]
 name = "ic_principal"
 version = "0.1.1"
-source = "git+https://github.com/dfinity/candid.git?branch=configs#221422f495fa7ec12df32bd4e0fd40dd1d9f0704"
+source = "git+https://github.com/dfinity/candid.git?branch=configs#511629bd611b820d449c38f8b4ad96ac0b29a6b8"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,9 +234,9 @@ dependencies = [
  "anyhow",
  "binread",
  "byteorder",
- "candid_derive",
+ "candid_derive 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
- "ic_principal",
+ "ic_principal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "leb128",
  "num-bigint",
  "num-traits",
@@ -246,6 +246,40 @@ dependencies = [
  "serde_bytes",
  "stacker",
  "thiserror",
+]
+
+[[package]]
+name = "candid"
+version = "0.10.8"
+source = "git+https://github.com/dfinity/candid.git?branch=configs#221422f495fa7ec12df32bd4e0fd40dd1d9f0704"
+dependencies = [
+ "anyhow",
+ "binread",
+ "byteorder",
+ "candid_derive 0.6.6 (git+https://github.com/dfinity/candid.git?branch=configs)",
+ "hex",
+ "ic_principal 0.1.1 (git+https://github.com/dfinity/candid.git?branch=configs)",
+ "leb128",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "pretty",
+ "serde",
+ "serde_bytes",
+ "stacker",
+ "thiserror",
+]
+
+[[package]]
+name = "candid-checker"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "candid_parser 0.2.0-beta.0",
+ "clap",
+ "codespan-reporting",
+ "proc-macro2",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -272,13 +306,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "candid_derive"
+version = "0.6.6"
+source = "git+https://github.com/dfinity/candid.git?branch=configs#221422f495fa7ec12df32bd4e0fd40dd1d9f0704"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
 name = "candid_parser"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48a3da76f989cd350b7342c64c6c6008341bb6186f6832ef04e56dc50ba0fd76"
 dependencies = [
  "anyhow",
- "candid",
+ "candid 0.10.7",
  "codespan-reporting",
  "convert_case",
  "hex",
@@ -288,6 +333,29 @@ dependencies = [
  "num-bigint",
  "pretty",
  "thiserror",
+]
+
+[[package]]
+name = "candid_parser"
+version = "0.2.0-beta.0"
+source = "git+https://github.com/dfinity/candid.git?branch=configs#221422f495fa7ec12df32bd4e0fd40dd1d9f0704"
+dependencies = [
+ "anyhow",
+ "candid 0.10.8",
+ "codespan-reporting",
+ "convert_case",
+ "handlebars",
+ "hex",
+ "lalrpop",
+ "lalrpop-util",
+ "logos",
+ "num-bigint",
+ "pretty",
+ "proc-macro2",
+ "serde",
+ "syn 2.0.60",
+ "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -890,6 +958,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "handlebars"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08485b96a0e6393e9e4d1b8d48cf74ad6c063cd905eb33f42c1ce3f0377539b"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,7 +1012,7 @@ name = "ic-cdk"
 version = "0.13.2"
 dependencies = [
  "anyhow",
- "candid",
+ "candid 0.10.7",
  "ic-cdk-macros",
  "ic0",
  "rstest",
@@ -944,8 +1026,8 @@ dependencies = [
 name = "ic-cdk-bindgen"
 version = "0.1.3"
 dependencies = [
- "candid",
- "candid_parser",
+ "candid 0.10.7",
+ "candid_parser 0.1.4",
  "convert_case",
  "pretty",
 ]
@@ -954,7 +1036,7 @@ dependencies = [
 name = "ic-cdk-e2e-tests"
 version = "0.1.0"
 dependencies = [
- "candid",
+ "candid 0.10.7",
  "cargo_metadata",
  "escargot",
  "futures",
@@ -971,7 +1053,7 @@ dependencies = [
 name = "ic-cdk-macros"
 version = "0.13.2"
 dependencies = [
- "candid",
+ "candid 0.10.7",
  "proc-macro2",
  "quote",
  "serde",
@@ -996,7 +1078,7 @@ name = "ic-certified-map"
 version = "0.4.0"
 dependencies = [
  "bincode",
- "candid",
+ "candid 0.10.7",
  "hex",
  "ic-cdk",
  "serde",
@@ -1009,7 +1091,7 @@ dependencies = [
 name = "ic-ledger-types"
 version = "0.10.0"
 dependencies = [
- "candid",
+ "candid 0.10.7",
  "crc32fast",
  "hex",
  "ic-cdk",
@@ -1024,7 +1106,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e05a81e0cbdf178228d72ace06c60ac7fa99927b49a238f9ccf5ef82eaced6"
 dependencies = [
- "candid",
+ "candid 0.10.7",
  "ciborium",
  "serde",
  "serde_bytes",
@@ -1043,6 +1125,19 @@ name = "ic_principal"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1762deb6f7c8d8c2bdee4b6c5a47b60195b74e9b5280faa5ba29692f8e17429c"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "data-encoding",
+ "serde",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
+name = "ic_principal"
+version = "0.1.1"
+source = "git+https://github.com/dfinity/candid.git?branch=configs#221422f495fa7ec12df32bd4e0fd40dd1d9f0704"
 dependencies = [
  "arbitrary",
  "crc32fast",
@@ -1350,6 +1445,51 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pest"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "petgraph"
@@ -1908,6 +2048,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicode-ident"

--- a/src/candid-checker/Cargo.toml
+++ b/src/candid-checker/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "candid-checker"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "CLI tool to check if Rust code implements a given did file"
+
+[[bin]]
+name = "candid-checker"
+path = "src/main.rs"
+required-features = ["exe"]
+
+[dependencies]
+syn = { version = "2.0", features = ["full", "visit", "extra-traits"] }
+proc-macro2 = { version = "1.0", features = ["span-locations"] }
+candid_parser = { git = "https://github.com/dfinity/candid.git", branch = "configs" }
+codespan-reporting = "0.11"
+
+clap = { version = "4", features = ["derive"], optional = true }
+anyhow = { version = "1.0", optional = true }
+
+[features]
+exe = ["dep:clap", "dep:anyhow"]
+

--- a/src/candid-checker/src/lib.rs
+++ b/src/candid-checker/src/lib.rs
@@ -1,0 +1,237 @@
+use codespan_reporting::{
+    diagnostic::{Diagnostic, Label},
+    files::SimpleFile,
+    term::{self, termcolor::StandardStream},
+};
+use syn::{Expr, ExprLit, FnArg, Lit, Meta, ReturnType, Attribute, Signature};
+use candid_parser::bindings::rust::{Output, Config, emit_bindgen};
+use candid_parser::configs::Configs;
+use candid_parser::{Result, utils::CandidSource};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::fs;
+use std::ops::Range;
+
+pub fn check_rust(rust: &Path, candid: &Path, config: &Option<PathBuf>) -> Result<()> {
+    let candid = CandidSource::File(candid);
+    let (env, actor) = candid.load()?;
+    let config = if let Some(config) = config {
+        fs::read_to_string(config)?
+    } else {
+        "".to_string()
+    };
+    let config: Configs = config.parse()?;
+    let config = Config::new(config);
+    let (output, unused) = emit_bindgen(&config, &env, &actor);
+    let name = rust.file_name().unwrap().to_str().unwrap();
+    let source = fs::read_to_string(rust)?;
+    report_errors(&name, &source, &output);
+    Ok(())
+}
+
+fn report_errors(name: &str, source: &str, candid: &Output) {
+    let rust = get_endpoint_from_rust_source(source);
+    let diags = diff_did_and_rust(candid, &rust);
+    let writer = StandardStream::stderr(term::termcolor::ColorChoice::Auto);
+    let config = term::Config::default();
+    let file = SimpleFile::new(name, source);
+    for diag in diags {
+        term::emit(&mut writer.lock(), &config, &file, &diag).unwrap();
+    }
+}
+fn get_endpoint_from_rust_source(source: &str) -> Vec<CDKMethod> {
+    use syn::visit::{self, Visit};
+    use syn::{ImplItemFn, ItemFn};
+    struct FnVisitor(Vec<CDKMethod>);
+    impl<'ast> Visit<'ast> for FnVisitor {
+        fn visit_item_fn(&mut self, node: &'ast ItemFn) {
+            if let Some(m) = get_cdk_function(&node.attrs, &node.sig) {
+                self.0.push(m);
+            }
+            // handle nested functions
+            visit::visit_item_fn(self, node);
+        }
+        fn visit_impl_item_fn(&mut self, node: &'ast ImplItemFn) {
+            if let Some(m) = get_cdk_function(&node.attrs, &node.sig) {
+                self.0.push(m);
+            }
+            // handle nested functions
+            visit::visit_impl_item_fn(self, node);
+        }
+    }
+    let ast = syn::parse_file(source).unwrap();
+    let mut visitor = FnVisitor(Vec::new());
+    visitor.visit_file(&ast);
+    for m in &visitor.0 {
+        m.debug_print(source);
+    }
+    visitor.0
+}
+fn diff_did_and_rust(candid: &Output, rust: &[CDKMethod]) -> Vec<Diagnostic<()>> {
+    use syn::spanned::Spanned;
+    let mut res = Vec::new();
+    let rust: BTreeMap<_, _> = rust
+        .iter()
+        .map(|m| {
+            let name = m
+                .export_name
+                .as_ref()
+                .map(|x| x.0.clone())
+                .unwrap_or(m.func_name.to_string());
+            (name, m)
+        })
+        .collect();
+    for m in &candid.methods {
+        let diag = Diagnostic::error()
+            .with_message(format!("Error with Candid method {}", m.original_name));
+        let mut labels = Vec::new();
+        let mut notes = Vec::new();
+        if let Some(func) = rust.get(&m.original_name) {
+            if m.original_name == m.name {
+            } else {
+                if let Some((name, meta)) = &func.export_name {
+                    if *name != m.original_name {
+                        labels
+                            .push(Label::primary((), meta.span().byte_range()).with_message(
+                                format!("expect {}", m.original_name.escape_debug()),
+                            ));
+                    }
+                } else {
+                    labels.push(
+                        Label::primary((), func.mode.span().byte_range()).with_message(format!(
+                            "missing (name = \"{}\")",
+                            m.original_name.escape_debug()
+                        )),
+                    );
+                }
+            }
+            let args = func.args.iter().zip(m.args.iter().map(|x| &x.1));
+            for (rust_arg, candid_arg) in args {
+                let parsed_candid_arg: syn::Type = syn::parse_str(candid_arg).unwrap();
+                if parsed_candid_arg != *rust_arg {
+                    labels.push(
+                        Label::primary((), rust_arg.span().byte_range())
+                            .with_message(format!("expect type: {}", candid_arg)),
+                    );
+                }
+            }
+        } else {
+            notes.push(format!(
+                "method \"{}\" missing from Rust code",
+                m.original_name
+            ));
+        }
+        if labels.is_empty() && notes.is_empty() {
+            continue;
+        }
+        res.push(diag.with_labels(labels).with_notes(notes));
+    }
+    res
+}
+struct CDKMethod {
+    func_name: syn::Ident,
+    export_name: Option<(String, syn::Meta)>,
+    composite: Option<syn::Meta>,
+    mode: syn::Ident,
+    args: Vec<syn::Type>,
+    rets: Vec<syn::Type>,
+    attr_span: Range<usize>,
+    fn_span: Range<usize>,
+    args_span: Range<usize>,
+    rets_span: Range<usize>,
+}
+fn get_cdk_function(attrs: &[Attribute], sig: &Signature) -> Option<CDKMethod> {
+    use syn::parse::Parser;
+    use syn::spanned::Spanned;
+    let func_name = sig.ident.clone();
+    let mut mode = None;
+    let mut export_name = None;
+    let mut composite = None;
+    let mut attr_span = None;
+    let mut fn_span = None;
+    for attr in attrs {
+        let attr_name = &attr.meta.path().segments.last().unwrap().ident;
+        if attr_name != "update" && attr_name != "query" && attr_name != "init" {
+            continue;
+        }
+        mode = Some(attr_name.clone());
+        attr_span = Some(attr.span().byte_range());
+        fn_span = Some(sig.span().byte_range());
+        if let Meta::List(list) = &attr.meta {
+            let nested = syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated
+                .parse2(list.tokens.clone())
+                .unwrap();
+            for meta in nested {
+                if let Meta::NameValue(ref m) = meta {
+                    if m.path.is_ident("name") {
+                        if let Expr::Lit(ExprLit {
+                            lit: Lit::Str(name),
+                            ..
+                        }) = &m.value
+                        {
+                            export_name = Some((name.value(), meta));
+                        }
+                    } else if m.path.is_ident("composite") {
+                        if let Expr::Lit(ExprLit {
+                            lit: Lit::Bool(b), ..
+                        }) = &m.value
+                        {
+                            if b.value {
+                                composite = Some(meta);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let args = sig
+        .inputs
+        .iter()
+        .filter_map(|arg| match arg {
+            FnArg::Receiver(_) => None,
+            FnArg::Typed(pat) => Some(*pat.ty.clone()),
+        })
+        .collect();
+    let rets = match &sig.output {
+        ReturnType::Default => Vec::new(),
+        ReturnType::Type(_, ty) => match ty.as_ref() {
+            syn::Type::Tuple(ty) => ty.elems.iter().map(|t| (*t).clone()).collect(),
+            _ => vec![*ty.clone()],
+        },
+    };
+    mode.map(|mode| CDKMethod {
+        func_name,
+        export_name,
+        composite,
+        args,
+        rets,
+        mode,
+        attr_span: attr_span.unwrap(),
+        fn_span: fn_span.unwrap(),
+        args_span: sig.inputs.span().byte_range(),
+        rets_span: sig.output.span().byte_range(),
+    })
+}
+impl CDKMethod {
+    fn debug_print(&self, source: &str) {
+        use syn::spanned::Spanned;
+        println!("{} {}", self.func_name, self.mode);
+        if let Some((_, meta)) = &self.export_name {
+            let range = meta.span().byte_range();
+            println!(" export {}", &source[range]);
+        }
+        if let Some(composite) = &self.composite {
+            let range = composite.span().byte_range();
+            println!(" composite {}", &source[range]);
+        }
+        for arg in &self.args {
+            let range = arg.span().byte_range();
+            println!(" arg {}", &source[range]);
+        }
+        for ret in &self.rets {
+            let range = ret.span().byte_range();
+            println!(" ret {}", &source[range]);
+        }
+    }
+}

--- a/src/candid-checker/src/lib.rs
+++ b/src/candid-checker/src/lib.rs
@@ -1,16 +1,17 @@
+use candid_parser::bindings::rust::{emit_bindgen, Config, Output};
+use candid_parser::configs::Configs;
+use candid_parser::{utils::CandidSource, Result};
 use codespan_reporting::{
     diagnostic::{Diagnostic, Label},
     files::SimpleFile,
     term::{self, termcolor::StandardStream},
 };
-use syn::{Expr, ExprLit, FnArg, Lit, Meta, ReturnType, Attribute, Signature};
-use candid_parser::bindings::rust::{Output, Config, emit_bindgen};
-use candid_parser::configs::Configs;
-use candid_parser::{Result, utils::CandidSource};
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
 use std::fs;
 use std::ops::Range;
+use std::path::{Path, PathBuf};
+use syn::spanned::Spanned;
+use syn::{Attribute, Expr, ExprLit, FnArg, Lit, Meta, ReturnType, Signature};
 
 pub fn check_rust(rust: &Path, candid: &Path, config: &Option<PathBuf>) -> Result<()> {
     let candid = CandidSource::File(candid);
@@ -25,7 +26,7 @@ pub fn check_rust(rust: &Path, candid: &Path, config: &Option<PathBuf>) -> Resul
     let (output, unused) = emit_bindgen(&config, &env, &actor);
     let name = rust.file_name().unwrap().to_str().unwrap();
     let source = fs::read_to_string(rust)?;
-    report_errors(&name, &source, &output);
+    report_errors(name, &source, &output);
     Ok(())
 }
 
@@ -67,10 +68,9 @@ fn get_endpoint_from_rust_source(source: &str) -> Vec<CDKMethod> {
     }
     visitor.0
 }
-fn diff_did_and_rust(candid: &Output, rust: &[CDKMethod]) -> Vec<Diagnostic<()>> {
-    use syn::spanned::Spanned;
+fn diff_did_and_rust(candid: &Output, rust_list: &[CDKMethod]) -> Vec<Diagnostic<()>> {
     let mut res = Vec::new();
-    let rust: BTreeMap<_, _> = rust
+    let rust: BTreeMap<_, _> = rust_list
         .iter()
         .map(|m| {
             let name = m
@@ -87,39 +87,65 @@ fn diff_did_and_rust(candid: &Output, rust: &[CDKMethod]) -> Vec<Diagnostic<()>>
         let mut labels = Vec::new();
         let mut notes = Vec::new();
         if let Some(func) = rust.get(&m.original_name) {
-            if m.original_name == m.name {
-            } else {
-                if let Some((name, meta)) = &func.export_name {
-                    if *name != m.original_name {
-                        labels
-                            .push(Label::primary((), meta.span().byte_range()).with_message(
-                                format!("expect {}", m.original_name.escape_debug()),
-                            ));
-                    }
-                } else {
-                    labels.push(
-                        Label::primary((), func.mode.span().byte_range()).with_message(format!(
-                            "missing (name = \"{}\")",
-                            m.original_name.escape_debug()
-                        )),
-                    );
-                }
+            // check function name
+            if func.func_name != m.name {
+                labels.push(
+                    Label::primary((), func.func_name.span().byte_range())
+                        .with_message(format!("Expect function name: {}", m.name)),
+                );
             }
-            let args = func.args.iter().zip(m.args.iter().map(|x| &x.1));
-            for (rust_arg, candid_arg) in args {
-                let parsed_candid_arg: syn::Type = syn::parse_str(candid_arg).unwrap();
-                if parsed_candid_arg != *rust_arg {
-                    labels.push(
-                        Label::primary((), rust_arg.span().byte_range())
-                            .with_message(format!("expect type: {}", candid_arg)),
-                    );
-                }
+            // check mode
+            let mode = if m.mode == "update" {
+                "update"
+            } else {
+                "query"
+            };
+            if func.mode != mode {
+                labels.push(
+                    Label::primary((), func.mode.span().byte_range())
+                        .with_message(format!("Expect mode: {}", mode)),
+                );
+            }
+            if m.mode == "composite_query" && func.composite.is_none() {
+                labels.push(
+                    Label::primary((), func.mode.span().byte_range())
+                        .with_message("Expect attribute: composite = true"),
+                );
+            }
+            // check rename attribute
+            if m.original_name != m.name && func.export_name.is_none() {
+                // no need to check func.export_name != m.original_name, since we already found the function
+                labels.push(
+                    Label::primary((), func.mode.span().byte_range()).with_message(format!(
+                        "Expect attribute: name = \"{}\"",
+                        m.original_name.escape_debug()
+                    )),
+                );
+            }
+            // check args
+            let args = m.args.iter().map(|x| x.1.clone()).collect::<Vec<_>>();
+            labels.extend(check_args(&func.args, &args, &func.args_span));
+            labels.extend(check_args(&func.rets, &m.rets, &func.rets_span));
+            if !labels.is_empty() {
+                labels.push(Label::secondary((), func.fn_span.clone()));
             }
         } else {
-            notes.push(format!(
-                "method \"{}\" missing from Rust code",
-                m.original_name
-            ));
+            if let Some(func) = rust_list.iter().find(|x| x.func_name == m.original_name) {
+                let (_, meta) = func.export_name.as_ref().unwrap();
+                labels.push(
+                    Label::primary((), meta.span().byte_range())
+                        .with_message("You may want to remove the name attribute"),
+                );
+                labels.push(
+                    Label::secondary((), func.func_name.span().byte_range())
+                        .with_message("This function name matches the Candid method name"),
+                );
+            } else {
+                notes.push(format!(
+                    "method \"{}\" missing from Rust code",
+                    m.original_name
+                ));
+            }
         }
         if labels.is_empty() && notes.is_empty() {
             continue;
@@ -128,6 +154,24 @@ fn diff_did_and_rust(candid: &Output, rust: &[CDKMethod]) -> Vec<Diagnostic<()>>
     }
     res
 }
+fn check_args(rust: &[syn::Type], candid: &[String], span: &Range<usize>) -> Vec<Label<()>> {
+    let mut labels = Vec::new();
+    if rust.len() != candid.len() {
+        labels.push(Label::primary((), span.clone()).with_message("Argument count mismatch"));
+        return labels;
+    }
+    let args = rust.iter().zip(candid.iter());
+    for (rust_arg, candid_arg) in args {
+        let parsed_candid_arg: syn::Type = syn::parse_str(candid_arg).unwrap();
+        if parsed_candid_arg != *rust_arg {
+            labels.push(
+                Label::primary((), rust_arg.span().byte_range())
+                    .with_message(format!("Expect type: {}", candid_arg)),
+            );
+        }
+    }
+    labels
+}
 struct CDKMethod {
     func_name: syn::Ident,
     export_name: Option<(String, syn::Meta)>,
@@ -135,19 +179,16 @@ struct CDKMethod {
     mode: syn::Ident,
     args: Vec<syn::Type>,
     rets: Vec<syn::Type>,
-    attr_span: Range<usize>,
     fn_span: Range<usize>,
     args_span: Range<usize>,
     rets_span: Range<usize>,
 }
 fn get_cdk_function(attrs: &[Attribute], sig: &Signature) -> Option<CDKMethod> {
     use syn::parse::Parser;
-    use syn::spanned::Spanned;
     let func_name = sig.ident.clone();
     let mut mode = None;
     let mut export_name = None;
     let mut composite = None;
-    let mut attr_span = None;
     let mut fn_span = None;
     for attr in attrs {
         let attr_name = &attr.meta.path().segments.last().unwrap().ident;
@@ -155,7 +196,6 @@ fn get_cdk_function(attrs: &[Attribute], sig: &Signature) -> Option<CDKMethod> {
             continue;
         }
         mode = Some(attr_name.clone());
-        attr_span = Some(attr.span().byte_range());
         fn_span = Some(sig.span().byte_range());
         if let Meta::List(list) = &attr.meta {
             let nested = syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated
@@ -207,7 +247,6 @@ fn get_cdk_function(attrs: &[Attribute], sig: &Signature) -> Option<CDKMethod> {
         args,
         rets,
         mode,
-        attr_span: attr_span.unwrap(),
         fn_span: fn_span.unwrap(),
         args_span: sig.inputs.span().byte_range(),
         rets_span: sig.output.span().byte_range(),
@@ -215,7 +254,6 @@ fn get_cdk_function(attrs: &[Attribute], sig: &Signature) -> Option<CDKMethod> {
 }
 impl CDKMethod {
     fn debug_print(&self, source: &str) {
-        use syn::spanned::Spanned;
         println!("{} {}", self.func_name, self.mode);
         if let Some((_, meta)) = &self.export_name {
             let range = meta.span().byte_range();

--- a/src/candid-checker/src/main.rs
+++ b/src/candid-checker/src/main.rs
@@ -1,0 +1,22 @@
+use clap::Parser;
+use std::path::PathBuf;
+use anyhow::Result;
+
+use candid_checker::check_rust;
+
+#[derive(Parser)]
+#[command(version, about)]
+struct Opts {
+    /// Rust source file
+    rust: PathBuf,
+    /// Candid file
+    candid: PathBuf,
+    /// TOML config file
+    config: Option<PathBuf>,
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    check_rust(&opts.rust, &opts.candid, &opts.config)?;
+    Ok(())
+}

--- a/src/candid-checker/src/main.rs
+++ b/src/candid-checker/src/main.rs
@@ -1,6 +1,6 @@
+use anyhow::Result;
 use clap::Parser;
 use std::path::PathBuf;
-use anyhow::Result;
 
 use candid_checker::check_rust;
 

--- a/src/candid-checker/test.did
+++ b/src/candid-checker/test.did
@@ -4,4 +4,6 @@ type List = opt record { head: blob; tail: List };
 service : {
   f:(my_type, vec Profile)->(List) composite_query;
   g:() -> ();
+  inner:()->();
+  missing:() -> () query;
 }

--- a/src/candid-checker/test.did
+++ b/src/candid-checker/test.did
@@ -1,0 +1,7 @@
+type my_type = principal;
+type Profile = record { name: text; age: nat8; country: text };
+type List = opt record { head: blob; tail: List };
+service : {
+  f:(my_type, vec Profile)->(List) composite_query;
+  g:() -> ();
+}

--- a/src/candid-checker/test.did
+++ b/src/candid-checker/test.did
@@ -5,5 +5,5 @@ service : {
   f:(my_type, vec Profile)->(List) composite_query;
   g:() -> ();
   inner:()->();
-  missing:() -> () query;
+  missing:(int) -> (nat) query;
 }

--- a/src/candid-checker/test.rs
+++ b/src/candid-checker/test.rs
@@ -13,7 +13,7 @@ pub struct List(Option<ListInner>);
 
 #[ic_cdk::update]
 #[candid_method(update)]
-pub async fn f(test: MyType, argument: Vec/* whatever */<Profile>) -> List {
+pub async fn f(test: MyType, argument: Vec/* whatever */<Profile>) -> (List, u8) {
 }
 
 fn not_candid() {}

--- a/src/candid-checker/test.rs
+++ b/src/candid-checker/test.rs
@@ -19,7 +19,7 @@ pub async fn f(test: MyType, argument: Vec/* whatever */<Profile>) -> List {
 fn not_candid() {}
 
 mod A {
-  #[query(composite = true, name="INNER")]
+  #[query(composite = true)]
   async fn inner(a: List) -> Result<List> {}
 }
 

--- a/src/candid-checker/test.rs
+++ b/src/candid-checker/test.rs
@@ -1,0 +1,32 @@
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+#![allow(dead_code, unused_imports)]
+use candid::{self, CandidType, Deserialize, Principal};
+
+pub type MyType = Principal;
+#[derive(CandidType, Deserialize)]
+pub struct Profile { pub age: u8, pub country: String, pub name: String }
+#[derive(CandidType, Deserialize)]
+pub struct ListInner { pub head: serde_bytes::ByteBuf, pub tail: Box<List> }
+#[derive(CandidType, Deserialize)]
+pub struct List(Option<ListInner>);
+
+#[ic_cdk::update]
+#[candid_method(update)]
+pub async fn f(test: MyType, argument: Vec/* whatever */<Profile>) -> List {
+}
+
+fn not_candid() {}
+
+mod A {
+  #[query(composite = true, name="INNER")]
+  async fn inner(a: List) -> Result<List> {}
+}
+
+#[::ic_cdk::query(name="test")]
+fn g() -> () {
+}
+impl T {
+  #[query]
+  fn h(&mut self) -> (u8,u16) {}
+}

--- a/src/candid-checker/test.toml
+++ b/src/candid-checker/test.toml
@@ -1,0 +1,3 @@
+f.name = "FFF"
+my_type.name = "CanisterId2"
+


### PR DESCRIPTION
Given a did file and a Rust file, check if the Rust code implements the Candid interface correctly.

To try it out:
```
$ candid-checker test.rs test.did test.toml
```