### PR TITLE
chore: release ic-cdk v0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,11 +1118,11 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "candid",
- "ic-cdk-macros 0.15.0",
+ "ic-cdk-macros 0.16.0",
  "ic0 0.23.0",
  "rstest",
  "serde",
@@ -1150,7 +1150,7 @@ dependencies = [
  "escargot",
  "futures",
  "hex",
- "ic-cdk 0.15.0",
+ "ic-cdk 0.16.0",
  "ic-cdk-timers",
  "lazy_static",
  "pocket-ic",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "candid",
  "proc-macro2",
@@ -1186,10 +1186,10 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-timers"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "futures",
- "ic-cdk 0.15.0",
+ "ic-cdk 0.16.0",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -1203,7 +1203,7 @@ dependencies = [
  "bincode",
  "candid",
  "hex",
- "ic-cdk 0.15.0",
+ "ic-cdk 0.16.0",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -1212,12 +1212,12 @@ dependencies = [
 
 [[package]]
 name = "ic-ledger-types"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "candid",
  "crc32fast",
  "hex",
- "ic-cdk 0.15.0",
+ "ic-cdk 0.16.0",
  "serde",
  "serde_bytes",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ opt-level = 'z'
 
 [workspace.dependencies]
 ic0 = { path = "src/ic0", version = "0.23.0" }
-ic-cdk = { path = "src/ic-cdk", version = "0.15.0" }
-ic-cdk-timers = { path = "src/ic-cdk-timers", version = "0.9.0" }
+ic-cdk = { path = "src/ic-cdk", version = "0.16.0" }
+ic-cdk-timers = { path = "src/ic-cdk-timers", version = "0.10.0" }
 
 candid = "0.10.4"
 candid_parser = "0.1.4"

--- a/library/ic-ledger-types/CHANGELOG.md
+++ b/library/ic-ledger-types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.13.0] - 2024-08-27
+
+### Changed
+
+- Upgrade `ic-cdk` to v0.16.
+
 ## [0.12.0] - 2024-07-01
 
 ### Changed

--- a/library/ic-ledger-types/Cargo.toml
+++ b/library/ic-ledger-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-ledger-types"
-version = "0.12.0"
+version = "0.13.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/src/ic-cdk-macros/CHANGELOG.md
+++ b/src/ic-cdk-macros/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
+
+This file will no longer be updated.
+
+Please check [`ic-cdk` changelog](../ic-cdk/CHANGELOG.md).
+
+---
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [unreleased]
 
 ### Fixed
 

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-macros"
-version = "0.15.0" # sync with ic-cdk
+version = "0.16.0" # sync with ic-cdk
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/src/ic-cdk-timers/CHANGELOG.md
+++ b/src/ic-cdk-timers/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.10.0] - 2024-08-27
+
+### Changed
+
+- Upgrade `ic-cdk` to v0.16.
+
 ## [0.9.0] - 2024-07-01
 
 ### Changed

--- a/src/ic-cdk-timers/Cargo.toml
+++ b/src/ic-cdk-timers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-timers"
-version = "0.9.0"
+version = "0.10.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.16.0] - 2024-08-27
+
 ### Changed
 
 - BREAKING: Add the `LoadSnapshot` variant to `CanisterChangeDetails`. (#504)

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.15.0" # sync with ic-cdk-macros
+version = "0.16.0" # sync with ic-cdk-macros
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -27,7 +27,7 @@ ic0.workspace = true
 # Dependents won't accidentaly upgrading ic-cdk-macros only but not ic-cdk.
 # ic-cdk-macros is a hidden dependency, re-exported by ic-cdk.
 # It should not be included by users direcly.
-ic-cdk-macros = { path = "../ic-cdk-macros", version = "=0.15.0" }
+ic-cdk-macros = { path = "../ic-cdk-macros", version = "=0.16.0" }
 serde.workspace = true
 serde_bytes.workspace = true
 slotmap = { workspace = true, optional = true }


### PR DESCRIPTION
This major release adds the support for Canister snapshots which enables data backup and restore.