### PR TITLE
fix: Fix memory leak in CallFuture

### DIFF
--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -74,7 +74,6 @@ impl<T: AsRef<[u8]>> Future for CallFuture<T> {
 
     fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
         let self_ref = Pin::into_inner(self);
-        let state_ptr = Weak::into_raw(Arc::downgrade(&self_ref.state));
         let mut state = self_ref.state.write().unwrap();
 
         if let Some(result) = state.result.take() {
@@ -85,6 +84,7 @@ impl<T: AsRef<[u8]>> Future for CallFuture<T> {
                 let method = &state.method;
                 let args = state.arg.as_ref();
                 let payment = state.payment;
+                let state_ptr = Weak::into_raw(Arc::downgrade(&self_ref.state));
                 // SAFETY:
                 // `callee`, being &[u8], is a readable sequence of bytes and therefore can be passed to ic0.call_new.
                 // `method`, being &str, is a readable sequence of bytes and therefore can be passed to ic0.call_new.


### PR DESCRIPTION
#391 accidentally introduced a memory leak in CallFuture under the right conditions. This reverses it.