### PR TITLE
feat: root call mod with new CallError

### DIFF
--- a/e2e-tests/src/bin/call_struct.rs
+++ b/e2e-tests/src/bin/call_struct.rs
@@ -1,17 +1,78 @@
-use candid::Principal;
-use ic_cdk::api::management_canister::main::{CanisterIdRecord, CreateCanisterArgument};
-use ic_cdk::prelude::*;
+use candid::Encode;
+use ic_cdk::{call::DecoderConfig, prelude::*};
+
+/// This endpoint is to be called by the following Call struct invocation.
+#[update]
+async fn echo(arg: u32) -> u32 {
+    arg
+}
 
 #[update]
-async fn create_canister_via_struct() -> Principal {
-    let res: (CanisterIdRecord,) = Call::new(Principal::management_canister(), "create_canister")
-        .with_args((CreateCanisterArgument::default(),))
-        .with_cycles(1_000_000_000_000)
+async fn call_struct() {
+    let num = 1u32;
+    let bytes: Vec<u8> = Encode!(&num).unwrap();
+
+    // 1. Various ways to call*
+    // 1.1 call()
+    let res: (u32,) = Call::new(id(), "echo")
+        .with_args((num,))
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(res.0, num);
+    // 1.2 call_raw()
+    let res = Call::new(id(), "echo")
+        .with_args((num,))
+        .call_raw()
+        .await
+        .unwrap();
+    assert_eq!(res, bytes);
+    // 1.3 call_with_decoder_config()
+    let config = DecoderConfig::default();
+    let res: (u32,) = Call::new(id(), "echo")
+        .with_args((num,))
+        .call_with_decoder_config(&config)
+        .await
+        .unwrap();
+    assert_eq!(res.0, num);
+    // 1.4 call_raw_with_decoder_config()
+    Call::new(id(), "echo")
+        .with_args((num,))
+        .call_and_forget()
+        .unwrap();
+
+    // 2. Various ways to config the call
+    // 2.1 with_raw_args()
+    let res: (u32,) = Call::new(id(), "echo")
+        .with_raw_args(&bytes)
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(res.0, num);
+    // 2.2 with_guaranteed_response()
+    let res: (u32,) = Call::new(id(), "echo")
+        .with_args((num,))
         .with_guaranteed_response()
         .call()
         .await
         .unwrap();
-    res.0.canister_id
+    assert_eq!(res.0, num);
+    // 2.3 change_timeout()
+    let res: (u32,) = Call::new(id(), "echo")
+        .with_args((num,))
+        .change_timeout(5)
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(res.0, num);
+    // 2.4 with_cycles()
+    let res: (u32,) = Call::new(id(), "echo")
+        .with_args((num,))
+        .with_cycles(100_000)
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(res.0, num);
 }
 
 fn main() {}

--- a/e2e-tests/tests/call_struct.rs
+++ b/e2e-tests/tests/call_struct.rs
@@ -1,21 +1,23 @@
-use candid::Principal;
 use ic_cdk_e2e_tests::cargo_build_canister;
 use pocket_ic::common::rest::RawEffectivePrincipal;
-use pocket_ic::{call_candid, PocketIc};
+use pocket_ic::{call_candid, PocketIcBuilder};
 
 #[test]
 fn call_struct() {
-    let pic = PocketIc::new();
+    let pic = PocketIcBuilder::new()
+        .with_application_subnet()
+        .with_nonmainnet_features(true)
+        .build();
     let wasm = cargo_build_canister("call_struct");
     let canister_id = pic.create_canister();
     pic.add_cycles(canister_id, 100_000_000_000_000);
     pic.install_canister(canister_id, wasm, vec![], None);
-    let _: (Principal,) = call_candid(
+    let _: () = call_candid(
         &pic,
         canister_id,
         RawEffectivePrincipal::None,
-        "create_canister_via_struct",
+        "call_struct",
         (),
     )
-    .expect("Error calling create_canister_via_struct");
+    .expect("Error calling call_struct");
 }

--- a/ic-cdk-timers/src/lib.rs
+++ b/ic-cdk-timers/src/lib.rs
@@ -148,7 +148,6 @@ extern "C" fn global_timer() {
                         | RejectionCode::DestinationInvalid
                         | RejectionCode::CanisterReject
                         | RejectionCode::CanisterError
-                        | RejectionCode::SysUnknown
                         | RejectionCode::Unknown => {}
                     }
                 }

--- a/ic-cdk/Cargo.toml
+++ b/ic-cdk/Cargo.toml
@@ -31,6 +31,7 @@ ic-cdk-macros = { path = "../ic-cdk-macros", version = "=0.18.0-alpha.1" }
 serde.workspace = true
 serde_bytes.workspace = true
 slotmap = { workspace = true, optional = true }
+thiserror = "2.0"
 
 [dev-dependencies]
 anyhow = "1"

--- a/ic-cdk/src/api/call.rs
+++ b/ic-cdk/src/api/call.rs
@@ -14,35 +14,24 @@ use std::task::{Context, Poll, Waker};
 
 /// Rejection code from calling another canister.
 ///
-/// These can be obtained using [reject_code].
-#[repr(i32)]
+/// These can be obtained either using `reject_code()` or `reject_result()`.
+#[allow(missing_docs)]
+#[repr(usize)]
 #[derive(CandidType, Deserialize, Clone, Copy, Hash, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RejectionCode {
-    /// No error.
     NoError = 0,
 
-    /// Fatal system error, retry unlikely to be useful.
     SysFatal = 1,
-    /// Transient system error, retry might be possible.
     SysTransient = 2,
-    /// Invalid destination (e.g. canister/account does not exist)
     DestinationInvalid = 3,
-    /// Explicit reject by the canister.
     CanisterReject = 4,
-    /// Canister error (e.g., trap, no response)
     CanisterError = 5,
-    /// Response unknown; system stopped waiting for it (e.g., timed out, or system under high load).
-    SysUnknown = 6,
 
-    /// Unknown rejection code.
-    ///
-    /// Note that this variant is not part of the IC interface spec, and is used to represent
-    /// rejection codes that are not recognized by the library.
     Unknown,
 }
 
-impl From<i32> for RejectionCode {
-    fn from(code: i32) -> Self {
+impl From<usize> for RejectionCode {
+    fn from(code: usize) -> Self {
         match code {
             0 => RejectionCode::NoError,
             1 => RejectionCode::SysFatal,
@@ -50,7 +39,6 @@ impl From<i32> for RejectionCode {
             3 => RejectionCode::DestinationInvalid,
             4 => RejectionCode::CanisterReject,
             5 => RejectionCode::CanisterError,
-            6 => RejectionCode::SysUnknown,
             _ => RejectionCode::Unknown,
         }
     }
@@ -58,7 +46,7 @@ impl From<i32> for RejectionCode {
 
 impl From<u32> for RejectionCode {
     fn from(code: u32) -> Self {
-        RejectionCode::from(code as i32)
+        RejectionCode::from(code as usize)
     }
 }
 
@@ -73,9 +61,8 @@ struct CallFutureState<T: AsRef<[u8]>> {
     waker: Option<Waker>,
     id: Principal,
     method: String,
-    arg: Option<T>,
-    payment: Option<u128>,
-    timeout_seconds: Option<u32>,
+    arg: T,
+    payment: u128,
 }
 
 struct CallFuture<T: AsRef<[u8]>> {
@@ -95,6 +82,8 @@ impl<T: AsRef<[u8]>> Future for CallFuture<T> {
             if state.waker.is_none() {
                 let callee = state.id.as_slice();
                 let method = &state.method;
+                let args = state.arg.as_ref();
+                let payment = state.payment;
                 let state_ptr = Weak::into_raw(Arc::downgrade(&self_ref.state));
                 // SAFETY:
                 // `callee`, being &[u8], is a readable sequence of bytes and therefore can be passed to ic0.call_new.
@@ -114,21 +103,15 @@ impl<T: AsRef<[u8]>> Future for CallFuture<T> {
                         callee.len(),
                         method.as_ptr() as usize,
                         method.len(),
-                        callback::<T> as usize,
+                        callback::<T> as usize as usize,
                         state_ptr as usize,
-                        callback::<T> as usize,
+                        callback::<T> as usize as usize,
                         state_ptr as usize,
                     );
-                    if let Some(args) = &state.arg {
-                        ic0::call_data_append(args.as_ref().as_ptr() as usize, args.as_ref().len());
-                    }
-                    if let Some(payment) = state.payment {
-                        add_payment(payment);
-                    }
-                    if let Some(timeout_seconds) = state.timeout_seconds {
-                        ic0::call_with_best_effort_response(timeout_seconds);
-                    }
-                    ic0::call_on_cleanup(cleanup::<T> as usize, state_ptr as usize);
+
+                    ic0::call_data_append(args.as_ptr() as usize, args.len());
+                    add_payment(payment);
+                    ic0::call_on_cleanup(cleanup::<T> as usize as usize, state_ptr as usize);
                     ic0::call_perform()
                 };
 
@@ -206,258 +189,6 @@ unsafe extern "C" fn cleanup<T: AsRef<[u8]>>(state_ptr: *const RwLock<CallFuture
     }
 }
 
-/// Inter-Canister Call.
-#[derive(Debug)]
-pub struct Call<'a> {
-    canister_id: Principal,
-    method: &'a str,
-    payment: Option<u128>,
-    timeout_seconds: Option<u32>,
-}
-
-/// Inter-Canister Call with typed arguments.
-#[derive(Debug)]
-pub struct CallWithArgs<'a, T> {
-    call: Call<'a>,
-    args: T,
-}
-
-/// Inter-Canister Call with raw arguments.
-#[derive(Debug)]
-pub struct CallWithRawArgs<'a, A> {
-    call: Call<'a>,
-    raw_args: A,
-}
-
-impl<'a> Call<'a> {
-    /// Constructs a new call with the Canister id and method name.
-    ///
-    /// # Note
-    /// The `Call` default to set a 10 seconds timeout for Best-Effort Responses.
-    /// If you want to set a guaranteed response, you can use the `with_guaranteed_response` method.
-    pub fn new(canister_id: Principal, method: &'a str) -> Self {
-        Self {
-            canister_id,
-            method,
-            payment: None,
-            // Default to 10 seconds.
-            timeout_seconds: Some(10),
-        }
-    }
-
-    /// Sets the arguments for the call.
-    ///
-    /// Another way to set the arguments is to use `with_raw_args`.
-    /// If both are invoked, the last one is used.
-    pub fn with_args<T>(self, args: T) -> CallWithArgs<'a, T> {
-        CallWithArgs { call: self, args }
-    }
-
-    /// Sets the arguments for the call as raw bytes.    
-    ///
-    /// Another way to set the arguments is to use `with_raw_args`.
-    /// If both are invoked, the last one is used.
-    pub fn with_raw_args<A>(self, raw_args: A) -> CallWithRawArgs<'a, A> {
-        CallWithRawArgs {
-            call: self,
-            raw_args,
-        }
-    }
-}
-
-/// Methods to configure a call.
-pub trait ConfigurableCall {
-    /// Sets the cycles payment for the call.
-    ///
-    /// If invoked multiple times, the last value is used.
-    fn with_cycles(self, cycles: u128) -> Self;
-
-    /// Sets the call to have a guaranteed response.
-    ///
-    /// If [change_timeout](ConfigurableCall::change_timeout) is invoked after this method,
-    /// the call will instead be set with Best-Effort Responses.
-    fn with_guaranteed_response(self) -> Self;
-
-    /// Sets the timeout for the Best-Effort Responses.
-    ///
-    /// If not set, the call will default to a 10 seconds timeout.
-    /// If invoked multiple times, the last value is used.
-    /// If [with_guaranteed_response](ConfigurableCall::with_guaranteed_response) is invoked after this method,
-    /// the timeout will be ignored.
-    fn change_timeout(self, timeout_seconds: u32) -> Self;
-}
-
-impl<'a> ConfigurableCall for Call<'a> {
-    fn with_cycles(mut self, cycles: u128) -> Self {
-        self.payment = Some(cycles);
-        self
-    }
-
-    fn with_guaranteed_response(mut self) -> Self {
-        self.timeout_seconds = None;
-        self
-    }
-
-    fn change_timeout(mut self, timeout_seconds: u32) -> Self {
-        self.timeout_seconds = Some(timeout_seconds);
-        self
-    }
-}
-
-impl<'a, T> ConfigurableCall for CallWithArgs<'a, T> {
-    fn with_cycles(mut self, cycles: u128) -> Self {
-        self.call.payment = Some(cycles);
-        self
-    }
-
-    fn with_guaranteed_response(mut self) -> Self {
-        self.call.timeout_seconds = None;
-        self
-    }
-
-    fn change_timeout(mut self, timeout_seconds: u32) -> Self {
-        self.call.timeout_seconds = Some(timeout_seconds);
-        self
-    }
-}
-
-impl<'a, A> ConfigurableCall for CallWithRawArgs<'a, A> {
-    fn with_cycles(mut self, cycles: u128) -> Self {
-        self.call.payment = Some(cycles);
-        self
-    }
-
-    fn with_guaranteed_response(mut self) -> Self {
-        self.call.timeout_seconds = None;
-        self
-    }
-
-    fn change_timeout(mut self, timeout_seconds: u32) -> Self {
-        self.call.timeout_seconds = Some(timeout_seconds);
-        self
-    }
-}
-
-/// Methods to send a call.
-pub trait SendableCall {
-    /// Sends the call and gets the reply as raw bytes.
-    fn call_raw(self) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync;
-
-    /// Sends the call and decodes the reply to a Candid type.
-    fn call<R: for<'b> ArgumentDecoder<'b>>(
-        self,
-    ) -> impl Future<Output = CallResult<R>> + Send + Sync
-    where
-        Self: Sized,
-    {
-        let fut = self.call_raw();
-        async {
-            let bytes = fut.await?;
-            decode_args(&bytes).map_err(decoder_error_to_reject::<R>)
-        }
-    }
-
-    /// Sends the call and decodes the reply to a Candid type with a decoding quota.
-    fn call_with_decoder_config<R: for<'b> ArgumentDecoder<'b>>(
-        self,
-        decoder_config: &ArgDecoderConfig,
-    ) -> impl Future<Output = CallResult<R>> + Send + Sync
-    where
-        Self: Sized,
-    {
-        let fut = self.call_raw();
-        async move {
-            let bytes = fut.await?;
-            let config = decoder_config.to_candid_config();
-            let pre_cycles = if decoder_config.debug {
-                Some(crate::api::performance_counter(0))
-            } else {
-                None
-            };
-            match decode_args_with_config_debug(&bytes, &config) {
-                Err(e) => Err(decoder_error_to_reject::<R>(e)),
-                Ok((r, cost)) => {
-                    if decoder_config.debug {
-                        print_decoding_debug_info(std::any::type_name::<R>(), &cost, pre_cycles);
-                    }
-                    Ok(r)
-                }
-            }
-        }
-    }
-
-    /// Sends the call and ignores the reply.
-    fn call_and_forget(self) -> Result<(), RejectionCode>;
-}
-
-impl SendableCall for Call<'_> {
-    fn call_raw(self) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync {
-        call_raw_internal::<Vec<u8>>(
-            self.canister_id,
-            self.method,
-            None,
-            self.payment,
-            self.timeout_seconds,
-        )
-    }
-
-    fn call_and_forget(self) -> Result<(), RejectionCode> {
-        notify_raw_internal::<Vec<u8>>(
-            self.canister_id,
-            self.method,
-            None,
-            self.payment,
-            self.timeout_seconds,
-        )
-    }
-}
-
-impl<'a, T: ArgumentEncoder> SendableCall for CallWithArgs<'a, T> {
-    fn call_raw(self) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync {
-        let args = encode_args(self.args).expect("failed to encode arguments");
-        call_raw_internal(
-            self.call.canister_id,
-            self.call.method,
-            Some(args),
-            self.call.payment,
-            self.call.timeout_seconds,
-        )
-    }
-
-    fn call_and_forget(self) -> Result<(), RejectionCode> {
-        let args = encode_args(self.args).expect("failed to encode arguments");
-        notify_raw_internal(
-            self.call.canister_id,
-            self.call.method,
-            Some(args),
-            self.call.payment,
-            self.call.timeout_seconds,
-        )
-    }
-}
-
-impl<'a, A: AsRef<[u8]> + Send + Sync + 'a> SendableCall for CallWithRawArgs<'a, A> {
-    fn call_raw(self) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync {
-        call_raw_internal(
-            self.call.canister_id,
-            self.call.method,
-            Some(self.raw_args),
-            self.call.payment,
-            self.call.timeout_seconds,
-        )
-    }
-
-    fn call_and_forget(self) -> Result<(), RejectionCode> {
-        notify_raw_internal(
-            self.call.canister_id,
-            self.call.method,
-            Some(self.raw_args),
-            self.call.payment,
-            self.call.timeout_seconds,
-        )
-    }
-}
-
 fn add_payment(payment: u128) {
     if payment == 0 {
         return;
@@ -516,16 +247,6 @@ pub fn notify_raw(
     args_raw: &[u8],
     payment: u128,
 ) -> Result<(), RejectionCode> {
-    notify_raw_internal(id, method, Some(args_raw), Some(payment), None)
-}
-
-fn notify_raw_internal<T: AsRef<[u8]>>(
-    id: Principal,
-    method: &str,
-    args_raw: Option<T>,
-    payment: Option<u128>,
-    timeout_seconds: Option<u32>,
-) -> Result<(), RejectionCode> {
     let callee = id.as_slice();
     // We set all callbacks to -1, which is guaranteed to be invalid callback index.
     // The system will still deliver the reply, but it will trap immediately because the callback
@@ -534,14 +255,11 @@ fn notify_raw_internal<T: AsRef<[u8]>>(
     // for more context.
 
     // SAFETY:
-    // ic0.call_new:
-    //   `callee_src` and `callee_size`: `callee` being &[u8], is a readable sequence of bytes.
-    //   `name_src` and `name_size`: `method`, being &str, is a readable sequence of bytes.
-    //   `reply_fun` and `reject_fun`: In "notify" style call, we want these callback functions to not be called. So pass `usize::MAX` which is a function pointer the wasm module cannot possibly contain.
-    //   `reply_env` and `reject_env`: Since the callback functions will never be called, any value can be passed as its context parameter.
-    // ic0.call_data_append:
-    //   `args`, being a &[u8], is a readable sequence of bytes.
-    // ic0.call_with_best_effort_response is always safe to call.
+    // `callee`, being &[u8], is a readable sequence of bytes and therefore can be passed to ic0.call_new.
+    // `method`, being &str, is a readable sequence of bytes and therefore can be passed to ic0.call_new.
+    // -1, i.e. usize::MAX, is a function pointer the wasm module cannot possibly contain, and therefore can be passed as both reply and reject fn for ic0.call_new.
+    // Since the callback function will never be called, any value can be passed as its context parameter, and therefore -1 can be passed for those values.
+    // `args`, being a &[u8], is a readable sequence of bytes and therefore can be passed to ic0.call_data_append.
     // ic0.call_perform is always safe to call.
     let err_code = unsafe {
         ic0::call_new(
@@ -549,20 +267,13 @@ fn notify_raw_internal<T: AsRef<[u8]>>(
             callee.len(),
             method.as_ptr() as usize,
             method.len(),
-            usize::MAX,
-            usize::MAX,
-            usize::MAX,
-            usize::MAX,
+            /* reply_fun = */ usize::MAX,
+            /* reply_env = */ usize::MAX,
+            /* reject_fun = */ usize::MAX,
+            /* reject_env = */ usize::MAX,
         );
-        if let Some(args) = args_raw {
-            ic0::call_data_append(args.as_ref().as_ptr() as usize, args.as_ref().len());
-        }
-        if let Some(payment) = payment {
-            add_payment(payment);
-        }
-        if let Some(timeout_seconds) = timeout_seconds {
-            ic0::call_with_best_effort_response(timeout_seconds);
-        }
+        add_payment(payment);
+        ic0::call_data_append(args_raw.as_ptr() as usize, args_raw.len());
         ic0::call_perform()
     };
     match err_code {
@@ -592,7 +303,7 @@ pub fn call_raw<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
     args_raw: T,
     payment: u64,
 ) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync + 'a {
-    call_raw_internal(id, method, Some(args_raw), Some(payment.into()), None)
+    call_raw_internal(id, method, args_raw, payment.into())
 }
 
 /// Performs an asynchronous call to another canister and pay cycles (in `u128`) at the same time.
@@ -615,15 +326,14 @@ pub fn call_raw128<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
     args_raw: T,
     payment: u128,
 ) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync + 'a {
-    call_raw_internal(id, method, Some(args_raw), Some(payment), None)
+    call_raw_internal(id, method, args_raw, payment)
 }
 
 fn call_raw_internal<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
     id: Principal,
     method: &str,
-    args_raw: Option<T>,
-    payment: Option<u128>,
-    timeout_seconds: Option<u32>,
+    args_raw: T,
+    payment: u128,
 ) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync + 'a {
     let state = Arc::new(RwLock::new(CallFutureState {
         result: None,
@@ -632,7 +342,6 @@ fn call_raw_internal<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
         method: method.to_string(),
         arg: args_raw,
         payment,
-        timeout_seconds,
     }));
     CallFuture { state }
 }
@@ -873,11 +582,11 @@ pub fn reject_code() -> RejectionCode {
 /// Returns the rejection message.
 pub fn reject_message() -> String {
     // SAFETY: ic0.msg_reject_msg_size is always safe to call.
-    let len = unsafe { ic0::msg_reject_msg_size() };
-    let mut bytes = vec![0u8; len];
+    let len: u32 = unsafe { ic0::msg_reject_msg_size() as u32 };
+    let mut bytes = vec![0u8; len as usize];
     // SAFETY: `bytes`, being mutable and allocated to `len` bytes, is safe to pass to ic0.msg_reject_msg_copy with no offset
     unsafe {
-        ic0::msg_reject_msg_copy(bytes.as_mut_ptr() as usize, 0, len);
+        ic0::msg_reject_msg_copy(bytes.as_mut_ptr() as usize, 0, len as usize);
     }
     String::from_utf8_lossy(&bytes).into_owned()
 }
@@ -889,11 +598,6 @@ pub fn reject(message: &str) {
     unsafe {
         ic0::msg_reject(err_message.as_ptr() as usize, err_message.len());
     }
-}
-/// The deadline, in nanoseconds since 1970-01-01, after which the caller might stop waiting for a response.
-pub fn msg_deadline() -> u64 {
-    // SAFETY: ic0.msg_deadline is always safe to call.
-    unsafe { ic0::msg_deadline() }
 }
 
 /// An io::Write for message replies.
@@ -925,6 +629,12 @@ pub fn reply<T: ArgumentEncoder>(reply: T) {
 
 /// Returns the amount of cycles that were transferred by the caller
 /// of the current call, and is still available in this message.
+pub fn msg_cycles_available() -> u64 {
+    msg_cycles_available128() as u64
+}
+
+/// Returns the amount of cycles that were transferred by the caller
+/// of the current call, and is still available in this message.
 pub fn msg_cycles_available128() -> u128 {
     let mut recv = 0u128;
     // SAFETY: recv is writable and sixteen bytes wide, and therefore is safe to pass to ic0.msg_cycles_available128
@@ -937,6 +647,13 @@ pub fn msg_cycles_available128() -> u128 {
 /// Returns the amount of cycles that came back with the response as a refund.
 ///
 /// The refund has already been added to the canister balance automatically.
+pub fn msg_cycles_refunded() -> u64 {
+    msg_cycles_refunded128() as u64
+}
+
+/// Returns the amount of cycles that came back with the response as a refund.
+///
+/// The refund has already been added to the canister balance automatically.
 pub fn msg_cycles_refunded128() -> u128 {
     let mut recv = 0u128;
     // SAFETY: recv is writable and sixteen bytes wide, and therefore is safe to pass to ic0.msg_cycles_refunded128
@@ -944,6 +661,13 @@ pub fn msg_cycles_refunded128() -> u128 {
         ic0::msg_cycles_refunded128(&mut recv as *mut u128 as usize);
     }
     recv
+}
+
+/// Moves cycles from the call to the canister balance.
+///
+/// The actual amount moved will be returned.
+pub fn msg_cycles_accept(max_amount: u64) -> u64 {
+    msg_cycles_accept128(max_amount as u128) as u64
 }
 
 /// Moves cycles from the call to the canister balance.
@@ -963,7 +687,7 @@ pub fn msg_cycles_accept128(max_amount: u128) -> u128 {
 /// Returns the argument data as bytes.
 pub fn arg_data_raw() -> Vec<u8> {
     // SAFETY: ic0.msg_arg_data_size is always safe to call.
-    let len = unsafe { ic0::msg_arg_data_size() };
+    let len: usize = unsafe { ic0::msg_arg_data_size() };
     let mut bytes = Vec::with_capacity(len);
     // SAFETY:
     // `bytes`, being mutable and allocated to `len` bytes, is safe to pass to ic0.msg_arg_data_copy with no offset
@@ -1055,11 +779,11 @@ pub fn accept_message() {
 /// Returns the name of current canister method.
 pub fn method_name() -> String {
     // SAFETY: ic0.msg_method_name_size is always safe to call.
-    let len = unsafe { ic0::msg_method_name_size() };
-    let mut bytes = vec![0u8; len];
+    let len: u32 = unsafe { ic0::msg_method_name_size() as u32 };
+    let mut bytes = vec![0u8; len as usize];
     // SAFETY: `bytes` is writable and allocated to `len` bytes, and therefore can be safely passed to ic0.msg_method_name_copy
     unsafe {
-        ic0::msg_method_name_copy(bytes.as_mut_ptr() as usize, 0, len);
+        ic0::msg_method_name_copy(bytes.as_mut_ptr() as usize, 0, len as usize);
     }
     String::from_utf8_lossy(&bytes).into_owned()
 }

--- a/ic-cdk/src/api/mod.rs
+++ b/ic-cdk/src/api/mod.rs
@@ -193,3 +193,42 @@ pub fn in_replicated_execution() -> bool {
         _ => unreachable!(),
     }
 }
+
+/// Returns the argument data as bytes.
+pub fn msg_arg_data() -> Vec<u8> {
+    // SAFETY: ic0.msg_arg_data_size is always safe to call.
+    let len = unsafe { ic0::msg_arg_data_size() };
+    let mut bytes = Vec::with_capacity(len);
+    // SAFETY:
+    // `bytes`, being mutable and allocated to `len` bytes, is safe to pass to ic0.msg_arg_data_copy with no offset
+    // ic0.msg_arg_data_copy writes to all of `bytes[0..len]`, so `set_len` is safe to call with the new len.
+    unsafe {
+        ic0::msg_arg_data_copy(bytes.as_mut_ptr() as usize, 0, len);
+        bytes.set_len(len);
+    }
+    bytes
+}
+
+/// Gets the len of the raw-argument-data-bytes.
+pub fn msg_arg_data_size() -> usize {
+    // SAFETY: ic0.msg_arg_data_size is always safe to call.
+    unsafe { ic0::msg_arg_data_size() }
+}
+
+/// Returns the rejection code for the call.
+pub fn msg_reject_code() -> u32 {
+    // SAFETY: ic0.msg_reject_code is always safe to call.
+    unsafe { ic0::msg_reject_code() }
+}
+
+/// Returns the rejection message.
+pub fn msg_reject_msg() -> String {
+    // SAFETY: ic0.msg_reject_msg_size is always safe to call.
+    let len = unsafe { ic0::msg_reject_msg_size() };
+    let mut bytes = vec![0u8; len];
+    // SAFETY: `bytes`, being mutable and allocated to `len` bytes, is safe to pass to ic0.msg_reject_msg_copy with no offset
+    unsafe {
+        ic0::msg_reject_msg_copy(bytes.as_mut_ptr() as usize, 0, len);
+    }
+    String::from_utf8_lossy(&bytes).into_owned()
+}

--- a/ic-cdk/src/call.rs
+++ b/ic-cdk/src/call.rs
@@ -1,0 +1,1150 @@
+//! APIs to make and manage calls in the canister.
+use crate::api::trap;
+use candid::utils::{decode_args_with_config_debug, ArgumentDecoder, ArgumentEncoder};
+use candid::{
+    decode_args, encode_args, write_args, CandidType, DecoderConfig, Deserialize, Principal,
+};
+use serde::ser::Error;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, RwLock, Weak};
+use std::task::{Context, Poll, Waker};
+
+/// Rejection code from calling another canister.
+///
+/// These can be obtained using [reject_code].
+#[repr(i32)]
+#[derive(CandidType, Deserialize, Clone, Copy, Hash, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RejectionCode {
+    /// No error.
+    NoError = 0,
+
+    /// Fatal system error, retry unlikely to be useful.
+    SysFatal = 1,
+    /// Transient system error, retry might be possible.
+    SysTransient = 2,
+    /// Invalid destination (e.g. canister/account does not exist)
+    DestinationInvalid = 3,
+    /// Explicit reject by the canister.
+    CanisterReject = 4,
+    /// Canister error (e.g., trap, no response)
+    CanisterError = 5,
+    /// Response unknown; system stopped waiting for it (e.g., timed out, or system under high load).
+    SysUnknown = 6,
+
+    /// Unknown rejection code.
+    ///
+    /// Note that this variant is not part of the IC interface spec, and is used to represent
+    /// rejection codes that are not recognized by the library.
+    Unknown,
+}
+
+impl From<i32> for RejectionCode {
+    fn from(code: i32) -> Self {
+        match code {
+            0 => RejectionCode::NoError,
+            1 => RejectionCode::SysFatal,
+            2 => RejectionCode::SysTransient,
+            3 => RejectionCode::DestinationInvalid,
+            4 => RejectionCode::CanisterReject,
+            5 => RejectionCode::CanisterError,
+            6 => RejectionCode::SysUnknown,
+            _ => RejectionCode::Unknown,
+        }
+    }
+}
+
+impl From<u32> for RejectionCode {
+    fn from(code: u32) -> Self {
+        RejectionCode::from(code as i32)
+    }
+}
+
+/// The result of a Call.
+///
+/// Errors on the IC have two components; a Code and a message associated with it.
+pub type CallResult<R> = Result<R, (RejectionCode, String)>;
+
+// Internal state for the Future when sending a call.
+struct CallFutureState<T: AsRef<[u8]>> {
+    result: Option<CallResult<Vec<u8>>>,
+    waker: Option<Waker>,
+    id: Principal,
+    method: String,
+    arg: Option<T>,
+    payment: Option<u128>,
+    timeout_seconds: Option<u32>,
+}
+
+struct CallFuture<T: AsRef<[u8]>> {
+    state: Arc<RwLock<CallFutureState<T>>>,
+}
+
+impl<T: AsRef<[u8]>> Future for CallFuture<T> {
+    type Output = CallResult<Vec<u8>>;
+
+    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        let self_ref = Pin::into_inner(self);
+        let mut state = self_ref.state.write().unwrap();
+
+        if let Some(result) = state.result.take() {
+            Poll::Ready(result)
+        } else {
+            if state.waker.is_none() {
+                let callee = state.id.as_slice();
+                let method = &state.method;
+                let state_ptr = Weak::into_raw(Arc::downgrade(&self_ref.state));
+                // SAFETY:
+                // `callee`, being &[u8], is a readable sequence of bytes and therefore can be passed to ic0.call_new.
+                // `method`, being &str, is a readable sequence of bytes and therefore can be passed to ic0.call_new.
+                // `callback` is a function with signature (env : usize) -> () and therefore can be called as both reply and reject fn for ic0.call_new.
+                // `state_ptr` is a pointer created via Weak::into_raw, and can therefore be passed as the userdata for `callback`.
+                // `args`, being a &[u8], is a readable sequence of bytes and therefore can be passed to ic0.call_data_append.
+                // `cleanup` is a function with signature (env : usize) -> () and therefore can be called as a cleanup fn for ic0.call_on_cleanup.
+                // `state_ptr` is a pointer created via Weak::into_raw, and can therefore be passed as the userdata for `cleanup`.
+                // ic0.call_perform is always safe to call.
+                // callback and cleanup are safe to parameterize with T because:
+                // - if the future is dropped before the callback is called, there will be no more strong references and the weak reference will fail to upgrade
+                // - if the future is *not* dropped before the callback is called, the compiler will mandate that any data borrowed by T is still alive
+                let err_code = unsafe {
+                    ic0::call_new(
+                        callee.as_ptr() as usize,
+                        callee.len(),
+                        method.as_ptr() as usize,
+                        method.len(),
+                        callback::<T> as usize,
+                        state_ptr as usize,
+                        callback::<T> as usize,
+                        state_ptr as usize,
+                    );
+                    if let Some(args) = &state.arg {
+                        ic0::call_data_append(args.as_ref().as_ptr() as usize, args.as_ref().len());
+                    }
+                    if let Some(payment) = state.payment {
+                        add_payment(payment);
+                    }
+                    if let Some(timeout_seconds) = state.timeout_seconds {
+                        ic0::call_with_best_effort_response(timeout_seconds);
+                    }
+                    ic0::call_on_cleanup(cleanup::<T> as usize, state_ptr as usize);
+                    ic0::call_perform()
+                };
+
+                // 0 is a special error code meaning call succeeded.
+                if err_code != 0 {
+                    let result = Err((
+                        RejectionCode::from(err_code),
+                        "Couldn't send message".to_string(),
+                    ));
+                    state.result = Some(result.clone());
+                    return Poll::Ready(result);
+                }
+            }
+            state.waker = Some(context.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+/// The callback from IC dereferences the future from a raw pointer, assigns the
+/// result and calls the waker. We cannot use a closure here because we pass raw
+/// pointers to the System and back.
+///
+/// # Safety
+///
+/// This function must only be passed to the IC with a pointer from Weak::into_raw as userdata.
+unsafe extern "C" fn callback<T: AsRef<[u8]>>(state_ptr: *const RwLock<CallFutureState<T>>) {
+    // SAFETY: This function is only ever called by the IC, and we only ever pass a Weak as userdata.
+    let state = unsafe { Weak::from_raw(state_ptr) };
+    if let Some(state) = state.upgrade() {
+        // Make sure to un-borrow_mut the state.
+        {
+            state.write().unwrap().result = Some(match reject_code() {
+                RejectionCode::NoError => Ok(arg_data_raw()),
+                n => Err((n, reject_message())),
+            });
+        }
+        let w = state.write().unwrap().waker.take();
+        if let Some(waker) = w {
+            // This is all to protect this little guy here which will call the poll() which
+            // borrow_mut() the state as well. So we need to be careful to not double-borrow_mut.
+            waker.wake()
+        }
+    }
+}
+
+/// This function is called when [callback] was just called with the same parameter, and trapped.
+/// We can't guarantee internal consistency at this point, but we can at least e.g. drop mutex guards.
+/// Waker is a very opaque API, so the best we can do is set a global flag and proceed normally.
+///
+/// # Safety
+///
+/// This function must only be passed to the IC with a pointer from Weak::into_raw as userdata.
+unsafe extern "C" fn cleanup<T: AsRef<[u8]>>(state_ptr: *const RwLock<CallFutureState<T>>) {
+    // SAFETY: This function is only ever called by the IC, and we only ever pass a Weak as userdata.
+    let state = unsafe { Weak::from_raw(state_ptr) };
+    if let Some(state) = state.upgrade() {
+        // We set the call result, even though it won't be read on the
+        // default executor, because we can't guarantee it was called on
+        // our executor. However, we are not allowed to inspect
+        // reject_code() inside of a cleanup callback, so always set the
+        // result to a reject.
+        //
+        // Borrowing does not trap - the rollback from the
+        // previous trap ensures that the RwLock can be borrowed again.
+        state.write().unwrap().result = Some(Err((RejectionCode::NoError, "cleanup".to_string())));
+        let w = state.write().unwrap().waker.take();
+        if let Some(waker) = w {
+            // Flag that we do not want to actually wake the task - we
+            // want to drop it *without* executing it.
+            crate::futures::CLEANUP.store(true, Ordering::Relaxed);
+            waker.wake();
+            crate::futures::CLEANUP.store(false, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Inter-Canister Call.
+#[derive(Debug)]
+pub struct Call<'a> {
+    canister_id: Principal,
+    method: &'a str,
+    payment: Option<u128>,
+    timeout_seconds: Option<u32>,
+}
+
+/// Inter-Canister Call with typed arguments.
+#[derive(Debug)]
+pub struct CallWithArgs<'a, T> {
+    call: Call<'a>,
+    args: T,
+}
+
+/// Inter-Canister Call with raw arguments.
+#[derive(Debug)]
+pub struct CallWithRawArgs<'a, A> {
+    call: Call<'a>,
+    raw_args: A,
+}
+
+impl<'a> Call<'a> {
+    /// Constructs a new call with the Canister id and method name.
+    ///
+    /// # Note
+    /// The `Call` default to set a 10 seconds timeout for Best-Effort Responses.
+    /// If you want to set a guaranteed response, you can use the `with_guaranteed_response` method.
+    pub fn new(canister_id: Principal, method: &'a str) -> Self {
+        Self {
+            canister_id,
+            method,
+            payment: None,
+            // Default to 10 seconds.
+            timeout_seconds: Some(10),
+        }
+    }
+
+    /// Sets the arguments for the call.
+    ///
+    /// Another way to set the arguments is to use `with_raw_args`.
+    /// If both are invoked, the last one is used.
+    pub fn with_args<T>(self, args: T) -> CallWithArgs<'a, T> {
+        CallWithArgs { call: self, args }
+    }
+
+    /// Sets the arguments for the call as raw bytes.    
+    ///
+    /// Another way to set the arguments is to use `with_raw_args`.
+    /// If both are invoked, the last one is used.
+    pub fn with_raw_args<A>(self, raw_args: A) -> CallWithRawArgs<'a, A> {
+        CallWithRawArgs {
+            call: self,
+            raw_args,
+        }
+    }
+}
+
+/// Methods to configure a call.
+pub trait ConfigurableCall {
+    /// Sets the cycles payment for the call.
+    ///
+    /// If invoked multiple times, the last value is used.
+    fn with_cycles(self, cycles: u128) -> Self;
+
+    /// Sets the call to have a guaranteed response.
+    ///
+    /// If [change_timeout](ConfigurableCall::change_timeout) is invoked after this method,
+    /// the call will instead be set with Best-Effort Responses.
+    fn with_guaranteed_response(self) -> Self;
+
+    /// Sets the timeout for the Best-Effort Responses.
+    ///
+    /// If not set, the call will default to a 10 seconds timeout.
+    /// If invoked multiple times, the last value is used.
+    /// If [with_guaranteed_response](ConfigurableCall::with_guaranteed_response) is invoked after this method,
+    /// the timeout will be ignored.
+    fn change_timeout(self, timeout_seconds: u32) -> Self;
+}
+
+impl<'a> ConfigurableCall for Call<'a> {
+    fn with_cycles(mut self, cycles: u128) -> Self {
+        self.payment = Some(cycles);
+        self
+    }
+
+    fn with_guaranteed_response(mut self) -> Self {
+        self.timeout_seconds = None;
+        self
+    }
+
+    fn change_timeout(mut self, timeout_seconds: u32) -> Self {
+        self.timeout_seconds = Some(timeout_seconds);
+        self
+    }
+}
+
+impl<'a, T> ConfigurableCall for CallWithArgs<'a, T> {
+    fn with_cycles(mut self, cycles: u128) -> Self {
+        self.call.payment = Some(cycles);
+        self
+    }
+
+    fn with_guaranteed_response(mut self) -> Self {
+        self.call.timeout_seconds = None;
+        self
+    }
+
+    fn change_timeout(mut self, timeout_seconds: u32) -> Self {
+        self.call.timeout_seconds = Some(timeout_seconds);
+        self
+    }
+}
+
+impl<'a, A> ConfigurableCall for CallWithRawArgs<'a, A> {
+    fn with_cycles(mut self, cycles: u128) -> Self {
+        self.call.payment = Some(cycles);
+        self
+    }
+
+    fn with_guaranteed_response(mut self) -> Self {
+        self.call.timeout_seconds = None;
+        self
+    }
+
+    fn change_timeout(mut self, timeout_seconds: u32) -> Self {
+        self.call.timeout_seconds = Some(timeout_seconds);
+        self
+    }
+}
+
+/// Methods to send a call.
+pub trait SendableCall {
+    /// Sends the call and gets the reply as raw bytes.
+    fn call_raw(self) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync;
+
+    /// Sends the call and decodes the reply to a Candid type.
+    fn call<R: for<'b> ArgumentDecoder<'b>>(
+        self,
+    ) -> impl Future<Output = CallResult<R>> + Send + Sync
+    where
+        Self: Sized,
+    {
+        let fut = self.call_raw();
+        async {
+            let bytes = fut.await?;
+            decode_args(&bytes).map_err(decoder_error_to_reject::<R>)
+        }
+    }
+
+    /// Sends the call and decodes the reply to a Candid type with a decoding quota.
+    fn call_with_decoder_config<R: for<'b> ArgumentDecoder<'b>>(
+        self,
+        decoder_config: &ArgDecoderConfig,
+    ) -> impl Future<Output = CallResult<R>> + Send + Sync
+    where
+        Self: Sized,
+    {
+        let fut = self.call_raw();
+        async move {
+            let bytes = fut.await?;
+            let config = decoder_config.to_candid_config();
+            let pre_cycles = if decoder_config.debug {
+                Some(crate::api::performance_counter(0))
+            } else {
+                None
+            };
+            match decode_args_with_config_debug(&bytes, &config) {
+                Err(e) => Err(decoder_error_to_reject::<R>(e)),
+                Ok((r, cost)) => {
+                    if decoder_config.debug {
+                        print_decoding_debug_info(std::any::type_name::<R>(), &cost, pre_cycles);
+                    }
+                    Ok(r)
+                }
+            }
+        }
+    }
+
+    /// Sends the call and ignores the reply.
+    fn call_and_forget(self) -> Result<(), RejectionCode>;
+}
+
+impl SendableCall for Call<'_> {
+    fn call_raw(self) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync {
+        call_raw_internal::<Vec<u8>>(
+            self.canister_id,
+            self.method,
+            None,
+            self.payment,
+            self.timeout_seconds,
+        )
+    }
+
+    fn call_and_forget(self) -> Result<(), RejectionCode> {
+        notify_raw_internal::<Vec<u8>>(
+            self.canister_id,
+            self.method,
+            None,
+            self.payment,
+            self.timeout_seconds,
+        )
+    }
+}
+
+impl<'a, T: ArgumentEncoder> SendableCall for CallWithArgs<'a, T> {
+    fn call_raw(self) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync {
+        let args = encode_args(self.args).expect("failed to encode arguments");
+        call_raw_internal(
+            self.call.canister_id,
+            self.call.method,
+            Some(args),
+            self.call.payment,
+            self.call.timeout_seconds,
+        )
+    }
+
+    fn call_and_forget(self) -> Result<(), RejectionCode> {
+        let args = encode_args(self.args).expect("failed to encode arguments");
+        notify_raw_internal(
+            self.call.canister_id,
+            self.call.method,
+            Some(args),
+            self.call.payment,
+            self.call.timeout_seconds,
+        )
+    }
+}
+
+impl<'a, A: AsRef<[u8]> + Send + Sync + 'a> SendableCall for CallWithRawArgs<'a, A> {
+    fn call_raw(self) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync {
+        call_raw_internal(
+            self.call.canister_id,
+            self.call.method,
+            Some(self.raw_args),
+            self.call.payment,
+            self.call.timeout_seconds,
+        )
+    }
+
+    fn call_and_forget(self) -> Result<(), RejectionCode> {
+        notify_raw_internal(
+            self.call.canister_id,
+            self.call.method,
+            Some(self.raw_args),
+            self.call.payment,
+            self.call.timeout_seconds,
+        )
+    }
+}
+
+fn add_payment(payment: u128) {
+    if payment == 0 {
+        return;
+    }
+    let high = (payment >> 64) as u64;
+    let low = (payment & u64::MAX as u128) as u64;
+    // SAFETY: ic0.call_cycles_add128 is always safe to call.
+    unsafe {
+        ic0::call_cycles_add128(high, low);
+    }
+}
+
+/// Sends a one-way message with `payment` cycles attached to it that invokes `method` with
+/// arguments `args` on the principal identified by `id`, ignoring the reply.
+///
+/// Returns `Ok(())` if the message was successfully enqueued, otherwise returns a reject code.
+///
+/// # Notes
+///
+///   * The caller has no way of checking whether the destination processed the notification.
+///     The system can drop the notification if the destination does not have resources to
+///     process the message (for example, if it's out of cycles or queue slots).
+///
+///   * The callee cannot tell whether the call is one-way or not.
+///     The callee must produce replies for all incoming messages.
+///
+///   * It is safe to upgrade a canister without stopping it first if it sends out *only*
+///     one-way messages.
+///
+///   * If the payment is non-zero and the system fails to deliver the notification, the behaviour
+///     is unspecified: the funds can be either reimbursed or consumed irrevocably by the IC depending
+///     on the underlying implementation of one-way calls.
+pub fn notify_with_payment128<T: ArgumentEncoder>(
+    id: Principal,
+    method: &str,
+    args: T,
+    payment: u128,
+) -> Result<(), RejectionCode> {
+    let args_raw = encode_args(args).expect("failed to encode arguments");
+    notify_raw(id, method, &args_raw, payment)
+}
+
+/// Like [notify_with_payment128], but sets the payment to zero.
+pub fn notify<T: ArgumentEncoder>(
+    id: Principal,
+    method: &str,
+    args: T,
+) -> Result<(), RejectionCode> {
+    notify_with_payment128(id, method, args, 0)
+}
+
+/// Like [notify], but sends the argument as raw bytes, skipping Candid serialization.
+pub fn notify_raw(
+    id: Principal,
+    method: &str,
+    args_raw: &[u8],
+    payment: u128,
+) -> Result<(), RejectionCode> {
+    notify_raw_internal(id, method, Some(args_raw), Some(payment), None)
+}
+
+fn notify_raw_internal<T: AsRef<[u8]>>(
+    id: Principal,
+    method: &str,
+    args_raw: Option<T>,
+    payment: Option<u128>,
+    timeout_seconds: Option<u32>,
+) -> Result<(), RejectionCode> {
+    let callee = id.as_slice();
+    // We set all callbacks to -1, which is guaranteed to be invalid callback index.
+    // The system will still deliver the reply, but it will trap immediately because the callback
+    // is not a valid function. See
+    // https://www.joachim-breitner.de/blog/789-Zero-downtime_upgrades_of_Internet_Computer_canisters#one-way-calls
+    // for more context.
+
+    // SAFETY:
+    // ic0.call_new:
+    //   `callee_src` and `callee_size`: `callee` being &[u8], is a readable sequence of bytes.
+    //   `name_src` and `name_size`: `method`, being &str, is a readable sequence of bytes.
+    //   `reply_fun` and `reject_fun`: In "notify" style call, we want these callback functions to not be called. So pass `usize::MAX` which is a function pointer the wasm module cannot possibly contain.
+    //   `reply_env` and `reject_env`: Since the callback functions will never be called, any value can be passed as its context parameter.
+    // ic0.call_data_append:
+    //   `args`, being a &[u8], is a readable sequence of bytes.
+    // ic0.call_with_best_effort_response is always safe to call.
+    // ic0.call_perform is always safe to call.
+    let err_code = unsafe {
+        ic0::call_new(
+            callee.as_ptr() as usize,
+            callee.len(),
+            method.as_ptr() as usize,
+            method.len(),
+            usize::MAX,
+            usize::MAX,
+            usize::MAX,
+            usize::MAX,
+        );
+        if let Some(args) = args_raw {
+            ic0::call_data_append(args.as_ref().as_ptr() as usize, args.as_ref().len());
+        }
+        if let Some(payment) = payment {
+            add_payment(payment);
+        }
+        if let Some(timeout_seconds) = timeout_seconds {
+            ic0::call_with_best_effort_response(timeout_seconds);
+        }
+        ic0::call_perform()
+    };
+    match err_code {
+        0 => Ok(()),
+        c => Err(RejectionCode::from(c)),
+    }
+}
+
+/// Performs an asynchronous call to another canister and pay cycles at the same time.
+///
+/// Treats arguments and returns as raw bytes. No data serialization and deserialization is performed.
+///
+/// # Example
+///
+/// It can be called:
+///
+/// ```rust
+/// # use ic_cdk::api::call::call_raw;
+/// # fn callee_canister() -> candid::Principal { unimplemented!() }
+/// async fn call_add_user() -> Vec<u8>{
+///     call_raw(callee_canister(), "add_user", b"abcd", 1_000_000u64).await.unwrap()
+/// }
+/// ```
+pub fn call_raw<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
+    id: Principal,
+    method: &str,
+    args_raw: T,
+    payment: u64,
+) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync + 'a {
+    call_raw_internal(id, method, Some(args_raw), Some(payment.into()), None)
+}
+
+/// Performs an asynchronous call to another canister and pay cycles (in `u128`) at the same time.
+///
+/// Treats arguments and returns as raw bytes. No data serialization and deserialization is performed.
+/// # Example
+///
+/// It can be called:
+///
+/// ```rust
+/// # use ic_cdk::api::call::call_raw128;
+/// # fn callee_canister() -> candid::Principal { unimplemented!() }
+/// async fn call_add_user() -> Vec<u8>{
+///     call_raw128(callee_canister(), "add_user", b"abcd", 1_000_000u128).await.unwrap()
+/// }
+/// ```
+pub fn call_raw128<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
+    id: Principal,
+    method: &str,
+    args_raw: T,
+    payment: u128,
+) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync + 'a {
+    call_raw_internal(id, method, Some(args_raw), Some(payment), None)
+}
+
+fn call_raw_internal<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
+    id: Principal,
+    method: &str,
+    args_raw: Option<T>,
+    payment: Option<u128>,
+    timeout_seconds: Option<u32>,
+) -> impl Future<Output = CallResult<Vec<u8>>> + Send + Sync + 'a {
+    let state = Arc::new(RwLock::new(CallFutureState {
+        result: None,
+        waker: None,
+        id,
+        method: method.to_string(),
+        arg: args_raw,
+        payment,
+        timeout_seconds,
+    }));
+    CallFuture { state }
+}
+
+fn decoder_error_to_reject<T>(err: candid::error::Error) -> (RejectionCode, String) {
+    (
+        RejectionCode::CanisterError,
+        format!(
+            "failed to decode canister response as {}: {}",
+            std::any::type_name::<T>(),
+            err
+        ),
+    )
+}
+
+/// Performs an asynchronous call to another canister.
+///
+/// # Example
+///
+/// Assuming that the callee canister has following interface:
+///
+/// ```text
+/// service : {
+///     add_user: (name: text) -> (nat64);
+/// }
+/// ```
+///
+/// It can be called:
+///
+/// ```rust
+/// # use ic_cdk::api::call::call;
+/// # fn callee_canister() -> candid::Principal { unimplemented!() }
+/// async fn call_add_user() -> u64 {
+///     let (user_id,) = call(callee_canister(), "add_user", ("Alice".to_string(),)).await.unwrap();
+///     user_id
+/// }
+/// ```
+///
+/// # Note
+///
+/// * Both argument and return types are tuples even if it has only one value, e.g `(user_id,)`, `("Alice".to_string(),)`.
+/// * The type annotation on return type is required. Or the return type can be inferred from the context.
+/// * The asynchronous call must be awaited in order for the inter-canister call to be made.
+/// * If the reply payload is not a valid encoding of the expected type `T`, the call results in [RejectionCode::CanisterError] error.
+pub fn call<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
+    id: Principal,
+    method: &str,
+    args: T,
+) -> impl Future<Output = CallResult<R>> + Send + Sync {
+    let args_raw = encode_args(args).expect("Failed to encode arguments.");
+    let fut = call_raw(id, method, args_raw, 0);
+    async {
+        let bytes = fut.await?;
+        decode_args(&bytes).map_err(decoder_error_to_reject::<R>)
+    }
+}
+
+/// Performs an asynchronous call to another canister and pay cycles at the same time.
+///
+/// # Example
+///
+/// Assuming that the callee canister has following interface:
+///
+/// ```text
+/// service : {
+///     add_user: (name: text) -> (nat64);
+/// }
+/// ```
+///
+/// It can be called:
+///
+/// ```rust
+/// # use ic_cdk::api::call::call_with_payment;
+/// # fn callee_canister() -> candid::Principal { unimplemented!() }
+/// async fn call_add_user() -> u64 {
+///     let (user_id,) = call_with_payment(callee_canister(), "add_user", ("Alice".to_string(),), 1_000_000u64).await.unwrap();
+///     user_id
+/// }
+/// ```
+///
+/// # Note
+///
+/// * Both argument and return types are tuples even if it has only one value, e.g `(user_id,)`, `("Alice".to_string(),)`.
+/// * The type annotation on return type is required. Or the return type can be inferred from the context.
+/// * The asynchronous call must be awaited in order for the inter-canister call to be made.
+/// * If the reply payload is not a valid encoding of the expected type `T`, the call results in [RejectionCode::CanisterError] error.
+pub fn call_with_payment<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
+    id: Principal,
+    method: &str,
+    args: T,
+    cycles: u64,
+) -> impl Future<Output = CallResult<R>> + Send + Sync {
+    let args_raw = encode_args(args).expect("Failed to encode arguments.");
+    let fut = call_raw(id, method, args_raw, cycles);
+    async {
+        let bytes = fut.await?;
+        decode_args(&bytes).map_err(decoder_error_to_reject::<R>)
+    }
+}
+
+/// Performs an asynchronous call to another canister and pay cycles (in `u128`) at the same time.
+///
+/// # Example
+///
+/// Assuming that the callee canister has following interface:
+///
+/// ```text
+/// service : {
+///     add_user: (name: text) -> (nat64);
+/// }
+/// ```
+///
+/// It can be called:
+///
+/// ```rust
+/// # use ic_cdk::api::call::call_with_payment128;
+/// # fn callee_canister() -> candid::Principal { unimplemented!() }
+/// async fn call_add_user() -> u64 {
+///     let (user_id,) = call_with_payment128(callee_canister(), "add_user", ("Alice".to_string(),), 1_000_000u128).await.unwrap();
+///     user_id
+/// }
+/// ```
+///
+/// # Note
+///
+/// * Both argument and return types are tuples even if it has only one value, e.g `(user_id,)`, `("Alice".to_string(),)`.
+/// * The type annotation on return type is required. Or the return type can be inferred from the context.
+/// * The asynchronous call must be awaited in order for the inter-canister call to be made.
+/// * If the reply payload is not a valid encoding of the expected type `T`, the call results in [RejectionCode::CanisterError] error.
+pub fn call_with_payment128<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
+    id: Principal,
+    method: &str,
+    args: T,
+    cycles: u128,
+) -> impl Future<Output = CallResult<R>> + Send + Sync {
+    let args_raw = encode_args(args).expect("Failed to encode arguments.");
+    let fut = call_raw128(id, method, args_raw, cycles);
+    async {
+        let bytes = fut.await?;
+        decode_args(&bytes).map_err(decoder_error_to_reject::<R>)
+    }
+}
+
+/// Performs an asynchronous call to another canister and pay cycles (in `u128`).
+/// It also allows setting a quota for decoding the return values.
+/// The decoding quota is strongly recommended when calling third-party or untrusted canisters.
+///
+/// # Example
+///
+/// Assuming that the callee canister has following interface:
+///
+/// ```text
+/// service : {
+///     add_user: (name: text) -> (nat64);
+/// }
+/// ```
+///
+/// It can be called:
+///
+/// ```rust
+/// # use ic_cdk::api::call::{call_with_config, ArgDecoderConfig};
+/// # fn callee_canister() -> candid::Principal { unimplemented!() }
+/// async fn call_add_user() -> u64 {
+///     let config = ArgDecoderConfig {
+///         // The function only returns a nat64, to accomodate future upgrades, we set a larger decoding_quota.
+///         decoding_quota: Some(10_000),
+///         // To accomodate future upgrades, reserve some skipping_quota.
+///         skipping_quota: Some(100),
+///         // Enable debug mode to print decoding instructions and cost to the replica log.
+///         debug: true,
+///     };
+///     let (user_id,) = call_with_config(callee_canister(), "add_user", ("Alice".to_string(),), 1_000_000u128, &config).await.unwrap();
+///     user_id
+/// }
+/// ```
+pub fn call_with_config<'b, T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
+    id: Principal,
+    method: &'b str,
+    args: T,
+    cycles: u128,
+    arg_config: &'b ArgDecoderConfig,
+) -> impl Future<Output = CallResult<R>> + Send + Sync + 'b {
+    let args_raw = encode_args(args).expect("Failed to encode arguments.");
+    let fut = call_raw128(id, method, args_raw, cycles);
+    async move {
+        let bytes = fut.await?;
+        let config = arg_config.to_candid_config();
+        let pre_cycles = if arg_config.debug {
+            Some(crate::api::performance_counter(0))
+        } else {
+            None
+        };
+        match decode_args_with_config_debug(&bytes, &config) {
+            Err(e) => Err(decoder_error_to_reject::<R>(e)),
+            Ok((r, cost)) => {
+                if arg_config.debug {
+                    print_decoding_debug_info(&format!("{method} return"), &cost, pre_cycles);
+                }
+                Ok(r)
+            }
+        }
+    }
+}
+
+fn print_decoding_debug_info(title: &str, cost: &DecoderConfig, pre_cycles: Option<u64>) {
+    use crate::api::{performance_counter, print};
+    let pre_cycles = pre_cycles.unwrap_or(0);
+    let instrs = performance_counter(0) - pre_cycles;
+    print(format!("[Debug] {title} decoding instructions: {instrs}"));
+    if let Some(n) = cost.decoding_quota {
+        print(format!("[Debug] {title} decoding cost: {n}"));
+    }
+    if let Some(n) = cost.skipping_quota {
+        print(format!("[Debug] {title} skipping cost: {n}"));
+    }
+}
+
+/// Returns a result that maps over the call
+///
+/// It will be Ok(T) if the call succeeded (with T being the arg_data),
+/// and [reject_message()] if it failed.
+pub fn result<T: for<'a> ArgumentDecoder<'a>>() -> Result<T, String> {
+    match reject_code() {
+        RejectionCode::NoError => {
+            decode_args(&arg_data_raw()).map_err(|e| format!("Failed to decode arguments: {}", e))
+        }
+        _ => Err(reject_message()),
+    }
+}
+
+/// Returns the rejection code for the call.
+pub fn reject_code() -> RejectionCode {
+    // SAFETY: ic0.msg_reject_code is always safe to call.
+    let code = unsafe { ic0::msg_reject_code() };
+    RejectionCode::from(code)
+}
+
+/// Returns the rejection message.
+pub fn reject_message() -> String {
+    // SAFETY: ic0.msg_reject_msg_size is always safe to call.
+    let len = unsafe { ic0::msg_reject_msg_size() };
+    let mut bytes = vec![0u8; len];
+    // SAFETY: `bytes`, being mutable and allocated to `len` bytes, is safe to pass to ic0.msg_reject_msg_copy with no offset
+    unsafe {
+        ic0::msg_reject_msg_copy(bytes.as_mut_ptr() as usize, 0, len);
+    }
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+/// Rejects the current call with the message.
+pub fn reject(message: &str) {
+    let err_message = message.as_bytes();
+    // SAFETY: `err_message`, being &[u8], is a readable sequence of bytes, and therefore valid to pass to ic0.msg_reject.
+    unsafe {
+        ic0::msg_reject(err_message.as_ptr() as usize, err_message.len());
+    }
+}
+/// The deadline, in nanoseconds since 1970-01-01, after which the caller might stop waiting for a response.
+pub fn msg_deadline() -> u64 {
+    // SAFETY: ic0.msg_deadline is always safe to call.
+    unsafe { ic0::msg_deadline() }
+}
+
+/// An io::Write for message replies.
+#[derive(Debug, Copy, Clone)]
+pub struct CallReplyWriter;
+
+impl std::io::Write for CallReplyWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        // SAFETY: buf, being &[u8], is a readable sequence of bytes, and therefore valid to pass to ic0.msg_reply_data_append.
+        unsafe {
+            ic0::msg_reply_data_append(buf.as_ptr() as usize, buf.len());
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Replies to the current call with a candid argument.
+pub fn reply<T: ArgumentEncoder>(reply: T) {
+    write_args(&mut CallReplyWriter, reply).expect("Could not encode reply.");
+    // SAFETY: ic0.msg_reply is always safe to call.
+    unsafe {
+        ic0::msg_reply();
+    }
+}
+
+/// Returns the amount of cycles that were transferred by the caller
+/// of the current call, and is still available in this message.
+pub fn msg_cycles_available128() -> u128 {
+    let mut recv = 0u128;
+    // SAFETY: recv is writable and sixteen bytes wide, and therefore is safe to pass to ic0.msg_cycles_available128
+    unsafe {
+        ic0::msg_cycles_available128(&mut recv as *mut u128 as usize);
+    }
+    recv
+}
+
+/// Returns the amount of cycles that came back with the response as a refund.
+///
+/// The refund has already been added to the canister balance automatically.
+pub fn msg_cycles_refunded128() -> u128 {
+    let mut recv = 0u128;
+    // SAFETY: recv is writable and sixteen bytes wide, and therefore is safe to pass to ic0.msg_cycles_refunded128
+    unsafe {
+        ic0::msg_cycles_refunded128(&mut recv as *mut u128 as usize);
+    }
+    recv
+}
+
+/// Moves cycles from the call to the canister balance.
+///
+/// The actual amount moved will be returned.
+pub fn msg_cycles_accept128(max_amount: u128) -> u128 {
+    let high = (max_amount >> 64) as u64;
+    let low = (max_amount & u64::MAX as u128) as u64;
+    let mut recv = 0u128;
+    // SAFETY: `recv` is writable and sixteen bytes wide, and therefore safe to pass to ic0.msg_cycles_accept128
+    unsafe {
+        ic0::msg_cycles_accept128(high, low, &mut recv as *mut u128 as usize);
+    }
+    recv
+}
+
+/// Returns the argument data as bytes.
+pub fn arg_data_raw() -> Vec<u8> {
+    // SAFETY: ic0.msg_arg_data_size is always safe to call.
+    let len = unsafe { ic0::msg_arg_data_size() };
+    let mut bytes = Vec::with_capacity(len);
+    // SAFETY:
+    // `bytes`, being mutable and allocated to `len` bytes, is safe to pass to ic0.msg_arg_data_copy with no offset
+    // ic0.msg_arg_data_copy writes to all of `bytes[0..len]`, so `set_len` is safe to call with the new len.
+    unsafe {
+        ic0::msg_arg_data_copy(bytes.as_mut_ptr() as usize, 0, len);
+        bytes.set_len(len);
+    }
+    bytes
+}
+
+/// Gets the len of the raw-argument-data-bytes.
+pub fn arg_data_raw_size() -> usize {
+    // SAFETY: ic0.msg_arg_data_size is always safe to call.
+    unsafe { ic0::msg_arg_data_size() }
+}
+
+/// Replies with the bytes passed
+pub fn reply_raw(buf: &[u8]) {
+    if !buf.is_empty() {
+        // SAFETY: `buf`, being &[u8], is a readable sequence of bytes, and therefore valid to pass to ic0.msg_reject.
+        unsafe { ic0::msg_reply_data_append(buf.as_ptr() as usize, buf.len()) }
+    };
+    // SAFETY: ic0.msg_reply is always safe to call.
+    unsafe { ic0::msg_reply() };
+}
+
+#[derive(Debug)]
+/// Config to control the behavior of decoding canister endpoint arguments.
+pub struct ArgDecoderConfig {
+    /// Limit the total amount of work the deserializer can perform. See [docs on the Candid library](https://docs.rs/candid/latest/candid/de/struct.DecoderConfig.html#method.set_decoding_quota) to understand the cost model.
+    pub decoding_quota: Option<usize>,
+    /// Limit the total amount of work for skipping unneeded data on the wire. See [docs on the Candid library](https://docs.rs/candid/latest/candid/de/struct.DecoderConfig.html#method.set_skipping_quota) to understand the skipping cost.
+    pub skipping_quota: Option<usize>,
+    /// When set to true, print instruction count and the decoding/skipping cost to the replica log.
+    pub debug: bool,
+}
+impl ArgDecoderConfig {
+    fn to_candid_config(&self) -> DecoderConfig {
+        let mut config = DecoderConfig::new();
+        if let Some(n) = self.decoding_quota {
+            config.set_decoding_quota(n);
+        }
+        if let Some(n) = self.skipping_quota {
+            config.set_skipping_quota(n);
+        }
+        if self.debug {
+            config.set_full_error_message(true);
+        }
+        config
+    }
+}
+impl Default for ArgDecoderConfig {
+    fn default() -> Self {
+        Self {
+            decoding_quota: None,
+            skipping_quota: Some(10_000),
+            debug: false,
+        }
+    }
+}
+
+/// Returns the argument data in the current call. Traps if the data cannot be
+/// decoded.
+pub fn arg_data<R: for<'a> ArgumentDecoder<'a>>(arg_config: ArgDecoderConfig) -> R {
+    let bytes = arg_data_raw();
+
+    let config = arg_config.to_candid_config();
+    let res = decode_args_with_config_debug(&bytes, &config);
+    match res {
+        Err(e) => trap(&format!("failed to decode call arguments: {:?}", e)),
+        Ok((r, cost)) => {
+            if arg_config.debug {
+                print_decoding_debug_info("Argument", &cost, None);
+            }
+            r
+        }
+    }
+}
+
+/// Accepts the ingress message.
+pub fn accept_message() {
+    // SAFETY: ic0.accept_message is always safe to call.
+    unsafe {
+        ic0::accept_message();
+    }
+}
+
+/// Returns the name of current canister method.
+pub fn method_name() -> String {
+    // SAFETY: ic0.msg_method_name_size is always safe to call.
+    let len = unsafe { ic0::msg_method_name_size() };
+    let mut bytes = vec![0u8; len];
+    // SAFETY: `bytes` is writable and allocated to `len` bytes, and therefore can be safely passed to ic0.msg_method_name_copy
+    unsafe {
+        ic0::msg_method_name_copy(bytes.as_mut_ptr() as usize, 0, len);
+    }
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+/// Gets the value of specified performance counter
+///
+/// See [`crate::api::performance_counter`].
+#[deprecated(
+    since = "0.11.3",
+    note = "This method conceptually doesn't belong to this module. Please use `ic_cdk::api::performance_counter` instead."
+)]
+pub fn performance_counter(counter_type: u32) -> u64 {
+    // SAFETY: ic0.performance_counter is always safe to call.
+    unsafe { ic0::performance_counter(counter_type) }
+}
+
+/// Pretends to have the Candid type `T`, but unconditionally errors
+/// when serialized.
+///
+/// Usable, but not required, as metadata when using `#[query(manual_reply = true)]`,
+/// so an accurate Candid file can still be generated.
+#[derive(Debug, Copy, Clone, Default)]
+pub struct ManualReply<T: ?Sized>(PhantomData<T>);
+
+impl<T: ?Sized> ManualReply<T> {
+    /// Constructs a new `ManualReply`.
+    #[allow(clippy::self_named_constructors)]
+    pub const fn empty() -> Self {
+        Self(PhantomData)
+    }
+    /// Replies with the given value and returns a new `ManualReply`,
+    /// for a useful reply-then-return shortcut.
+    pub fn all<U>(value: U) -> Self
+    where
+        U: ArgumentEncoder,
+    {
+        reply(value);
+        Self::empty()
+    }
+    /// Replies with a one-element tuple around the given value and returns
+    /// a new `ManualReply`, for a useful reply-then-return shortcut.
+    pub fn one<U>(value: U) -> Self
+    where
+        U: CandidType,
+    {
+        reply((value,));
+        Self::empty()
+    }
+
+    /// Rejects the call with the specified message and returns a new
+    /// `ManualReply`, for a useful reply-then-return shortcut.
+    pub fn reject(message: impl AsRef<str>) -> Self {
+        reject(message.as_ref());
+        Self::empty()
+    }
+}
+
+impl<T> CandidType for ManualReply<T>
+where
+    T: CandidType + ?Sized,
+{
+    fn _ty() -> candid::types::Type {
+        T::_ty()
+    }
+    /// Unconditionally errors.
+    fn idl_serialize<S>(&self, _: S) -> Result<(), S::Error>
+    where
+        S: candid::types::Serializer,
+    {
+        Err(S::Error::custom("`Empty` cannot be serialized"))
+    }
+}
+
+/// Tells you whether the current async fn is being canceled due to a trap/panic.
+///
+/// If a function traps/panics, then the canister state is rewound to the beginning of the function.
+/// However, due to the way async works, the beginning of the function as the IC understands it is actually
+/// the most recent `await` from an inter-canister-call. This means that part of the function will have executed,
+/// and part of it won't.
+///
+/// When this happens the CDK will cancel the task, causing destructors to be run. If you need any functions to be run
+/// no matter what happens, they should happen in a destructor; the [`scopeguard`](https://docs.rs/scopeguard) crate
+/// provides a convenient wrapper for this. In a destructor, `is_recovering_from_trap` serves the same purpose as
+/// [std::thread::panicking] - it tells you whether the destructor is executing *because* of a trap,
+/// as opposed to just because the scope was exited, so you could e.g. implement mutex poisoning.
+pub fn is_recovering_from_trap() -> bool {
+    crate::futures::CLEANUP.load(Ordering::Relaxed)
+}

--- a/ic-cdk/src/call.rs
+++ b/ic-cdk/src/call.rs
@@ -94,12 +94,6 @@ pub enum CallError {
     #[error("The call was rejected with code {0:?} and message: {1}")]
     CallRejected(RejectCode, String),
 
-    /// The cleanup callback was executed.
-    //
-    // TODO: Is this really an error?
-    #[error("The cleanup callback was executed")]
-    CleanupExecuted,
-
     /// The response could not be decoded.
     #[error("Failed to decode the response as {0}")]
     CandidDecodeFailed(String),
@@ -232,8 +226,6 @@ unsafe extern "C" fn cleanup<T: AsRef<[u8]>>(state_ptr: *const RwLock<CallFuture
         //
         // Borrowing does not trap - the rollback from the
         // previous trap ensures that the RwLock can be borrowed again.
-        // TODO: Should we have this?
-        state.write().unwrap().result = Some(Err(CallError::CleanupExecuted));
         let w = state.write().unwrap().waker.take();
         if let Some(waker) = w {
             // Flag that we do not want to actually wake the task - we

--- a/ic-cdk/src/call.rs
+++ b/ic-cdk/src/call.rs
@@ -56,12 +56,18 @@ impl TryFrom<u32> for RejectCode {
 ///
 /// See [here](https://internetcomputer.org/docs/current/references/ic-interface-spec/#system-api-call) for more details.
 ///
-/// The spec currently only states that: "If the function returns a non-zero value, the call cannot (and will not be) performed."
-/// It does not specify what the error codes are. So we only have a single variant (`Unrecognized`) for now.
+/// So far, the specified codes (1, 2, 3) share the same meaning as the corresponding [RejectCode]s.
 #[repr(u32)]
 #[non_exhaustive]
 #[derive(CandidType, Deserialize, Clone, Copy, Hash, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CallPerformErrorCode {
+    /// Fatal system error, retry unlikely to be useful.
+    SysFatal = 1,
+    /// Transient system error, retry might be possible.
+    SysTransient = 2,
+    /// Invalid destination (e.g. canister/account does not exist).
+    DestinationInvalid = 3,
+
     /// Unrecognized error code.
     ///
     /// Note that this variant is not part of the IC interface spec, and is used to represent

--- a/ic-cdk/src/lib.rs
+++ b/ic-cdk/src/lib.rs
@@ -15,6 +15,7 @@ compile_error!("This version of the CDK does not support multithreading.");
 pub mod prelude;
 
 pub mod api;
+pub mod call;
 mod futures;
 mod macros;
 mod printer;

--- a/ic-cdk/src/prelude.rs
+++ b/ic-cdk/src/prelude.rs
@@ -1,6 +1,6 @@
 //! The prelude module contains the most commonly used types and traits.
-pub use crate::api::call::{Call, CallResult, ConfigurableCall, RejectionCode, SendableCall};
 pub use crate::api::{caller, id, print, trap};
+pub use crate::call::{Call, CallResult, ConfigurableCall, RejectionCode, SendableCall};
 pub use crate::macros::{
     export_candid, heartbeat, init, inspect_message, post_upgrade, pre_upgrade, query, update,
 };

--- a/ic-cdk/src/prelude.rs
+++ b/ic-cdk/src/prelude.rs
@@ -1,6 +1,6 @@
 //! The prelude module contains the most commonly used types and traits.
 pub use crate::api::{caller, id, print, trap};
-pub use crate::call::{Call, CallResult, ConfigurableCall, RejectionCode, SendableCall};
+pub use crate::call::{Call, CallResult, ConfigurableCall, RejectCode, SendableCall};
 pub use crate::macros::{
     export_candid, heartbeat, init, inspect_message, post_upgrade, pre_upgrade, query, update,
 };


### PR DESCRIPTION
# Description

The Call struct API was added to the existing `src/api/call.rs` module.
This PR moves the new API to `src/call.rs` module.
The `src/api/call.rs` is consistent with the main branch with some minor adjustment for the new ic0 crate.

The `src/call.rs` module also got some refreshment.

```Rust
pub type CallResult<R> = Result<R, CallError>;

pub enum CallError {
    #[error("Failed to encode the arguments: {0}")]
    CandidEncodeFailed(String),

    #[error("The IC was not able to enqueue the call with code {0:?}")]
    CallPerformFailed(CallPerformErrorCode),

    #[error("The call was rejected with code {0:?} and message: {1}")]
    CallRejected(RejectCode, String),

    #[error("Failed to decode the response as {0}")]
    CandidDecodeFailed(String),
}
```

# How Has This Been Tested?

e2e tests

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
