### PR TITLE
feat: support log_visibility canister setting

### DIFF
--- a/e2e-tests/canisters/canister_info.rs
+++ b/e2e-tests/canisters/canister_info.rs
@@ -69,6 +69,7 @@ async fn canister_lifecycle() -> Principal {
             memory_allocation: None,
             freezing_threshold: None,
             reserved_cycles_limit: None,
+            log_visibility: None,
             wasm_memory_limit: None,
         },
         canister_id: canister_id.canister_id,

--- a/e2e-tests/canisters/management_caller.rs
+++ b/e2e-tests/canisters/management_caller.rs
@@ -39,6 +39,10 @@ mod main {
         assert_eq!(definite_canister_setting.freezing_threshold, u64::MAX);
         assert_eq!(definite_canister_setting.reserved_cycles_limit, u128::MAX);
         assert_eq!(
+            definite_canister_setting.log_visibility,
+            LogVisibility::Public
+        );
+        assert_eq!(
             definite_canister_setting.wasm_memory_limit,
             2u64.pow(48) - 1
         );

--- a/e2e-tests/canisters/management_caller.rs
+++ b/e2e-tests/canisters/management_caller.rs
@@ -18,6 +18,7 @@ mod main {
                 memory_allocation: Some(10000u16.into()),
                 freezing_threshold: Some(u64::MAX.into()),
                 reserved_cycles_limit: Some(u128::MAX.into()),
+                log_visibility: Some(LogVisibility::Public),
                 wasm_memory_limit: Some((2u64.pow(48) - 1).into()),
             }),
         };
@@ -72,6 +73,7 @@ mod main {
 
 mod provisional {
     use super::*;
+    use api::management_canister::main::LogVisibility;
     use ic_cdk::api::management_canister::provisional::*;
 
     #[update]
@@ -82,6 +84,7 @@ mod provisional {
             memory_allocation: Some(10000u16.into()),
             freezing_threshold: Some(10000u16.into()),
             reserved_cycles_limit: Some(10000u16.into()),
+            log_visibility: Some(LogVisibility::Public),
             wasm_memory_limit: Some(10000u16.into()),
         };
         let arg = ProvisionalCreateCanisterWithCyclesArgument {

--- a/src/ic-cdk-bindgen/CHANGELOG.md
+++ b/src/ic-cdk-bindgen/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+- Support canister setting `log_visibility`.
+
 ### Changed
 
 - Refactor!: move Rust code generation logic from candid_parser. (#480)

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -8,11 +8,12 @@ pub type CanisterId = Principal;
 #[derive(
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default,
 )]
-#[serde(rename_all = "lowercase")]
 pub enum LogVisibility {
     #[default]
+    #[serde(rename = "controllers")]
     /// Only controllers of the canister can access the logs.
     Controllers,
+    #[serde(rename = "public")]
     /// Everyone is allowed to access the canister's logs.
     Public,
 }

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -4,6 +4,19 @@ use serde::{Deserialize, Serialize};
 /// Canister ID is Principal.
 pub type CanisterId = Principal;
 
+/// todo
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum LogVisibility {
+    #[default]
+    /// Only controllers of the canister can access the logs.
+    Controllers,
+    /// Everyone is allowed to access the canister's logs.
+    Public,
+}
+
 /// Canister settings.
 ///
 /// The settings are optional. If they are not explicitly set, the default values will be applied automatically.
@@ -52,6 +65,10 @@ pub struct CanisterSettings {
     ///
     /// Default value: 5_000_000_000_000 (5 trillion cycles).
     pub reserved_cycles_limit: Option<Nat>,
+    /// Defines who is allowed to read the canister's logs.
+    ///
+    /// Default value: Controllers
+    pub log_visibility: Option<LogVisibility>,
     /// Must be a number between 0 and 2<sup>48</sup>-1 (i.e 256TB), inclusively.
     ///
     /// It indicates the upper limit on the WASM heap memory consumption of the canister.
@@ -317,6 +334,8 @@ pub struct DefiniteCanisterSettings {
     pub freezing_threshold: Nat,
     /// Reserved cycles limit.
     pub reserved_cycles_limit: Nat,
+    /// Visibility of canister logs.
+    pub log_visibility: LogVisibility,
     /// The Wasm memory limit.
     pub wasm_memory_limit: Nat,
 }


### PR DESCRIPTION
# Description

Canister settings now include `log_visibility`.

Addresses [feature request on the forum](https://forum.dfinity.org/t/fetching-canister-logs-dynamically-or-by-using-rs-agent/32420/3)

# How Has This Been Tested?

Covered in a test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
