### PR TITLE
feat: macros that decoding arguments can set custom decoder using decode_with

### DIFF
--- a/e2e-tests/src/bin/macros.rs
+++ b/e2e-tests/src/bin/macros.rs
@@ -1,0 +1,28 @@
+use candid::utils::{decode_args, decode_one};
+use ic_cdk::api::msg_arg_data;
+use ic_cdk::update;
+
+#[update(decode_with = "decode_u0")]
+fn u0() {}
+fn decode_u0() {}
+
+#[update(decode_with = "decode_u1")]
+fn u1(a: u32) {
+    assert_eq!(a, 1)
+}
+fn decode_u1() -> u32 {
+    let arg_bytes = msg_arg_data();
+    decode_one(&arg_bytes).unwrap()
+}
+
+#[update(decode_with = "decode_u2")]
+fn u2(a: u32, b: u32) {
+    assert_eq!(a, 1);
+    assert_eq!(b, 2);
+}
+fn decode_u2() -> (u32, u32) {
+    let arg_bytes = msg_arg_data();
+    decode_args(&arg_bytes).unwrap()
+}
+
+fn main() {}

--- a/e2e-tests/tests/macros.rs
+++ b/e2e-tests/tests/macros.rs
@@ -1,0 +1,31 @@
+use pocket_ic::call_candid;
+use pocket_ic::common::rest::RawEffectivePrincipal;
+
+mod test_utilities;
+use test_utilities::{cargo_build_canister, pocket_ic};
+
+#[test]
+fn call_macros() {
+    let pic = pocket_ic();
+    let wasm = cargo_build_canister("macros");
+    let canister_id = pic.create_canister();
+    pic.add_cycles(canister_id, 100_000_000_000_000);
+    pic.install_canister(canister_id, wasm, vec![], None);
+    let _: () = call_candid(&pic, canister_id, RawEffectivePrincipal::None, "u0", ()).unwrap();
+    let _: () = call_candid(
+        &pic,
+        canister_id,
+        RawEffectivePrincipal::None,
+        "u1",
+        (1u32,),
+    )
+    .unwrap();
+    let _: () = call_candid(
+        &pic,
+        canister_id,
+        RawEffectivePrincipal::None,
+        "u2",
+        (1u32, 2u32),
+    )
+    .unwrap();
+}


### PR DESCRIPTION
SDK-1924

# Description

* Add `decode_with` hook for customizing arguments decoding.
* When the argument is empty, the macros won't generate the code which get `msg_arg_data` then decode as Candid.
  * The callee can send any arguments to such entry-points. And the entry-point won't waste any cycles on decoding it into `'()'`.
  * If it's needed, developer can still use `decode_with` to decode the arguments data.
* Some code cleanup for better maintainability.

# How Has This Been Tested?

Added a macros e2e test.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
