### PR TITLE
fix: update/query macro could not handle function arguments with the same name as the function itself

### DIFF
--- a/ic-cdk-macros/src/export.rs
+++ b/ic-cdk-macros/src/export.rs
@@ -81,14 +81,17 @@ fn get_args(method: MethodType, signature: &Signature) -> Result<Vec<(Ident, Box
                 ));
             }
             FnArg::Typed(PatType { pat, ty, .. }) => {
-                if let Pat::Ident(PatIdent { ident, .. }) = pat.as_ref() {
-                    (ident.clone(), ty.clone())
+                let ident = if let Pat::Ident(PatIdent { ident, .. }) = pat.as_ref() {
+                    // If the argument is named the same as the function, we need to rename it.
+                    if ident == &signature.ident {
+                        format_ident!("__arg_{}", ident, span = pat.span())
+                    } else {
+                        ident.clone()
+                    }
                 } else {
-                    (
-                        format_ident!("__unnamed_arg_{i}", span = pat.span()),
-                        ty.clone(),
-                    )
-                }
+                    format_ident!("__unnamed_arg_{i}", span = pat.span())
+                };
+                (ident, ty.clone())
             }
         };
 

--- a/ic-cdk/CHANGELOG.md
+++ b/ic-cdk/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+
+- Fix update/query macro could not handle function arguments with the same name as the function itself. (#525)
+
 ### Changed
 
 - Add `AllowedViewers` variant to `LogVisibility` enum. (#512)

--- a/ic-cdk/tests/pass/func_arg_same_name.rs
+++ b/ic-cdk/tests/pass/func_arg_same_name.rs
@@ -1,9 +1,0 @@
-use ic_cdk::{query, update};
-
-#[update]
-fn foo(foo: i32) {}
-
-#[query]
-fn bar(bar: i32) {}
-
-fn main() {}

--- a/ic-cdk/tests/pass/func_arg_same_name.rs
+++ b/ic-cdk/tests/pass/func_arg_same_name.rs
@@ -1,0 +1,9 @@
+use ic_cdk::{query, update};
+
+#[update]
+fn foo(foo: i32) {}
+
+#[query]
+fn bar(bar: i32) {}
+
+fn main() {}

--- a/ic-cdk/tests/pass/method_arg_same_name.rs
+++ b/ic-cdk/tests/pass/method_arg_same_name.rs
@@ -1,0 +1,13 @@
+use ic_cdk::{query, update};
+
+#[update]
+fn foo(foo: i32) -> i32 {
+    foo
+}
+
+#[query]
+fn bar(bar: i32) -> i32 {
+    bar
+}
+
+fn main() {}


### PR DESCRIPTION
SDK-1856

# How Has This Been Tested?

ic-cdk/tests/pass/method_arg_same_name.rs

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
