### PR TITLE
fix: Use ld-compatible symbol in ic-cdk-timers

### DIFF
--- a/src/ic-cdk-timers/src/lib.rs
+++ b/src/ic-cdk-timers/src/lib.rs
@@ -260,7 +260,14 @@ fn update_ic0_timer() {
     });
 }
 
-#[export_name = "canister_update <ic-cdk internal> timer_executor"]
+#[cfg_attr(
+    target_family = "wasm",
+    export_name = "canister_update <ic-cdk internal> timer_executor"
+)]
+#[cfg_attr(
+    not(target_family = "wasm"),
+    export_name = "canister_update_ic_cdk_internal.timer_executor"
+)]
 extern "C" fn timer_executor() {
     if ic_cdk::api::caller() != ic_cdk::api::id() {
         ic_cdk::trap("This function is internal to ic-cdk and should not be called externally.");


### PR DESCRIPTION
See #500