### PR TITLE
feat(ic-ledger-types): Add AccountIdentifier.as_bytes()

### DIFF
--- a/library/ic-ledger-types/CHANGELOG.md
+++ b/library/ic-ledger-types/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+- as_bytes method to AccountIdentifier in ic-ledger-types
+
 ## [0.13.0] - 2024-08-27
 
 ### Changed

--- a/library/ic-ledger-types/src/lib.rs
+++ b/library/ic-ledger-types/src/lib.rs
@@ -218,6 +218,11 @@ impl AccountIdentifier {
         hex::encode(self.0)
     }
 
+    /// Provide the account identifier as bytes.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
     /// Returns the checksum of the account identifier.
     pub fn generate_checksum(&self) -> [u8; 4] {
         let mut hasher = crc32fast::Hasher::new();
@@ -883,8 +888,11 @@ mod tests {
         )
     }
 
+    /// Verifies that these conversions yield the same result:
+    /// * bytes -> AccountIdentifier -> hex -> AccountIdentifier
+    /// * bytes -> AccountIdentifier
     #[test]
-    fn check_round_trip() {
+    fn check_hex_round_trip() {
         let bytes: [u8; 32] = [
             237, 196, 46, 168, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
             7, 7, 7, 7, 7,
@@ -895,6 +903,23 @@ mod tests {
         assert_eq!(
             AccountIdentifier::from_hex(&res),
             Ok(ai),
+            "The account identifier doesn't change after going back and forth between a string"
+        )
+    }
+
+    /// Verifies that this convertion yields the original data:
+    /// * bytes -> AccountIdentifier -> bytes
+    #[test]
+    fn check_bytes_round_trip() {
+        let bytes: [u8; 32] = [
+            237, 196, 46, 168, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+            7, 7, 7, 7, 7,
+        ];
+        assert_eq!(
+            AccountIdentifier::from_slice(&bytes)
+                .expect("Failed to parse bytes as principal")
+                .as_bytes(),
+            &bytes,
             "The account identifier doesn't change after going back and forth between a string"
         )
     }


### PR DESCRIPTION
# Description
It is currently not possible to obtain an `AccountIdentifier` as bytes.  It is only possible to obtain hex and then convert the hex back to bytes.  This is resolved by adding an `.as_bytes()` method that returns a reference to the inner bytes.

Fixes #519

# How Has This Been Tested?
A unit test is included that verifies that parsing bytes and returning them as bytes yields the original data.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
  - Rustdoc is included on the method.
