### PR TITLE
fix: ld-compatible symbols

### DIFF
--- a/src/ic-cdk-macros/CHANGELOG.md
+++ b/src/ic-cdk-macros/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+
+- `cargo build` should no longer give a confusing linkage error on Linux.
+
 ## [0.13.2] - 2024-04-08
 
 ### Changed

--- a/src/ic-cdk-macros/src/export.rs
+++ b/src/ic-cdk-macros/src/export.rs
@@ -329,7 +329,8 @@ mod test {
         };
 
         let expected = quote! {
-            #[export_name = "canister_query query"]
+            #[cfg_attr(target_family = "wasm", export_name = "canister_query query")]
+            #[cfg_attr(not(target_family = "wasm"), export_name = "canister_query.query")]
             fn #fn_name() {
                 ic_cdk::setup();
                 ic_cdk::spawn(async {
@@ -371,7 +372,8 @@ mod test {
         };
 
         let expected = quote! {
-            #[export_name = "canister_query query"]
+            #[cfg_attr(target_family = "wasm", export_name = "canister_query query")]
+            #[cfg_attr(not(target_family = "wasm"), export_name = "canister_query.query")]
             fn #fn_name() {
                 ic_cdk::setup();
                 ic_cdk::spawn(async {
@@ -414,7 +416,8 @@ mod test {
         };
 
         let expected = quote! {
-            #[export_name = "canister_query query"]
+            #[cfg_attr(target_family = "wasm", export_name = "canister_query query")]
+            #[cfg_attr(not(target_family = "wasm"), export_name = "canister_query.query")]
             fn #fn_name() {
                 ic_cdk::setup();
                 ic_cdk::spawn(async {
@@ -457,7 +460,8 @@ mod test {
         };
 
         let expected = quote! {
-            #[export_name = "canister_query query"]
+            #[cfg_attr(target_family = "wasm", export_name = "canister_query query")]
+            #[cfg_attr(not(target_family = "wasm"), export_name = "canister_query.query")]
             fn #fn_name() {
                 ic_cdk::setup();
                 ic_cdk::spawn(async {
@@ -500,7 +504,8 @@ mod test {
         };
 
         let expected = quote! {
-            #[export_name = "canister_query query"]
+            #[cfg_attr(target_family = "wasm", export_name = "canister_query query")]
+            #[cfg_attr(not(target_family = "wasm"), export_name = "canister_query.query")]
             fn #fn_name() {
                 ic_cdk::setup();
                 ic_cdk::spawn(async {
@@ -543,7 +548,8 @@ mod test {
         };
 
         let expected = quote! {
-            #[export_name = "canister_query query"]
+            #[cfg_attr(target_family = "wasm", export_name = "canister_query query")]
+            #[cfg_attr(not(target_family = "wasm"), export_name = "canister_query.query")]
             fn #fn_name() {
                 ic_cdk::setup();
                 ic_cdk::spawn(async {
@@ -586,7 +592,8 @@ mod test {
         };
 
         let expected = quote! {
-            #[export_name = "canister_query custom_query"]
+            #[cfg_attr(target_family = "wasm", export_name = "canister_query custom_query")]
+            #[cfg_attr(not(target_family = "wasm"), export_name = "canister_query.custom_query")]
             fn #fn_name() {
                 ic_cdk::setup();
                 ic_cdk::spawn(async {

--- a/src/ic-cdk-macros/src/export.rs
+++ b/src/ic-cdk-macros/src/export.rs
@@ -162,6 +162,7 @@ fn dfn_macro(
         }
         format!("canister_{method} {function_name}")
     };
+    let host_compatible_name = export_name.replace(' ', ".").replace(['-', '<', '>'], "_");
 
     let function_call = if is_async {
         quote! { #name ( #(#arg_tuple),* ) .await }
@@ -256,7 +257,8 @@ fn dfn_macro(
     };
 
     Ok(quote! {
-        #[export_name = #export_name]
+        #[cfg_attr(target_family = "wasm", export_name = #export_name)]
+        #[cfg_attr(not(target_family = "wasm"), export_name = #host_compatible_name)]
         fn #outer_function_ident() {
             ic_cdk::setup();
 


### PR DESCRIPTION
This changes export macros to not contain spaces or brackets, so `cargo build` doesn't give weird errors with GNU ld.