### PR TITLE
feat: simplify Call implementation and enable retry logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,6 @@ serde_bytes = "0.11"
 sha2 = "0.10"
 slotmap = "1"
 syn = "2"
+
+[patch.crates-io]
+candid = { git = "https://github.com/dfinity/candid", branch = "lwshang/encode_ref" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.0-alpha.1" }
 ic-response-codes = { path = "ic-response-codes", version = "0.1.0" }
 ic-management-canister-types = { path = "ic-management-canister-types", version = "0.1.0" }
 
-candid = "0.10.12"
+candid = "0.10.13"
 candid_parser = "0.1.4"
 futures = "0.3"
 hex = "0.4"
@@ -47,6 +47,3 @@ serde_bytes = "0.11"
 sha2 = "0.10"
 slotmap = "1"
 syn = "2"
-
-[patch.crates-io]
-candid = { git = "https://github.com/dfinity/candid", branch = "lwshang/encode_ref" }

--- a/e2e-tests/src/bin/api.rs
+++ b/e2e-tests/src/bin/api.rs
@@ -2,7 +2,7 @@
 //! The [`inspect_message`] function defined below mandates that all the update/query entrypoints must start with "call_".
 
 use candid::Principal;
-use ic_cdk::{api::*, call::ConfigurableCall};
+use ic_cdk::api::*;
 
 #[export_name = "canister_update call_msg_arg_data"]
 fn call_msg_arg_data() {
@@ -19,7 +19,7 @@ fn call_msg_caller() {
 /// This entrypoint will call [`call_msg_deadline`] with both best-effort and guaranteed responses.
 #[ic_cdk::update]
 async fn call_msg_deadline_caller() {
-    use ic_cdk::call::{Call, SendableCall};
+    use ic_cdk::call::Call;
     // Call with best-effort responses.
     let reply1 = Call::new(canister_self(), "call_msg_deadline")
         .call_raw()

--- a/e2e-tests/src/bin/async.rs
+++ b/e2e-tests/src/bin/async.rs
@@ -1,5 +1,5 @@
 use candid::Principal;
-use ic_cdk::call::{Call, CallError, CallResult, SendableCall};
+use ic_cdk::call::{Call, CallError, CallResult};
 use ic_cdk::{query, update};
 use lazy_static::lazy_static;
 use std::sync::RwLock;

--- a/e2e-tests/src/bin/async.rs
+++ b/e2e-tests/src/bin/async.rs
@@ -33,7 +33,7 @@ async fn panic_after_async() {
     // Do not drop the lock before the await point.
 
     let _: u64 = Call::new(ic_cdk::api::canister_self(), "inc")
-        .with_arg(&value)
+        .with_arg(value)
         .call()
         .await
         .unwrap();
@@ -87,7 +87,7 @@ fn greet(name: String) -> String {
 #[query(composite = true)]
 async fn greet_self(greeter: Principal) -> String {
     Call::new(greeter, "greet")
-        .with_arg(&"myself")
+        .with_arg("myself")
         .call()
         .await
         .unwrap()
@@ -97,7 +97,7 @@ async fn greet_self(greeter: Principal) -> String {
 async fn invalid_reply_payload_does_not_trap() -> String {
     // We're decoding an integer instead of a string, decoding must fail.
     let result: CallResult<u64> = Call::new(ic_cdk::api::canister_self(), "greet")
-        .with_arg(&"World")
+        .with_arg("World")
         .call()
         .await;
 

--- a/e2e-tests/src/bin/async.rs
+++ b/e2e-tests/src/bin/async.rs
@@ -33,7 +33,7 @@ async fn panic_after_async() {
     // Do not drop the lock before the await point.
 
     let _: u64 = Call::new(ic_cdk::api::canister_self(), "inc")
-        .with_arg(value)
+        .with_arg(&value)
         .call()
         .await
         .unwrap();
@@ -87,7 +87,7 @@ fn greet(name: String) -> String {
 #[query(composite = true)]
 async fn greet_self(greeter: Principal) -> String {
     Call::new(greeter, "greet")
-        .with_arg("myself")
+        .with_arg(&"myself")
         .call()
         .await
         .unwrap()
@@ -97,7 +97,7 @@ async fn greet_self(greeter: Principal) -> String {
 async fn invalid_reply_payload_does_not_trap() -> String {
     // We're decoding an integer instead of a string, decoding must fail.
     let result: CallResult<u64> = Call::new(ic_cdk::api::canister_self(), "greet")
-        .with_arg("World")
+        .with_arg(&"World")
         .call()
         .await;
 

--- a/e2e-tests/src/bin/call.rs
+++ b/e2e-tests/src/bin/call.rs
@@ -59,44 +59,44 @@ async fn call_echo_with_arg() {
     let bytes = Encode!(&n).unwrap();
     // call*
     let res: u32 = Call::new(canister_self(), "echo")
-        .with_arg(n)
+        .with_arg(&n)
         .call()
         .await
         .unwrap();
     assert_eq!(res, n);
     let res: (u32,) = Call::new(canister_self(), "echo")
-        .with_arg(n)
+        .with_arg(&n)
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
     let res = Call::new(canister_self(), "echo")
-        .with_arg(n)
+        .with_arg(&n)
         .call_raw()
         .await
         .unwrap();
     assert_eq!(res, bytes);
     Call::new(canister_self(), "echo")
-        .with_arg(n)
+        .with_arg(&n)
         .call_oneway()
         .unwrap();
     // with*
     let res: (u32,) = Call::new(canister_self(), "echo")
-        .with_arg(n)
+        .with_arg(&n)
         .with_guaranteed_response()
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
     let res: (u32,) = Call::new(canister_self(), "echo")
-        .with_arg(n)
+        .with_arg(&n)
         .change_timeout(5)
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
     let res: (u32,) = Call::new(canister_self(), "echo")
-        .with_arg(n)
+        .with_arg(&n)
         .with_cycles(1000)
         .call_tuple()
         .await

--- a/e2e-tests/src/bin/call.rs
+++ b/e2e-tests/src/bin/call.rs
@@ -59,44 +59,44 @@ async fn call_echo_with_arg() {
     let bytes = Encode!(&n).unwrap();
     // call*
     let res: u32 = Call::new(canister_self(), "echo")
-        .with_arg(&n)
+        .with_arg(n)
         .call()
         .await
         .unwrap();
     assert_eq!(res, n);
     let res: (u32,) = Call::new(canister_self(), "echo")
-        .with_arg(&n)
+        .with_arg(n)
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
     let res = Call::new(canister_self(), "echo")
-        .with_arg(&n)
+        .with_arg(n)
         .call_raw()
         .await
         .unwrap();
     assert_eq!(res, bytes);
     Call::new(canister_self(), "echo")
-        .with_arg(&n)
+        .with_arg(n)
         .call_oneway()
         .unwrap();
     // with*
     let res: (u32,) = Call::new(canister_self(), "echo")
-        .with_arg(&n)
+        .with_arg(n)
         .with_guaranteed_response()
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
     let res: (u32,) = Call::new(canister_self(), "echo")
-        .with_arg(&n)
+        .with_arg(n)
         .change_timeout(5)
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
     let res: (u32,) = Call::new(canister_self(), "echo")
-        .with_arg(&n)
+        .with_arg(n)
         .with_cycles(1000)
         .call_tuple()
         .await
@@ -230,7 +230,7 @@ async fn retry_calls() {
     let n: u32 = 1u32;
     let call = Call::new(canister_self(), "foo");
     assert_eq!(retry(call).await, 0);
-    let call_with_arg = Call::new(canister_self(), "echo").with_arg(&n);
+    let call_with_arg = Call::new(canister_self(), "echo").with_arg(n);
     assert_eq!(retry(call_with_arg).await, 0);
     let args = (n,);
     let call_with_args = Call::new(canister_self(), "echo").with_args(&args);

--- a/e2e-tests/src/bin/call.rs
+++ b/e2e-tests/src/bin/call.rs
@@ -1,6 +1,6 @@
 use candid::Encode;
 use ic_cdk::api::canister_self;
-use ic_cdk::call::{Call, ConfigurableCall, SendableCall};
+use ic_cdk::call::Call;
 use ic_cdk::update;
 
 /// A simple endpoint that takes empty arguments.
@@ -211,7 +211,7 @@ async fn call_echo_with_raw_args() {
 /// Retries the call until it succeeds.
 ///
 /// Returns the number of retries.
-async fn retry<C: SendableCall>(call_to_retry: C) -> u32 {
+async fn retry(call_to_retry: Call<'_, '_>) -> u32 {
     let mut retry = 0;
     loop {
         match call_to_retry.call_raw().await {

--- a/e2e-tests/src/bin/call.rs
+++ b/e2e-tests/src/bin/call.rs
@@ -111,44 +111,44 @@ async fn call_echo_with_args() {
     let bytes = Encode!(&n).unwrap();
     // call*
     let res: u32 = Call::new(canister_self(), "echo")
-        .with_args((n,))
+        .with_args(&(n,))
         .call()
         .await
         .unwrap();
     assert_eq!(res, n);
     let res: (u32,) = Call::new(canister_self(), "echo")
-        .with_args((n,))
+        .with_args(&(n,))
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
     let res = Call::new(canister_self(), "echo")
-        .with_args((n,))
+        .with_args(&(n,))
         .call_raw()
         .await
         .unwrap();
     assert_eq!(res, bytes);
     Call::new(canister_self(), "echo")
-        .with_args((n,))
+        .with_args(&(n,))
         .call_oneway()
         .unwrap();
     // with*
     let res: (u32,) = Call::new(canister_self(), "echo")
-        .with_args((n,))
+        .with_args(&(n,))
         .with_guaranteed_response()
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
     let res: (u32,) = Call::new(canister_self(), "echo")
-        .with_args((n,))
+        .with_args(&(n,))
         .change_timeout(5)
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
     let res: (u32,) = Call::new(canister_self(), "echo")
-        .with_args((n,))
+        .with_args(&(n,))
         .with_cycles(1000)
         .call_tuple()
         .await
@@ -208,4 +208,35 @@ async fn call_echo_with_raw_args() {
     assert_eq!(res.0, n);
 }
 
+/// Retries the call until it succeeds.
+///
+/// Returns the number of retries.
+async fn retry<C: SendableCall>(call_to_retry: C) -> u32 {
+    let mut retry = 0;
+    loop {
+        match call_to_retry.call_raw().await {
+            Ok(_) => break,
+            Err(_) => {
+                retry += 1;
+                continue;
+            }
+        }
+    }
+    retry
+}
+
+#[update]
+async fn retry_calls() {
+    let n: u32 = 1u32;
+    let call = Call::new(canister_self(), "foo");
+    assert_eq!(retry(call).await, 0);
+    let call_with_arg = Call::new(canister_self(), "echo").with_arg(&n);
+    assert_eq!(retry(call_with_arg).await, 0);
+    let args = (n,);
+    let call_with_args = Call::new(canister_self(), "echo").with_args(&args);
+    assert_eq!(retry(call_with_args).await, 0);
+    let raw_args = Encode!(&n).unwrap();
+    let call_with_raw_args = Call::new(canister_self(), "echo").with_raw_args(&raw_args);
+    assert_eq!(retry(call_with_raw_args).await, 0);
+}
 fn main() {}

--- a/e2e-tests/src/bin/canister_info.rs
+++ b/e2e-tests/src/bin/canister_info.rs
@@ -12,16 +12,16 @@ async fn info(canister_id: Principal) -> CanisterInfoResult {
         canister_id,
         num_requested_changes: Some(20),
     };
-    canister_info(request).await.unwrap()
+    canister_info(&request).await.unwrap()
 }
 
 #[ic_cdk::update]
 async fn canister_lifecycle() -> Principal {
-    let canister_id = create_canister(CreateCanisterArgs { settings: None }, 1_000_000_000_000)
+    let canister_id = create_canister(&CreateCanisterArgs { settings: None }, 1_000_000_000_000)
         .await
         .unwrap()
         .canister_id;
-    install_code(InstallCodeArgs {
+    install_code(&InstallCodeArgs {
         mode: Install,
         arg: vec![],
         wasm_module: vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00],
@@ -29,10 +29,10 @@ async fn canister_lifecycle() -> Principal {
     })
     .await
     .unwrap();
-    uninstall_code(UninstallCodeArgs { canister_id })
+    uninstall_code(&UninstallCodeArgs { canister_id })
         .await
         .unwrap();
-    install_code(InstallCodeArgs {
+    install_code(&InstallCodeArgs {
         mode: Install,
         arg: vec![],
         wasm_module: vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00],
@@ -40,7 +40,7 @@ async fn canister_lifecycle() -> Principal {
     })
     .await
     .unwrap();
-    install_code(InstallCodeArgs {
+    install_code(&InstallCodeArgs {
         mode: Reinstall,
         arg: vec![],
         wasm_module: vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00],
@@ -48,7 +48,7 @@ async fn canister_lifecycle() -> Principal {
     })
     .await
     .unwrap();
-    install_code(InstallCodeArgs {
+    install_code(&InstallCodeArgs {
         mode: Upgrade(None),
         arg: vec![],
         wasm_module: vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00],
@@ -56,7 +56,7 @@ async fn canister_lifecycle() -> Principal {
     })
     .await
     .unwrap();
-    update_settings(UpdateSettingsArgs {
+    update_settings(&UpdateSettingsArgs {
         settings: CanisterSettings {
             controllers: Some(vec![
                 ic_cdk::api::canister_self(),

--- a/e2e-tests/src/bin/chunk.rs
+++ b/e2e-tests/src/bin/chunk.rs
@@ -10,7 +10,7 @@ use ic_cdk::update;
 async fn call_create_canister() -> Principal {
     let arg = CreateCanisterArgs::default();
 
-    create_canister(arg, 1_000_000_000_000u128)
+    create_canister(&arg, 1_000_000_000_000u128)
         .await
         .unwrap()
         .canister_id
@@ -23,20 +23,20 @@ async fn call_upload_chunk(canister_id: Principal, chunk: Vec<u8>) -> Vec<u8> {
         chunk: chunk.to_vec(),
     };
 
-    upload_chunk(arg).await.unwrap().hash
+    upload_chunk(&arg).await.unwrap().hash
 }
 
 #[update]
 async fn call_stored_chunks(canister_id: Principal) -> Vec<Vec<u8>> {
     let arg = StoredChunksArgs { canister_id };
-    let hashes = stored_chunks(arg).await.unwrap();
+    let hashes = stored_chunks(&arg).await.unwrap();
     hashes.into_iter().map(|v| v.hash).collect()
 }
 
 #[update]
 async fn call_clear_chunk_store(canister_id: Principal) {
     let arg = ClearChunkStoreArgs { canister_id };
-    clear_chunk_store(arg).await.unwrap();
+    clear_chunk_store(&arg).await.unwrap();
 }
 
 #[update]
@@ -57,7 +57,7 @@ async fn call_install_chunked_code(
         wasm_module_hash,
         arg: vec![],
     };
-    install_chunked_code(arg).await.unwrap();
+    install_chunked_code(&arg).await.unwrap();
 }
 
 fn main() {}

--- a/e2e-tests/src/bin/http_request.rs
+++ b/e2e-tests/src/bin/http_request.rs
@@ -38,7 +38,7 @@ async fn get_without_transform() {
         transform: None,
     };
     let cycles = cycles_cost(&args);
-    let res = http_request(args, cycles).await.unwrap();
+    let res = http_request(&args, cycles).await.unwrap();
     assert_eq!(res.status, 200u32);
     assert_eq!(
         res.headers,
@@ -59,7 +59,7 @@ async fn post() {
         ..Default::default()
     };
     let cycles = cycles_cost(&args);
-    http_request(args, cycles).await.unwrap();
+    http_request(&args, cycles).await.unwrap();
 }
 
 /// Method is HEAD.
@@ -71,7 +71,7 @@ async fn head() {
         ..Default::default()
     };
     let cycles = cycles_cost(&args);
-    http_request(args, cycles).await.unwrap();
+    http_request(&args, cycles).await.unwrap();
 }
 
 /// The standard way to define a transform function.
@@ -101,7 +101,7 @@ async fn get_with_transform() {
         ..Default::default()
     };
     let cycles = cycles_cost(&args);
-    let res = http_request(args, cycles).await.unwrap();
+    let res = http_request(&args, cycles).await.unwrap();
     assert_eq!(res.status, 200u32);
     assert_eq!(
         res.headers,
@@ -134,7 +134,7 @@ async fn get_with_transform_closure() {
     };
     // The transform closure takes 40 bytes.
     let cycles = cycles_cost(&args) + 40 * 400 * 13;
-    let res = http_request_with_closure(args.clone(), cycles, transform)
+    let res = http_request_with_closure(&args, cycles, transform)
         .await
         .unwrap();
     assert_eq!(res.status, 200u32);

--- a/e2e-tests/src/bin/management_canister.rs
+++ b/e2e-tests/src/bin/management_canister.rs
@@ -21,14 +21,14 @@ async fn basic() {
     };
     // 500 B is the minimum cycles required to create a canister.
     // Here we set 1 T cycles for other operations below.
-    let canister_id = create_canister(arg, 1_000_000_000_000u128)
+    let canister_id = create_canister(&arg, 1_000_000_000_000u128)
         .await
         .unwrap()
         .canister_id;
 
     // canister_status
     let arg = CanisterStatusArgs { canister_id };
-    let result = canister_status(arg).await.unwrap();
+    let result = canister_status(&arg).await.unwrap();
     assert_eq!(result.status, CanisterStatusType::Running);
     assert_eq!(result.reserved_cycles.0, 0u128.into());
     let definite_canister_setting = result.settings;
@@ -52,7 +52,7 @@ async fn basic() {
             ..Default::default()
         },
     };
-    update_settings(arg).await.unwrap();
+    update_settings(&arg).await.unwrap();
 
     // install_code
     let arg = InstallCodeArgs {
@@ -63,27 +63,27 @@ async fn basic() {
         wasm_module: b"\x00asm\x01\x00\x00\x00".to_vec(),
         arg: vec![],
     };
-    install_code(arg).await.unwrap();
+    install_code(&arg).await.unwrap();
 
     // uninstall_code
     let arg = UninstallCodeArgs { canister_id };
-    uninstall_code(arg).await.unwrap();
+    uninstall_code(&arg).await.unwrap();
 
     // start_canister
     let arg = StartCanisterArgs { canister_id };
-    start_canister(arg).await.unwrap();
+    start_canister(&arg).await.unwrap();
 
     // stop_canister
     let arg = StopCanisterArgs { canister_id };
-    stop_canister(arg).await.unwrap();
+    stop_canister(&arg).await.unwrap();
 
     // deposit_cycles
     let arg = DepositCyclesArgs { canister_id };
-    deposit_cycles(arg, 1_000_000_000_000u128).await.unwrap();
+    deposit_cycles(&arg, 1_000_000_000_000u128).await.unwrap();
 
     // delete_canister
     let arg = DeleteCanisterArgs { canister_id };
-    delete_canister(arg).await.unwrap();
+    delete_canister(&arg).await.unwrap();
 
     // raw_rand
     let bytes = raw_rand().await.unwrap();
@@ -106,7 +106,7 @@ async fn ecdsa() {
     let EcdsaPublicKeyResult {
         public_key,
         chain_code,
-    } = ecdsa_public_key(arg).await.unwrap();
+    } = ecdsa_public_key(&arg).await.unwrap();
     assert_eq!(public_key.len(), 33);
     assert_eq!(chain_code.len(), 32);
 
@@ -117,7 +117,7 @@ async fn ecdsa() {
         derivation_path,
         key_id,
     };
-    let SignWithEcdsaResult { signature } = sign_with_ecdsa(arg).await.unwrap();
+    let SignWithEcdsaResult { signature } = sign_with_ecdsa(&arg).await.unwrap();
     assert_eq!(signature.len(), 64);
 }
 
@@ -137,7 +137,7 @@ async fn schnorr() {
     let SchnorrPublicKeyResult {
         public_key,
         chain_code,
-    } = schnorr_public_key(arg).await.unwrap();
+    } = schnorr_public_key(&arg).await.unwrap();
     assert_eq!(public_key.len(), 33);
     assert_eq!(chain_code.len(), 32);
     let arg = SchnorrPublicKeyArgs {
@@ -151,7 +151,7 @@ async fn schnorr() {
     let SchnorrPublicKeyResult {
         public_key,
         chain_code,
-    } = schnorr_public_key(arg).await.unwrap();
+    } = schnorr_public_key(&arg).await.unwrap();
     assert_eq!(public_key.len(), 32);
     assert_eq!(chain_code.len(), 32);
 
@@ -162,7 +162,7 @@ async fn schnorr() {
         derivation_path,
         key_id,
     };
-    let SignWithSchnorrResult { signature } = sign_with_schnorr(arg).await.unwrap();
+    let SignWithSchnorrResult { signature } = sign_with_schnorr(&arg).await.unwrap();
     assert_eq!(signature.len(), 64);
 }
 
@@ -173,7 +173,7 @@ async fn metrics(subnet_id: Principal) {
         subnet_id,
         start_at_timestamp_nanos: 0,
     };
-    let result = node_metrics_history(arg).await.unwrap();
+    let result = node_metrics_history(&arg).await.unwrap();
     for record in result {
         assert!(record.timestamp_nanos > 0);
         assert!(!record.node_metrics.is_empty());
@@ -184,7 +184,7 @@ async fn metrics(subnet_id: Principal) {
 async fn subnet(subnet_id: Principal) {
     // subnet_info
     let arg = SubnetInfoArgs { subnet_id };
-    let result = subnet_info(arg).await.unwrap();
+    let result = subnet_info(&arg).await.unwrap();
     assert!(!result.replica_version.is_empty());
 }
 
@@ -202,7 +202,7 @@ async fn provisional() {
             255, 255, 255, 255, 255, 209, 0, 0, 1, 1,
         ])),
     };
-    let canister_id = provisional_create_canister_with_cycles(arg)
+    let canister_id = provisional_create_canister_with_cycles(&arg)
         .await
         .unwrap()
         .canister_id;
@@ -212,13 +212,13 @@ async fn provisional() {
         canister_id,
         amount: 1_000_000_000u64.into(),
     };
-    provisional_top_up_canister(arg).await.unwrap();
+    provisional_top_up_canister(&arg).await.unwrap();
 }
 
 #[update]
 async fn snapshots() {
     let arg = CreateCanisterArgs::default();
-    let canister_id = create_canister(arg, 2_000_000_000_000u128)
+    let canister_id = create_canister(&arg, 2_000_000_000_000u128)
         .await
         .unwrap()
         .canister_id;
@@ -233,25 +233,25 @@ async fn snapshots() {
         wasm_module: b"\x00asm\x01\x00\x00\x00".to_vec(),
         arg: vec![],
     };
-    install_code(arg).await.unwrap();
+    install_code(&arg).await.unwrap();
 
     // take_canister_snapshot
     let arg = TakeCanisterSnapshotArgs {
         canister_id,
         replace_snapshot: None,
     };
-    let snapshot = take_canister_snapshot(arg).await.unwrap();
+    let snapshot = take_canister_snapshot(&arg).await.unwrap();
 
     // load_canister_snapshot
     let arg = LoadCanisterSnapshotArgs {
         canister_id,
         snapshot_id: snapshot.id.clone(),
     };
-    assert!(load_canister_snapshot(arg).await.is_ok());
+    assert!(load_canister_snapshot(&arg).await.is_ok());
 
     // list_canister_snapshots
     let args = ListCanisterSnapshotsArgs { canister_id };
-    let snapshots = list_canister_snapshots(args).await.unwrap();
+    let snapshots = list_canister_snapshots(&args).await.unwrap();
     assert_eq!(snapshots.len(), 1);
     assert_eq!(snapshots[0].id, snapshot.id);
 
@@ -260,14 +260,14 @@ async fn snapshots() {
         canister_id,
         snapshot_id: snapshot.id.clone(),
     };
-    assert!(delete_canister_snapshot(arg).await.is_ok());
+    assert!(delete_canister_snapshot(&arg).await.is_ok());
 
     // check the above snapshot operations are recorded in the canister's history.
     let arg = CanisterInfoArgs {
         canister_id,
         num_requested_changes: Some(1),
     };
-    let canister_info_result = canister_info(arg).await.unwrap();
+    let canister_info_result = canister_info(&arg).await.unwrap();
     assert_eq!(canister_info_result.total_num_changes, 3);
     assert_eq!(canister_info_result.recent_changes.len(), 1);
     if let Change {

--- a/e2e-tests/tests/call.rs
+++ b/e2e-tests/tests/call.rs
@@ -43,4 +43,12 @@ fn call() {
         (),
     )
     .unwrap();
+    let _: () = call_candid(
+        &pic,
+        canister_id,
+        RawEffectivePrincipal::None,
+        "retry_calls",
+        (),
+    )
+    .unwrap();
 }

--- a/ic-cdk-timers/src/lib.rs
+++ b/ic-cdk-timers/src/lib.rs
@@ -29,7 +29,7 @@ use std::{
 use futures::{stream::FuturesUnordered, StreamExt};
 use slotmap::{new_key_type, KeyData, SlotMap};
 
-use ic_cdk::call::{Call, RejectCode, SendableCall};
+use ic_cdk::call::{Call, RejectCode};
 
 // To ensure that tasks are removable seamlessly, there are two separate concepts here: tasks, for the actual function being called,
 // and timers, the scheduled execution of tasks. As this is an implementation detail, this does not affect the exported name TimerId,

--- a/ic-cdk-timers/src/lib.rs
+++ b/ic-cdk-timers/src/lib.rs
@@ -117,7 +117,7 @@ extern "C" fn global_timer() {
                                         ic_cdk::api::canister_self(),
                                         "<ic-cdk internal> timer_executor",
                                     )
-                                    .with_raw_args(&task_id.0.as_ffi().to_be_bytes().to_vec())
+                                    .with_raw_args(task_id.0.as_ffi().to_be_bytes().as_ref())
                                     .call_raw()
                                     .await,
                                 )

--- a/ic-cdk-timers/src/lib.rs
+++ b/ic-cdk-timers/src/lib.rs
@@ -117,7 +117,7 @@ extern "C" fn global_timer() {
                                         ic_cdk::api::canister_self(),
                                         "<ic-cdk internal> timer_executor",
                                     )
-                                    .with_raw_args(task_id.0.as_ffi().to_be_bytes().to_vec())
+                                    .with_raw_args(&task_id.0.as_ffi().to_be_bytes().to_vec())
                                     .call_raw()
                                     .await,
                                 )

--- a/ic-cdk/src/call.rs
+++ b/ic-cdk/src/call.rs
@@ -288,31 +288,34 @@ pub trait SendableCall {
     fn call_oneway(&self) -> SystemResult<()>;
 }
 
+/// Bytes for empty arguments.
+///
+/// `candid::Encode!(&()).unwrap()`
+const EMPTY_BYTES: &[u8] = &[0x44, 0x49, 0x44, 0x4c, 0x00, 0x00];
+
 impl SendableCall for Call<'_> {
     fn call_raw(&self) -> impl Future<Output = SystemResult<Vec<u8>>> + Send + Sync {
-        let args_raw = vec![0x44, 0x49, 0x44, 0x4c, 0x00, 0x00];
-        call_raw_internal::<Vec<u8>>(
+        call_raw_internal(
             self.canister_id,
             self.method,
-            args_raw,
+            EMPTY_BYTES,
             self.cycles,
             self.timeout_seconds,
         )
     }
 
     fn call_oneway(&self) -> SystemResult<()> {
-        let args_raw = vec![0x44, 0x49, 0x44, 0x4c, 0x00, 0x00];
-        call_oneway_internal::<Vec<u8>>(
+        call_oneway_internal(
             self.canister_id,
             self.method,
-            args_raw,
+            EMPTY_BYTES,
             self.cycles,
             self.timeout_seconds,
         )
     }
 }
 
-impl<'a,'b, T: ArgumentEncoder + Send + Sync> SendableCall for CallWithArgs<'a,'b, T> {
+impl<'a, 'b, T: ArgumentEncoder + Send + Sync> SendableCall for CallWithArgs<'a, 'b, T> {
     async fn call_raw(&self) -> SystemResult<Vec<u8>> {
         let args_raw = encode_args_ref(self.args).unwrap_or_else(panic_when_encode_fails);
         call_raw_internal(

--- a/ic-cdk/src/call.rs
+++ b/ic-cdk/src/call.rs
@@ -93,9 +93,9 @@ pub struct Call<'a> {
 ///
 /// The argument must impl [`CandidType`].
 #[derive(Debug)]
-pub struct CallWithArg<'a, T> {
+pub struct CallWithArg<'a, 'b, T> {
     call: Call<'a>,
-    arg: T,
+    arg: &'b T,
 }
 
 /// Inter-Canister Call with typed arguments.
@@ -135,7 +135,7 @@ impl<'a> Call<'a> {
     /// Sets the argument for the call.
     ///
     /// The argument must implement [`CandidType`].
-    pub fn with_arg<T>(self, arg: T) -> CallWithArg<'a, T> {
+    pub fn with_arg<'b, T>(self, arg: &'b T) -> CallWithArg<'a, 'b, T> {
         CallWithArg { call: self, arg }
     }
 
@@ -204,7 +204,7 @@ impl<'a> ConfigurableCall for Call<'a> {
     }
 }
 
-impl<'a, T> ConfigurableCall for CallWithArg<'a, T> {
+impl<'a, 'b, T> ConfigurableCall for CallWithArg<'a, 'b, T> {
     fn with_cycles(mut self, cycles: u128) -> Self {
         self.call.cycles = Some(cycles);
         self
@@ -339,7 +339,7 @@ impl<'a, T: ArgumentEncoder + Send + Sync> SendableCall for CallWithArgs<'a, T> 
     }
 }
 
-impl<'a, T: CandidType + Send + Sync> SendableCall for CallWithArg<'a, T> {
+impl<'a, 'b, T: CandidType + Send + Sync> SendableCall for CallWithArg<'a, 'b, T> {
     async fn call_raw(self) -> SystemResult<Vec<u8>> {
         let args_raw = encode_one(self.arg).unwrap_or_else(panic_when_encode_fails);
         call_raw_internal(

--- a/ic-cdk/src/lib.rs
+++ b/ic-cdk/src/lib.rs
@@ -12,8 +12,6 @@
 #[cfg(target_feature = "atomics")]
 compile_error!("This version of the CDK does not support multithreading.");
 
-pub mod prelude;
-
 pub mod api;
 pub mod call;
 mod futures;

--- a/ic-cdk/src/management_canister.rs
+++ b/ic-cdk/src/management_canister.rs
@@ -52,15 +52,15 @@ use ic_management_canister_types::{
 /// This call requires cycles payment. The required cycles varies according to the subnet size (number of nodes).
 /// Check [Gas and cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost) for more details.
 pub async fn create_canister(
-    arg: CreateCanisterArgs,
+    arg: &CreateCanisterArgs,
     cycles: u128,
 ) -> CallResult<CreateCanisterResult> {
     let complete_arg = CreateCanisterArgsComplete {
-        settings: arg.settings,
+        settings: arg.settings.clone(),
         sender_canister_version: Some(canister_version()),
     };
     Call::new(Principal::management_canister(), "create_canister")
-        .with_arg(complete_arg)
+        .with_arg(&complete_arg)
         .with_guaranteed_response()
         .with_cycles(cycles)
         .call()
@@ -85,14 +85,14 @@ pub struct CreateCanisterArgs {
 /// Updates the settings of a canister.
 ///
 /// See [IC method `update_settings`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-update_settings).
-pub async fn update_settings(arg: UpdateSettingsArgs) -> CallResult<()> {
+pub async fn update_settings(arg: &UpdateSettingsArgs) -> CallResult<()> {
     let complete_arg = UpdateSettingsArgsComplete {
         canister_id: arg.canister_id,
-        settings: arg.settings,
+        settings: arg.settings.clone(),
         sender_canister_version: Some(canister_version()),
     };
     Call::new(Principal::management_canister(), "update_settings")
-        .with_arg(complete_arg)
+        .with_arg(&complete_arg)
         .call()
         .await
 }
@@ -117,9 +117,9 @@ pub struct UpdateSettingsArgs {
 /// Uploads a chunk to the chunk store of a canister.
 ///
 /// See [IC method `upload_chunk`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-upload_chunk).
-pub async fn upload_chunk(arg: UploadChunkArgs) -> CallResult<UploadChunkResult> {
+pub async fn upload_chunk(arg: &UploadChunkArgs) -> CallResult<UploadChunkResult> {
     Call::new(Principal::management_canister(), "upload_chunk")
-        .with_arg(arg)
+        .with_arg(&arg)
         .call()
         .await
 }
@@ -127,9 +127,9 @@ pub async fn upload_chunk(arg: UploadChunkArgs) -> CallResult<UploadChunkResult>
 /// Clears the chunk store of a canister.
 ///
 /// See [IC method `clear_chunk_store`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-clear_chunk_store).
-pub async fn clear_chunk_store(arg: ClearChunkStoreArgs) -> CallResult<()> {
+pub async fn clear_chunk_store(arg: &ClearChunkStoreArgs) -> CallResult<()> {
     Call::new(Principal::management_canister(), "clear_chunk_store")
-        .with_arg(arg)
+        .with_arg(&arg)
         .call()
         .await
 }
@@ -137,9 +137,9 @@ pub async fn clear_chunk_store(arg: ClearChunkStoreArgs) -> CallResult<()> {
 /// Gets the hashes of all chunks stored in the chunk store of a canister.
 ///
 /// See [IC method `stored_chunks`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-stored_chunks).
-pub async fn stored_chunks(arg: StoredChunksArgs) -> CallResult<StoredChunksResult> {
+pub async fn stored_chunks(arg: &StoredChunksArgs) -> CallResult<StoredChunksResult> {
     Call::new(Principal::management_canister(), "stored_chunks")
-        .with_arg(arg)
+        .with_arg(&arg)
         .call()
         .await
 }
@@ -147,16 +147,16 @@ pub async fn stored_chunks(arg: StoredChunksArgs) -> CallResult<StoredChunksResu
 /// Installs code into a canister.
 ///
 /// See [IC method `install_code`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-install_code).
-pub async fn install_code(arg: InstallCodeArgs) -> CallResult<()> {
+pub async fn install_code(arg: &InstallCodeArgs) -> CallResult<()> {
     let complete_arg = InstallCodeArgsComplete {
         mode: arg.mode,
         canister_id: arg.canister_id,
-        wasm_module: arg.wasm_module,
-        arg: arg.arg,
+        wasm_module: arg.wasm_module.clone(),
+        arg: arg.arg.clone(),
         sender_canister_version: Some(canister_version()),
     };
     Call::new(Principal::management_canister(), "install_code")
-        .with_arg(complete_arg)
+        .with_arg(&complete_arg)
         .call()
         .await
 }
@@ -186,18 +186,18 @@ pub struct InstallCodeArgs {
 /// Installs code into a canister where the code has previously been uploaded in chunks.
 ///
 /// See [IC method `install_chunked_code`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-install_chunked_code).
-pub async fn install_chunked_code(arg: InstallChunkedCodeArgs) -> CallResult<()> {
+pub async fn install_chunked_code(arg: &InstallChunkedCodeArgs) -> CallResult<()> {
     let complete_arg = InstallChunkedCodeArgsComplete {
         mode: arg.mode,
         target_canister: arg.target_canister,
         store_canister: arg.store_canister,
-        chunk_hashes_list: arg.chunk_hashes_list,
-        wasm_module_hash: arg.wasm_module_hash,
-        arg: arg.arg,
+        chunk_hashes_list: arg.chunk_hashes_list.clone(),
+        wasm_module_hash: arg.wasm_module_hash.clone(),
+        arg: arg.arg.clone(),
         sender_canister_version: Some(canister_version()),
     };
     Call::new(Principal::management_canister(), "install_chunked_code")
-        .with_arg(complete_arg)
+        .with_arg(&complete_arg)
         .call()
         .await
 }
@@ -232,13 +232,13 @@ pub struct InstallChunkedCodeArgs {
 /// Removes a canister's code and state, making the canister empty again.
 ///
 /// See [IC method `uninstall_code`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-uninstall_code).
-pub async fn uninstall_code(arg: UninstallCodeArgs) -> CallResult<()> {
+pub async fn uninstall_code(arg: &UninstallCodeArgs) -> CallResult<()> {
     let complete_arg = UninstallCodeArgsComplete {
         canister_id: arg.canister_id,
         sender_canister_version: Some(canister_version()),
     };
     Call::new(Principal::management_canister(), "uninstall_code")
-        .with_arg(complete_arg)
+        .with_arg(&complete_arg)
         .call()
         .await
 }
@@ -261,9 +261,9 @@ pub struct UninstallCodeArgs {
 /// Starts a canister if the canister status was `stopped` or `stopping`.
 ///
 /// See [IC method `start_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-start_canister).
-pub async fn start_canister(arg: StartCanisterArgs) -> CallResult<()> {
+pub async fn start_canister(arg: &StartCanisterArgs) -> CallResult<()> {
     Call::new(Principal::management_canister(), "start_canister")
-        .with_arg(arg)
+        .with_arg(&arg)
         .call()
         .await
 }
@@ -271,9 +271,9 @@ pub async fn start_canister(arg: StartCanisterArgs) -> CallResult<()> {
 /// Stops a canister.
 ///
 /// See [IC method `stop_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-stop_canister).
-pub async fn stop_canister(arg: StopCanisterArgs) -> CallResult<()> {
+pub async fn stop_canister(arg: &StopCanisterArgs) -> CallResult<()> {
     Call::new(Principal::management_canister(), "stop_canister")
-        .with_arg(arg)
+        .with_arg(&arg)
         .call()
         .await
 }
@@ -281,9 +281,9 @@ pub async fn stop_canister(arg: StopCanisterArgs) -> CallResult<()> {
 /// Gets status information about the canister.
 ///
 /// See [IC method `canister_status`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-canister_status).
-pub async fn canister_status(arg: CanisterStatusArgs) -> CallResult<CanisterStatusResult> {
+pub async fn canister_status(arg: &CanisterStatusArgs) -> CallResult<CanisterStatusResult> {
     Call::new(Principal::management_canister(), "canister_status")
-        .with_arg(arg)
+        .with_arg(&arg)
         .call()
         .await
 }
@@ -291,9 +291,9 @@ pub async fn canister_status(arg: CanisterStatusArgs) -> CallResult<CanisterStat
 /// Gets public information about the canister.
 ///
 /// See [IC method `canister_info`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-canister_info).
-pub async fn canister_info(arg: CanisterInfoArgs) -> CallResult<CanisterInfoResult> {
+pub async fn canister_info(arg: &CanisterInfoArgs) -> CallResult<CanisterInfoResult> {
     Call::new(Principal::management_canister(), "canister_info")
-        .with_arg(arg)
+        .with_arg(&arg)
         .call()
         .await
 }
@@ -301,9 +301,9 @@ pub async fn canister_info(arg: CanisterInfoArgs) -> CallResult<CanisterInfoResu
 /// Deletes a canister.
 ///
 /// See [IC method `delete_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-delete_canister).
-pub async fn delete_canister(arg: DeleteCanisterArgs) -> CallResult<()> {
+pub async fn delete_canister(arg: &DeleteCanisterArgs) -> CallResult<()> {
     Call::new(Principal::management_canister(), "delete_canister")
-        .with_arg(arg)
+        .with_arg(&arg)
         .call()
         .await
 }
@@ -311,9 +311,9 @@ pub async fn delete_canister(arg: DeleteCanisterArgs) -> CallResult<()> {
 /// Deposits cycles to a canister.
 ///
 /// See [IC method `deposit_cycles`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-deposit_cycles).
-pub async fn deposit_cycles(arg: DepositCyclesArgs, cycles: u128) -> CallResult<()> {
+pub async fn deposit_cycles(arg: &DepositCyclesArgs, cycles: u128) -> CallResult<()> {
     Call::new(Principal::management_canister(), "deposit_cycles")
-        .with_arg(arg)
+        .with_arg(&arg)
         .with_guaranteed_response()
         .with_cycles(cycles)
         .call()
@@ -335,9 +335,9 @@ pub async fn raw_rand() -> CallResult<Vec<u8>> {
 ///
 /// This call requires cycles payment. The required cycles is a function of the request size and max_response_bytes.
 /// Check [HTTPS outcalls cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost#https-outcalls) for more details.
-pub async fn http_request(arg: HttpRequestArgs, cycles: u128) -> CallResult<HttpRequestResult> {
+pub async fn http_request(arg: &HttpRequestArgs, cycles: u128) -> CallResult<HttpRequestResult> {
     Call::new(Principal::management_canister(), "http_request")
-        .with_arg(arg)
+        .with_arg(&arg)
         .with_guaranteed_response()
         .with_cycles(cycles)
         .call()
@@ -404,7 +404,7 @@ mod transform_closure {
     /// Check [Gas and cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost) for more details.
     #[cfg_attr(docsrs, doc(cfg(feature = "transform-closure")))]
     pub async fn http_request_with_closure(
-        arg: HttpRequestArgs,
+        arg: &HttpRequestArgs,
         cycles: u128,
         transform_func: impl FnOnce(HttpRequestResult) -> HttpRequestResult + 'static,
     ) -> CallResult<HttpRequestResult> {
@@ -427,9 +427,9 @@ mod transform_closure {
                 "<ic-cdk internal> http_transform".to_string(),
                 context,
             )),
-            ..arg
+            ..arg.clone()
         };
-        http_request(arg, cycles).await
+        http_request(&arg, cycles).await
     }
 }
 
@@ -439,9 +439,9 @@ pub use transform_closure::http_request_with_closure;
 /// Gets a SEC1 encoded ECDSA public key for the given canister using the given derivation path.
 ///
 /// See [IC method `ecdsa_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-ecdsa_public_key).
-pub async fn ecdsa_public_key(arg: EcdsaPublicKeyArgs) -> CallResult<EcdsaPublicKeyResult> {
+pub async fn ecdsa_public_key(arg: &EcdsaPublicKeyArgs) -> CallResult<EcdsaPublicKeyResult> {
     Call::new(Principal::management_canister(), "ecdsa_public_key")
-        .with_arg(arg)
+        .with_arg(&arg)
         .call()
         .await
 }
@@ -453,9 +453,9 @@ pub async fn ecdsa_public_key(arg: EcdsaPublicKeyArgs) -> CallResult<EcdsaPublic
 /// This call requires cycles payment.
 /// This method handles the cycles cost under the hood.
 /// Check [Threshold signatures](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works) for more details.
-pub async fn sign_with_ecdsa(arg: SignWithEcdsaArgs) -> CallResult<SignWithEcdsaResult> {
+pub async fn sign_with_ecdsa(arg: &SignWithEcdsaArgs) -> CallResult<SignWithEcdsaResult> {
     Call::new(Principal::management_canister(), "sign_with_ecdsa")
-        .with_arg(arg)
+        .with_arg(&arg)
         .with_guaranteed_response()
         .with_cycles(SIGN_WITH_ECDSA_FEE)
         .call()
@@ -468,9 +468,9 @@ const SIGN_WITH_ECDSA_FEE: u128 = 26_153_846_153;
 /// Gets a SEC1 encoded Schnorr public key for the given canister using the given derivation path.
 ///
 /// See [IC method `schnorr_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-schnorr_public_key).
-pub async fn schnorr_public_key(arg: SchnorrPublicKeyArgs) -> CallResult<SchnorrPublicKeyResult> {
+pub async fn schnorr_public_key(arg: &SchnorrPublicKeyArgs) -> CallResult<SchnorrPublicKeyResult> {
     Call::new(Principal::management_canister(), "schnorr_public_key")
-        .with_arg(arg)
+        .with_arg(&arg)
         .call()
         .await
 }
@@ -482,9 +482,9 @@ pub async fn schnorr_public_key(arg: SchnorrPublicKeyArgs) -> CallResult<Schnorr
 /// This call requires cycles payment.
 /// This method handles the cycles cost under the hood.
 /// Check [Threshold signatures](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works) for more details.
-pub async fn sign_with_schnorr(arg: SignWithSchnorrArgs) -> CallResult<SignWithSchnorrResult> {
+pub async fn sign_with_schnorr(arg: &SignWithSchnorrArgs) -> CallResult<SignWithSchnorrResult> {
     Call::new(Principal::management_canister(), "sign_with_schnorr")
-        .with_arg(arg)
+        .with_arg(&arg)
         .with_guaranteed_response()
         .with_cycles(SIGN_WITH_SCHNORR_FEE)
         .call()
@@ -500,10 +500,10 @@ const SIGN_WITH_SCHNORR_FEE: u128 = 26_153_846_153;
 // ! The actual url ends with `ic-node-metrics-history` instead of `ic-node_metrics_history`.
 // ! It will likely be changed to be consistent with the other methods soon.
 pub async fn node_metrics_history(
-    arg: NodeMetricsHistoryArgs,
+    arg: &NodeMetricsHistoryArgs,
 ) -> CallResult<NodeMetricsHistoryResult> {
     Call::new(Principal::management_canister(), "node_metrics_history")
-        .with_arg(arg)
+        .with_arg(&arg)
         .call()
         .await
 }
@@ -513,9 +513,9 @@ pub async fn node_metrics_history(
 /// See [IC method `subnet_info`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-subnet_info).
 // ! The actual url ends with `ic-subnet-info` instead of `ic-subnet_info`.
 // ! It will likely be changed to be consistent with the other methods soon.
-pub async fn subnet_info(arg: SubnetInfoArgs) -> CallResult<SubnetInfoResult> {
+pub async fn subnet_info(arg: &SubnetInfoArgs) -> CallResult<SubnetInfoResult> {
     Call::new(Principal::management_canister(), "subnet_info")
-        .with_arg(arg)
+        .with_arg(&arg)
         .call()
         .await
 }
@@ -526,11 +526,11 @@ pub async fn subnet_info(arg: SubnetInfoArgs) -> CallResult<SubnetInfoResult> {
 ///
 /// See [IC method `provisional_create_canister_with_cycles`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-provisional_create_canister_with_cycles).
 pub async fn provisional_create_canister_with_cycles(
-    arg: ProvisionalCreateCanisterWithCyclesArgs,
+    arg: &ProvisionalCreateCanisterWithCyclesArgs,
 ) -> CallResult<ProvisionalCreateCanisterWithCyclesResult> {
     let complete_arg = ProvisionalCreateCanisterWithCyclesArgsComplete {
-        amount: arg.amount,
-        settings: arg.settings,
+        amount: arg.amount.clone(),
+        settings: arg.settings.clone(),
         specified_id: arg.specified_id,
         sender_canister_version: Some(canister_version()),
     };
@@ -538,7 +538,7 @@ pub async fn provisional_create_canister_with_cycles(
         Principal::management_canister(),
         "provisional_create_canister_with_cycles",
     )
-    .with_arg(complete_arg)
+    .with_arg(&complete_arg)
     .with_guaranteed_response()
     .call()
     .await
@@ -568,12 +568,12 @@ pub struct ProvisionalCreateCanisterWithCyclesArgs {
 /// This method is only available in local development instances.
 ///
 /// See [IC method `provisional_top_up_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-provisional_top_up_canister).
-pub async fn provisional_top_up_canister(arg: ProvisionalTopUpCanisterArgs) -> CallResult<()> {
+pub async fn provisional_top_up_canister(arg: &ProvisionalTopUpCanisterArgs) -> CallResult<()> {
     Call::new(
         Principal::management_canister(),
         "provisional_top_up_canister",
     )
-    .with_arg(arg)
+    .with_arg(&arg)
     .with_guaranteed_response()
     .call()
     .await
@@ -585,10 +585,10 @@ pub async fn provisional_top_up_canister(arg: ProvisionalTopUpCanisterArgs) -> C
 ///
 /// See [IC method `take_canister_snapshot`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-take_canister_snapshot).
 pub async fn take_canister_snapshot(
-    arg: TakeCanisterSnapshotArgs,
+    arg: &TakeCanisterSnapshotArgs,
 ) -> CallResult<TakeCanisterSnapshotReturn> {
     Call::new(Principal::management_canister(), "take_canister_snapshot")
-        .with_arg(arg)
+        .with_arg(&arg)
         .with_guaranteed_response()
         .call()
         .await
@@ -599,14 +599,14 @@ pub async fn take_canister_snapshot(
 /// It fails if no snapshot with the specified `snapshot_id` can be found.
 ///
 /// See [IC method `load_canister_snapshot`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-load_canister_snapshot).
-pub async fn load_canister_snapshot(arg: LoadCanisterSnapshotArgs) -> CallResult<()> {
+pub async fn load_canister_snapshot(arg: &LoadCanisterSnapshotArgs) -> CallResult<()> {
     let complete_arg = LoadCanisterSnapshotArgsComplete {
         canister_id: arg.canister_id,
-        snapshot_id: arg.snapshot_id,
+        snapshot_id: arg.snapshot_id.clone(),
         sender_canister_version: Some(canister_version()),
     };
     Call::new(Principal::management_canister(), "load_canister_snapshot")
-        .with_arg(complete_arg)
+        .with_arg(&complete_arg)
         .with_guaranteed_response()
         .call()
         .await
@@ -633,10 +633,10 @@ pub struct LoadCanisterSnapshotArgs {
 ///
 /// See [IC method `list_canister_snapshots`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-list_canister_snapshots).
 pub async fn list_canister_snapshots(
-    arg: ListCanisterSnapshotsArgs,
+    arg: &ListCanisterSnapshotsArgs,
 ) -> CallResult<ListCanisterSnapshotsReturn> {
     Call::new(Principal::management_canister(), "list_canister_snapshots")
-        .with_arg(arg)
+        .with_arg(&arg)
         .call()
         .await
 }
@@ -646,9 +646,9 @@ pub async fn list_canister_snapshots(
 /// An error will be returned if the snapshot is not found.
 ///
 /// See [IC method `delete_canister_snapshot`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-delete_canister_snapshot).
-pub async fn delete_canister_snapshot(arg: DeleteCanisterSnapshotArgs) -> CallResult<()> {
+pub async fn delete_canister_snapshot(arg: &DeleteCanisterSnapshotArgs) -> CallResult<()> {
     Call::new(Principal::management_canister(), "delete_canister_snapshot")
-        .with_arg(arg)
+        .with_arg(&arg)
         .call()
         .await
 }

--- a/ic-cdk/src/management_canister.rs
+++ b/ic-cdk/src/management_canister.rs
@@ -10,7 +10,7 @@
 //! [1]: https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-management-canister
 
 use crate::api::canister_version;
-use crate::call::{Call, CallResult, ConfigurableCall, SendableCall};
+use crate::call::{Call, CallResult};
 use candid::{CandidType, Nat, Principal};
 use serde::{Deserialize, Serialize};
 

--- a/ic-cdk/src/management_canister.rs
+++ b/ic-cdk/src/management_canister.rs
@@ -119,7 +119,7 @@ pub struct UpdateSettingsArgs {
 /// See [IC method `upload_chunk`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-upload_chunk).
 pub async fn upload_chunk(arg: &UploadChunkArgs) -> CallResult<UploadChunkResult> {
     Call::new(Principal::management_canister(), "upload_chunk")
-        .with_arg(&arg)
+        .with_arg(arg)
         .call()
         .await
 }
@@ -129,7 +129,7 @@ pub async fn upload_chunk(arg: &UploadChunkArgs) -> CallResult<UploadChunkResult
 /// See [IC method `clear_chunk_store`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-clear_chunk_store).
 pub async fn clear_chunk_store(arg: &ClearChunkStoreArgs) -> CallResult<()> {
     Call::new(Principal::management_canister(), "clear_chunk_store")
-        .with_arg(&arg)
+        .with_arg(arg)
         .call()
         .await
 }
@@ -139,7 +139,7 @@ pub async fn clear_chunk_store(arg: &ClearChunkStoreArgs) -> CallResult<()> {
 /// See [IC method `stored_chunks`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-stored_chunks).
 pub async fn stored_chunks(arg: &StoredChunksArgs) -> CallResult<StoredChunksResult> {
     Call::new(Principal::management_canister(), "stored_chunks")
-        .with_arg(&arg)
+        .with_arg(arg)
         .call()
         .await
 }
@@ -263,7 +263,7 @@ pub struct UninstallCodeArgs {
 /// See [IC method `start_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-start_canister).
 pub async fn start_canister(arg: &StartCanisterArgs) -> CallResult<()> {
     Call::new(Principal::management_canister(), "start_canister")
-        .with_arg(&arg)
+        .with_arg(arg)
         .call()
         .await
 }
@@ -273,7 +273,7 @@ pub async fn start_canister(arg: &StartCanisterArgs) -> CallResult<()> {
 /// See [IC method `stop_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-stop_canister).
 pub async fn stop_canister(arg: &StopCanisterArgs) -> CallResult<()> {
     Call::new(Principal::management_canister(), "stop_canister")
-        .with_arg(&arg)
+        .with_arg(arg)
         .call()
         .await
 }
@@ -283,7 +283,7 @@ pub async fn stop_canister(arg: &StopCanisterArgs) -> CallResult<()> {
 /// See [IC method `canister_status`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-canister_status).
 pub async fn canister_status(arg: &CanisterStatusArgs) -> CallResult<CanisterStatusResult> {
     Call::new(Principal::management_canister(), "canister_status")
-        .with_arg(&arg)
+        .with_arg(arg)
         .call()
         .await
 }
@@ -293,7 +293,7 @@ pub async fn canister_status(arg: &CanisterStatusArgs) -> CallResult<CanisterSta
 /// See [IC method `canister_info`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-canister_info).
 pub async fn canister_info(arg: &CanisterInfoArgs) -> CallResult<CanisterInfoResult> {
     Call::new(Principal::management_canister(), "canister_info")
-        .with_arg(&arg)
+        .with_arg(arg)
         .call()
         .await
 }
@@ -303,7 +303,7 @@ pub async fn canister_info(arg: &CanisterInfoArgs) -> CallResult<CanisterInfoRes
 /// See [IC method `delete_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-delete_canister).
 pub async fn delete_canister(arg: &DeleteCanisterArgs) -> CallResult<()> {
     Call::new(Principal::management_canister(), "delete_canister")
-        .with_arg(&arg)
+        .with_arg(arg)
         .call()
         .await
 }
@@ -313,7 +313,7 @@ pub async fn delete_canister(arg: &DeleteCanisterArgs) -> CallResult<()> {
 /// See [IC method `deposit_cycles`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-deposit_cycles).
 pub async fn deposit_cycles(arg: &DepositCyclesArgs, cycles: u128) -> CallResult<()> {
     Call::new(Principal::management_canister(), "deposit_cycles")
-        .with_arg(&arg)
+        .with_arg(arg)
         .with_guaranteed_response()
         .with_cycles(cycles)
         .call()
@@ -337,7 +337,7 @@ pub async fn raw_rand() -> CallResult<Vec<u8>> {
 /// Check [HTTPS outcalls cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost#https-outcalls) for more details.
 pub async fn http_request(arg: &HttpRequestArgs, cycles: u128) -> CallResult<HttpRequestResult> {
     Call::new(Principal::management_canister(), "http_request")
-        .with_arg(&arg)
+        .with_arg(arg)
         .with_guaranteed_response()
         .with_cycles(cycles)
         .call()
@@ -441,7 +441,7 @@ pub use transform_closure::http_request_with_closure;
 /// See [IC method `ecdsa_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-ecdsa_public_key).
 pub async fn ecdsa_public_key(arg: &EcdsaPublicKeyArgs) -> CallResult<EcdsaPublicKeyResult> {
     Call::new(Principal::management_canister(), "ecdsa_public_key")
-        .with_arg(&arg)
+        .with_arg(arg)
         .call()
         .await
 }
@@ -455,7 +455,7 @@ pub async fn ecdsa_public_key(arg: &EcdsaPublicKeyArgs) -> CallResult<EcdsaPubli
 /// Check [Threshold signatures](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works) for more details.
 pub async fn sign_with_ecdsa(arg: &SignWithEcdsaArgs) -> CallResult<SignWithEcdsaResult> {
     Call::new(Principal::management_canister(), "sign_with_ecdsa")
-        .with_arg(&arg)
+        .with_arg(arg)
         .with_guaranteed_response()
         .with_cycles(SIGN_WITH_ECDSA_FEE)
         .call()
@@ -470,7 +470,7 @@ const SIGN_WITH_ECDSA_FEE: u128 = 26_153_846_153;
 /// See [IC method `schnorr_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-schnorr_public_key).
 pub async fn schnorr_public_key(arg: &SchnorrPublicKeyArgs) -> CallResult<SchnorrPublicKeyResult> {
     Call::new(Principal::management_canister(), "schnorr_public_key")
-        .with_arg(&arg)
+        .with_arg(arg)
         .call()
         .await
 }
@@ -484,7 +484,7 @@ pub async fn schnorr_public_key(arg: &SchnorrPublicKeyArgs) -> CallResult<Schnor
 /// Check [Threshold signatures](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works) for more details.
 pub async fn sign_with_schnorr(arg: &SignWithSchnorrArgs) -> CallResult<SignWithSchnorrResult> {
     Call::new(Principal::management_canister(), "sign_with_schnorr")
-        .with_arg(&arg)
+        .with_arg(arg)
         .with_guaranteed_response()
         .with_cycles(SIGN_WITH_SCHNORR_FEE)
         .call()
@@ -503,7 +503,7 @@ pub async fn node_metrics_history(
     arg: &NodeMetricsHistoryArgs,
 ) -> CallResult<NodeMetricsHistoryResult> {
     Call::new(Principal::management_canister(), "node_metrics_history")
-        .with_arg(&arg)
+        .with_arg(arg)
         .call()
         .await
 }
@@ -515,7 +515,7 @@ pub async fn node_metrics_history(
 // ! It will likely be changed to be consistent with the other methods soon.
 pub async fn subnet_info(arg: &SubnetInfoArgs) -> CallResult<SubnetInfoResult> {
     Call::new(Principal::management_canister(), "subnet_info")
-        .with_arg(&arg)
+        .with_arg(arg)
         .call()
         .await
 }
@@ -573,7 +573,7 @@ pub async fn provisional_top_up_canister(arg: &ProvisionalTopUpCanisterArgs) -> 
         Principal::management_canister(),
         "provisional_top_up_canister",
     )
-    .with_arg(&arg)
+    .with_arg(arg)
     .with_guaranteed_response()
     .call()
     .await
@@ -588,7 +588,7 @@ pub async fn take_canister_snapshot(
     arg: &TakeCanisterSnapshotArgs,
 ) -> CallResult<TakeCanisterSnapshotReturn> {
     Call::new(Principal::management_canister(), "take_canister_snapshot")
-        .with_arg(&arg)
+        .with_arg(arg)
         .with_guaranteed_response()
         .call()
         .await
@@ -636,7 +636,7 @@ pub async fn list_canister_snapshots(
     arg: &ListCanisterSnapshotsArgs,
 ) -> CallResult<ListCanisterSnapshotsReturn> {
     Call::new(Principal::management_canister(), "list_canister_snapshots")
-        .with_arg(&arg)
+        .with_arg(arg)
         .call()
         .await
 }
@@ -648,7 +648,7 @@ pub async fn list_canister_snapshots(
 /// See [IC method `delete_canister_snapshot`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-delete_canister_snapshot).
 pub async fn delete_canister_snapshot(arg: &DeleteCanisterSnapshotArgs) -> CallResult<()> {
     Call::new(Principal::management_canister(), "delete_canister_snapshot")
-        .with_arg(&arg)
+        .with_arg(arg)
         .call()
         .await
 }

--- a/ic-cdk/src/prelude.rs
+++ b/ic-cdk/src/prelude.rs
@@ -1,7 +1,0 @@
-//! The prelude module contains the most commonly used types and traits.
-pub use crate::api::{canister_self, debug_print, msg_caller, trap};
-pub use crate::call::Call;
-pub use crate::macros::{
-    export_candid, heartbeat, init, inspect_message, post_upgrade, pre_upgrade, query, update,
-};
-pub use crate::{eprintln, println, setup, spawn};

--- a/ic-cdk/src/prelude.rs
+++ b/ic-cdk/src/prelude.rs
@@ -1,6 +1,6 @@
 //! The prelude module contains the most commonly used types and traits.
 pub use crate::api::{canister_self, debug_print, msg_caller, trap};
-pub use crate::call::{Call, ConfigurableCall, SendableCall};
+pub use crate::call::Call;
 pub use crate::macros::{
     export_candid, heartbeat, init, inspect_message, post_upgrade, pre_upgrade, query, update,
 };

--- a/library/ic-ledger-types/src/lib.rs
+++ b/library/ic-ledger-types/src/lib.rs
@@ -681,7 +681,7 @@ impl CandidType for QueryArchiveFn {
 /// async fn check_callers_balance() -> Tokens {
 ///   account_balance(
 ///     MAINNET_LEDGER_CANISTER_ID,
-///     AccountBalanceArgs {
+///     &AccountBalanceArgs {
 ///       account: AccountIdentifier::new(&msg_caller(), &DEFAULT_SUBACCOUNT)
 ///     }
 ///   ).await.expect("call to ledger failed")
@@ -689,7 +689,7 @@ impl CandidType for QueryArchiveFn {
 /// ```
 pub async fn account_balance(
     ledger_canister_id: Principal,
-    args: AccountBalanceArgs,
+    args: &AccountBalanceArgs,
 ) -> CallResult<Tokens> {
     Call::new(ledger_canister_id, "account_balance")
         .with_arg(args)
@@ -719,10 +719,10 @@ pub async fn account_balance(
 /// ```
 pub async fn transfer(
     ledger_canister_id: Principal,
-    args: TransferArgs,
+    args: &TransferArgs,
 ) -> CallResult<TransferResult> {
     Call::new(ledger_canister_id, "transfer")
-        .with_arg(args)
+        .with_arg(&args)
         .call()
         .await
 }
@@ -758,7 +758,7 @@ pub async fn token_symbol(ledger_canister_id: Principal) -> CallResult<Symbol> {
 /// async fn query_one_block(ledger: Principal, block_index: BlockIndex) -> CallResult<Option<Block>> {
 ///   let args = GetBlocksArgs { start: block_index, length: 1 };
 ///
-///   let blocks_result = query_blocks(ledger, args.clone()).await?;
+///   let blocks_result = query_blocks(ledger, &args).await?;
 ///
 ///   if blocks_result.blocks.len() >= 1 {
 ///       debug_assert_eq!(blocks_result.first_block_index, block_index);
@@ -769,7 +769,7 @@ pub async fn token_symbol(ledger_canister_id: Principal) -> CallResult<Symbol> {
 ///       .archived_blocks
 ///       .into_iter()
 ///       .find_map(|b| (b.start <= block_index && (block_index - b.start) < b.length).then(|| b.callback)) {
-///       match query_archived_blocks(&func, args).await? {
+///       match query_archived_blocks(&func, &args).await? {
 ///           Ok(range) => return Ok(range.blocks.into_iter().next()),
 ///           _ => (),
 ///       }
@@ -778,7 +778,7 @@ pub async fn token_symbol(ledger_canister_id: Principal) -> CallResult<Symbol> {
 /// }
 pub async fn query_blocks(
     ledger_canister_id: Principal,
-    args: GetBlocksArgs,
+    args: &GetBlocksArgs,
 ) -> CallResult<QueryBlocksResponse> {
     Call::new(ledger_canister_id, "query_blocks")
         .with_arg(args)
@@ -798,7 +798,7 @@ pub async fn query_blocks(
 /// async fn query_one_block(ledger: Principal, block_index: BlockIndex) -> CallResult<Option<Block>> {
 ///   let args = GetBlocksArgs { start: block_index, length: 1 };
 ///
-///   let blocks_result = query_blocks(ledger, args.clone()).await?;
+///   let blocks_result = query_blocks(ledger, &args).await?;
 ///
 ///   if blocks_result.blocks.len() >= 1 {
 ///       debug_assert_eq!(blocks_result.first_block_index, block_index);
@@ -809,7 +809,7 @@ pub async fn query_blocks(
 ///       .archived_blocks
 ///       .into_iter()
 ///       .find_map(|b| (b.start <= block_index && (block_index - b.start) < b.length).then(|| b.callback)) {
-///       match query_archived_blocks(&func, args).await? {
+///       match query_archived_blocks(&func, &args).await? {
 ///           Ok(range) => return Ok(range.blocks.into_iter().next()),
 ///           _ => (),
 ///       }
@@ -818,7 +818,7 @@ pub async fn query_blocks(
 /// }
 pub async fn query_archived_blocks(
     func: &QueryArchiveFn,
-    args: GetBlocksArgs,
+    args: &GetBlocksArgs,
 ) -> CallResult<GetBlocksResult> {
     Call::new(func.0.principal, &func.0.method)
         .with_arg(args)

--- a/library/ic-ledger-types/src/lib.rs
+++ b/library/ic-ledger-types/src/lib.rs
@@ -706,7 +706,7 @@ pub async fn account_balance(
 /// async fn transfer_to_caller() -> BlockIndex {
 ///   transfer(
 ///     MAINNET_LEDGER_CANISTER_ID,
-///     TransferArgs {
+///     &TransferArgs {
 ///       memo: Memo(0),
 ///       amount: Tokens::from_e8s(1_000_000),
 ///       fee: DEFAULT_FEE,

--- a/library/ic-ledger-types/src/lib.rs
+++ b/library/ic-ledger-types/src/lib.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 use sha2::Digest;
 
-use ic_cdk::call::{Call, CallResult, SendableCall};
+use ic_cdk::call::{Call, CallResult};
 
 /// The subaccount that is used by default.
 pub const DEFAULT_SUBACCOUNT: Subaccount = Subaccount([0; 32]);

--- a/library/ic-ledger-types/src/lib.rs
+++ b/library/ic-ledger-types/src/lib.rs
@@ -722,7 +722,7 @@ pub async fn transfer(
     args: &TransferArgs,
 ) -> CallResult<TransferResult> {
     Call::new(ledger_canister_id, "transfer")
-        .with_arg(&args)
+        .with_arg(args)
         .call()
         .await
 }


### PR DESCRIPTION
SDK-1948

# Description

Previously, such call retry logic is not possible:

```rust
async fn retry<C: SendableCall>(call_to_retry: C) {
    loop {
        match call_to_retry.call_raw().await {
            // handle
        }
    }
}
```

Now the implementation is simplified that `CallWith*` structs, `ConfigurableCall` and `SendableCall` traits/impls are removed. As a result, the `prelude` module is removed which was mainly for importing the two `*Call` traits.

The arguments are encoded once in `with_arg` and `with_args`, only the `encoded_args` is saved in the `Call` struct.
Therefore, the call can be sent multiple times.

```rust
async fn retry(call_to_retry: Call<'_, '_>) {
    loop {
        match call_to_retry.call_raw().await {
            // handle
        }
    }
}
```

> This PR relies on https://github.com/dfinity/candid/pull/593.
> We need to wait for a Candid release once it's merged.
> Then we can update the candid dependency in `Cargo.toml`.
This is Done.

# How Has This Been Tested?

Added `retry_calls` in e2e-test/call.rs

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
