### PR TITLE
feat: safe binding for msg_deadline

### DIFF
--- a/e2e-tests/src/bin/api.rs
+++ b/e2e-tests/src/bin/api.rs
@@ -18,7 +18,7 @@ fn call_msg_caller() {
 
 /// This entrypoint will call [`call_msg_deadline`] with both best-effort and guaranteed responses.
 #[ic_cdk::update]
-async fn call_msg_dealine_caller() {
+async fn call_msg_deadline_caller() {
     use ic_cdk::call::{Call, SendableCall};
     // Call with best-effort responses.
     let reply1 = Call::new(canister_self(), "call_msg_deadline")
@@ -35,13 +35,17 @@ async fn call_msg_dealine_caller() {
     assert_eq!(reply1, vec![0]);
 }
 
-/// This entrypoint is to be called by [`call_msg_dealine_caller`].
+/// This entrypoint is to be called by [`call_msg_deadline_caller`].
 /// If the call was made with best-effort responses, `msg_deadline` should be `Some`, then return 1.
 /// If the call was made with guaranteed responses, `msg_deadline` should be `None`, then return 0.
 #[export_name = "canister_update call_msg_deadline"]
 fn call_msg_deadline() {
     let reply = match msg_deadline() {
-        Some(_) => 1,
+        Some(v) => {
+            // `NonZeroU64::get()` converts the value to `u64`.
+            assert!(v.get() > 1);
+            1
+        }
         None => 0,
     };
     msg_reply(vec![reply]);

--- a/e2e-tests/tests/api.rs
+++ b/e2e-tests/tests/api.rs
@@ -20,6 +20,13 @@ fn call_api() {
         .update_call(canister_id, sender, "call_msg_caller", vec![])
         .unwrap();
     assert_eq!(res, WasmResult::Reply(vec![]));
+    let res = pic
+        .update_call(canister_id, sender, "call_msg_dealine_caller", vec![])
+        .unwrap();
+    // Unlike the other entry points, `call_msg_dealine_caller` was implemented with the `#[update]` macro.
+    // So it returns the bytes of the Candid value `()` which is not the vec![]`.
+    // The assertion below is to check if the call was successful.
+    assert!(matches!(res, WasmResult::Reply(_)));
     // `msg_reject_code` and `msg_reject_msg` can't be tested here.
     // They are invoked in the reply/reject callback of inter-canister calls.
     // So the `call.rs` test covers them.

--- a/e2e-tests/tests/api.rs
+++ b/e2e-tests/tests/api.rs
@@ -21,7 +21,7 @@ fn call_api() {
         .unwrap();
     assert_eq!(res, WasmResult::Reply(vec![]));
     let res = pic
-        .update_call(canister_id, sender, "call_msg_dealine_caller", vec![])
+        .update_call(canister_id, sender, "call_msg_deadline_caller", vec![])
         .unwrap();
     // Unlike the other entry points, `call_msg_dealine_caller` was implemented with the `#[update]` macro.
     // So it returns the bytes of the Candid value `()` which is not the vec![]`.

--- a/ic-cdk/src/api.rs
+++ b/ic-cdk/src/api.rs
@@ -83,6 +83,26 @@ pub fn msg_reject_msg() -> String {
     String::from_utf8_lossy(&bytes).into_owned()
 }
 
+/// Gets the deadline, in nanoseconds since 1970-01-01, after which the caller might stop waiting for a response.
+///
+/// For calls to update methods with best-effort responses and their callbacks,
+/// the deadline is computed based on the time the call was made,
+/// and the `timeout_seconds` parameter provided by the caller.
+/// In such cases, the deadline value wrapped in `Some` is returned.
+///
+/// For other calls (ingress messages and all calls to query and composite query methods,
+/// including calls in replicated mode), a `None` is returned.
+/// Please note that the raw `msg_deadline` system API returns 0 in such cases.
+/// This function is a wrapper around the raw system API that provides more semantic information through the return type.
+pub fn msg_deadline() -> Option<u64> {
+    // SAFETY: ic0.msg_deadline is always safe to call.
+    let nano_seconds = unsafe { ic0::msg_deadline() };
+    match nano_seconds {
+        0 => None,
+        _ => Some(nano_seconds),
+    }
+}
+
 /// Replies to the sender with the data.
 pub fn msg_reply<T: AsRef<[u8]>>(data: T) {
     let buf = data.as_ref();


### PR DESCRIPTION
# Description

`msg_deadline ` is a new system API as a part of the Best-Effort Responses feature.

It's specification can be found [here](https://github.com/dfinity/portal/pull/3764).

# How Has This Been Tested?

e2e-tests api.rs

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
