### PR TITLE
chore: deprecate old call API

### DIFF
--- a/ic-cdk/src/api/call.rs
+++ b/ic-cdk/src/api/call.rs
@@ -18,6 +18,10 @@ use std::task::{Context, Poll, Waker};
 ///
 /// These can be obtained either using `reject_code()` or `reject_result()`.
 #[allow(missing_docs)]
+#[deprecated(
+    since = "0.18.0",
+    note = "Please use `ic_cdk::call::RejectCode` instead."
+)]
 #[repr(usize)]
 #[derive(CandidType, Deserialize, Clone, Copy, Hash, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RejectionCode {
@@ -55,6 +59,10 @@ impl From<u32> for RejectionCode {
 /// The result of a Call.
 ///
 /// Errors on the IC have two components; a Code and a message associated with it.
+#[deprecated(
+    since = "0.18.0",
+    note = "Please use `ic_cdk::call::CallResult` instead."
+)]
 pub type CallResult<R> = Result<R, (RejectionCode, String)>;
 
 // Internal state for the Future when sending a call.
@@ -223,6 +231,10 @@ fn add_payment(payment: u128) {
 ///   * If the payment is non-zero and the system fails to deliver the notification, the behaviour
 ///     is unspecified: the funds can be either reimbursed or consumed irrevocably by the IC depending
 ///     on the underlying implementation of one-way calls.
+#[deprecated(
+    since = "0.18.0",
+    note = "Please use `ic_cdk::call::Call::new().with_arg(,,).with_cycles(..).call_oneway()` instead."
+)]
 pub fn notify_with_payment128<T: ArgumentEncoder>(
     id: Principal,
     method: &str,
@@ -234,6 +246,10 @@ pub fn notify_with_payment128<T: ArgumentEncoder>(
 }
 
 /// Like [notify_with_payment128], but sets the payment to zero.
+#[deprecated(
+    since = "0.18.0",
+    note = "Please use `ic_cdk::call::Call::new().with_arg(,,).with_cycles(..).call_oneway()` instead."
+)]
 pub fn notify<T: ArgumentEncoder>(
     id: Principal,
     method: &str,
@@ -243,6 +259,10 @@ pub fn notify<T: ArgumentEncoder>(
 }
 
 /// Like [notify], but sends the argument as raw bytes, skipping Candid serialization.
+#[deprecated(
+    since = "0.18.0",
+    note = "Please use `ic_cdk::call::Call::new().with_raw_args(..).with_cycles(..).call_oneway()` instead."
+)]
 pub fn notify_raw(
     id: Principal,
     method: &str,
@@ -299,6 +319,10 @@ pub fn notify_raw(
 ///     call_raw(callee_canister(), "add_user", b"abcd", 1_000_000u64).await.unwrap()
 /// }
 /// ```
+#[deprecated(
+    since = "0.18.0",
+    note = "Please use `ic_cdk::call::Call::new().with_raw_args(..).with_cycles(..).call()` instead."
+)]
 pub fn call_raw<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
     id: Principal,
     method: &str,
@@ -322,6 +346,10 @@ pub fn call_raw<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
 ///     call_raw128(callee_canister(), "add_user", b"abcd", 1_000_000u128).await.unwrap()
 /// }
 /// ```
+#[deprecated(
+    since = "0.18.0",
+    note = "Please use `ic_cdk::call::Call::new().with_raw_args(..).with_cycles(..).call()` instead."
+)]
 pub fn call_raw128<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
     id: Principal,
     method: &str,
@@ -388,6 +416,10 @@ fn decoder_error_to_reject<T>(err: candid::error::Error) -> (RejectionCode, Stri
 /// * The type annotation on return type is required. Or the return type can be inferred from the context.
 /// * The asynchronous call must be awaited in order for the inter-canister call to be made.
 /// * If the reply payload is not a valid encoding of the expected type `T`, the call results in [RejectionCode::CanisterError] error.
+#[deprecated(
+    since = "0.18.0",
+    note = "Please use `ic_cdk::call::Call::new().with_arg(..).call()` instead."
+)]
 pub fn call<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     id: Principal,
     method: &str,
@@ -430,6 +462,10 @@ pub fn call<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
 /// * The type annotation on return type is required. Or the return type can be inferred from the context.
 /// * The asynchronous call must be awaited in order for the inter-canister call to be made.
 /// * If the reply payload is not a valid encoding of the expected type `T`, the call results in [RejectionCode::CanisterError] error.
+#[deprecated(
+    since = "0.18.0",
+    note = "Please use `ic_cdk::call::Call::new().with_arg(..).with_cycles(..).call()` instead."
+)]
 pub fn call_with_payment<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     id: Principal,
     method: &str,
@@ -473,6 +509,10 @@ pub fn call_with_payment<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
 /// * The type annotation on return type is required. Or the return type can be inferred from the context.
 /// * The asynchronous call must be awaited in order for the inter-canister call to be made.
 /// * If the reply payload is not a valid encoding of the expected type `T`, the call results in [RejectionCode::CanisterError] error.
+#[deprecated(
+    since = "0.18.0",
+    note = "Please use `ic_cdk::call::Call::new().with_arg(..).with_cycles(..).call()` instead."
+)]
 pub fn call_with_payment128<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     id: Principal,
     method: &str,
@@ -519,6 +559,10 @@ pub fn call_with_payment128<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
 ///     user_id
 /// }
 /// ```
+#[deprecated(
+    since = "0.18.0",
+    note = "Please use `ic_cdk::call::Call::new().with_arg(..).with_cycles(..).with_decoder_config(..).call()` instead."
+)]
 pub fn call_with_config<'b, T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     id: Principal,
     method: &'b str,

--- a/ic-cdk/src/lib.rs
+++ b/ic-cdk/src/lib.rs
@@ -26,15 +26,14 @@ pub mod storage;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 #[doc(inline)]
-pub use api::call::call;
-#[doc(inline)]
-pub use api::call::notify;
-#[doc(inline)]
 pub use api::trap;
 
 #[doc(inline)]
 #[allow(deprecated)]
-pub use api::{caller, id, print};
+pub use api::{
+    call::{call, notify},
+    caller, id, print,
+};
 
 #[doc(inline)]
 pub use macros::*;

--- a/library/ic-ledger-types/src/lib.rs
+++ b/library/ic-ledger-types/src/lib.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 use sha2::Digest;
 
-use ic_cdk::api::call::CallResult;
+use ic_cdk::call::{Call, CallResult, SendableCall};
 
 /// The subaccount that is used by default.
 pub const DEFAULT_SUBACCOUNT: Subaccount = Subaccount([0; 32]);
@@ -691,8 +691,10 @@ pub async fn account_balance(
     ledger_canister_id: Principal,
     args: AccountBalanceArgs,
 ) -> CallResult<Tokens> {
-    let (icp,) = ic_cdk::call(ledger_canister_id, "account_balance", (args,)).await?;
-    Ok(icp)
+    Call::new(ledger_canister_id, "account_balance")
+        .with_arg(args)
+        .call()
+        .await
 }
 
 /// Calls the "transfer" method on the specified canister.
@@ -719,8 +721,10 @@ pub async fn transfer(
     ledger_canister_id: Principal,
     args: TransferArgs,
 ) -> CallResult<TransferResult> {
-    let (result,) = ic_cdk::call(ledger_canister_id, "transfer", (args,)).await?;
-    Ok(result)
+    Call::new(ledger_canister_id, "transfer")
+        .with_arg(args)
+        .call()
+        .await
 }
 
 /// Return type of the `token_symbol` function.
@@ -742,8 +746,7 @@ pub struct Symbol {
 /// }
 /// ```
 pub async fn token_symbol(ledger_canister_id: Principal) -> CallResult<Symbol> {
-    let (result,) = ic_cdk::call(ledger_canister_id, "token_symbol", ()).await?;
-    Ok(result)
+    Call::new(ledger_canister_id, "token_symbol").call().await
 }
 
 /// Calls the "query_block" method on the specified canister.
@@ -778,8 +781,10 @@ pub async fn query_blocks(
     ledger_canister_id: Principal,
     args: GetBlocksArgs,
 ) -> CallResult<QueryBlocksResponse> {
-    let (result,) = ic_cdk::call(ledger_canister_id, "query_blocks", (args,)).await?;
-    Ok(result)
+    Call::new(ledger_canister_id, "query_blocks")
+        .with_arg(args)
+        .call()
+        .await
 }
 
 /// Continues a query started in [`query_blocks`] by calling its returned archive function.
@@ -816,8 +821,10 @@ pub async fn query_archived_blocks(
     func: &QueryArchiveFn,
     args: GetBlocksArgs,
 ) -> CallResult<GetBlocksResult> {
-    let (result,) = ic_cdk::api::call::call(func.0.principal, &func.0.method, (args,)).await?;
-    Ok(result)
+    Call::new(func.0.principal, &func.0.method)
+        .with_arg(args)
+        .call()
+        .await
 }
 
 #[cfg(test)]

--- a/library/ic-ledger-types/src/lib.rs
+++ b/library/ic-ledger-types/src/lib.rs
@@ -675,14 +675,14 @@ impl CandidType for QueryArchiveFn {
 ///
 /// # Example
 /// ```no_run
-/// use ic_cdk::api::{caller, call::call};
+/// use ic_cdk::api::msg_caller;
 /// use ic_ledger_types::{AccountIdentifier, AccountBalanceArgs, Tokens, DEFAULT_SUBACCOUNT, MAINNET_LEDGER_CANISTER_ID, account_balance};
 ///
 /// async fn check_callers_balance() -> Tokens {
 ///   account_balance(
 ///     MAINNET_LEDGER_CANISTER_ID,
 ///     AccountBalanceArgs {
-///       account: AccountIdentifier::new(&caller(), &DEFAULT_SUBACCOUNT)
+///       account: AccountIdentifier::new(&msg_caller(), &DEFAULT_SUBACCOUNT)
 ///     }
 ///   ).await.expect("call to ledger failed")
 /// }
@@ -700,7 +700,7 @@ pub async fn account_balance(
 /// Calls the "transfer" method on the specified canister.
 /// # Example
 /// ```no_run
-/// use ic_cdk::api::{caller, call::call};
+/// use ic_cdk::api::msg_caller;
 /// use ic_ledger_types::{AccountIdentifier, BlockIndex, Memo, TransferArgs, Tokens, DEFAULT_SUBACCOUNT, DEFAULT_FEE, MAINNET_LEDGER_CANISTER_ID, transfer};
 ///
 /// async fn transfer_to_caller() -> BlockIndex {
@@ -711,7 +711,7 @@ pub async fn account_balance(
 ///       amount: Tokens::from_e8s(1_000_000),
 ///       fee: DEFAULT_FEE,
 ///       from_subaccount: None,
-///       to: AccountIdentifier::new(&caller(), &DEFAULT_SUBACCOUNT),
+///       to: AccountIdentifier::new(&msg_caller(), &DEFAULT_SUBACCOUNT),
 ///       created_at_time: None,
 ///     }
 ///   ).await.expect("call to ledger failed").expect("transfer failed")
@@ -738,7 +738,6 @@ pub struct Symbol {
 /// # Example
 /// ```no_run
 /// use candid::Principal;
-/// use ic_cdk::api::{caller, call::call};
 /// use ic_ledger_types::{Symbol, token_symbol};
 ///
 /// async fn symbol(ledger_canister_id: Principal) -> String {
@@ -753,7 +752,7 @@ pub async fn token_symbol(ledger_canister_id: Principal) -> CallResult<Symbol> {
 /// # Example
 /// ```no_run
 /// use candid::Principal;
-/// use ic_cdk::api::call::CallResult;
+/// use ic_cdk::call::CallResult;
 /// use ic_ledger_types::{BlockIndex, Block, GetBlocksArgs, query_blocks, query_archived_blocks};
 ///
 /// async fn query_one_block(ledger: Principal, block_index: BlockIndex) -> CallResult<Option<Block>> {
@@ -793,7 +792,7 @@ pub async fn query_blocks(
 ///
 /// ```no_run
 /// use candid::Principal;
-/// use ic_cdk::api::call::CallResult;
+/// use ic_cdk::call::CallResult;
 /// use ic_ledger_types::{BlockIndex, Block, GetBlocksArgs, query_blocks, query_archived_blocks};
 ///
 /// async fn query_one_block(ledger: Principal, block_index: BlockIndex) -> CallResult<Option<Block>> {


### PR DESCRIPTION
# Description

The old call API in `ic_cdk::api::call.rs` are deprecated.

`ic-cdk-timers`, `ic-ledger-types` and some e2e tests are migrated to the new `Call::new(...)` API.

During the migration, a bug in `CallPerformErrorCode` handling was found. And both `RejectCode` and `CallPerformErrorCode` are improved to include a `NoError` variant and implemented `Into/From/PartialEq` traits with `u32`.

# How Has This Been Tested?

The e2e tests. And there should be no compiler error/warning across the whole project.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
