### PR TITLE
feat: add AllowedViewers variant to LogVisibility enum

### DIFF
--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+* Add `AllowedViewers` to `LogVisibility` enum.
+
 ### Changed
 
 - BREAKING: Add the `LoadSnapshot` variant to `CanisterChangeDetails`. (#504)

--- a/src/ic-cdk/src/api/management_canister/main/types.rs
+++ b/src/ic-cdk/src/api/management_canister/main/types.rs
@@ -16,6 +16,9 @@ pub enum LogVisibility {
     #[serde(rename = "public")]
     /// Everyone is allowed to access the canister's logs.
     Public,
+    #[serde(rename = "allowed_viewers")]
+    /// Canister logs are visible to a set of principals.
+    AllowedViewers(Vec<Principal>),
 }
 
 /// Canister settings.


### PR DESCRIPTION
# Description

Canister's `log_visibility` now include `AllowedViewers` variant.

Fixes # (issue): SDK-1799

# How Has This Been Tested?

Regular CI.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
