### PR TITLE
feat: Call constructors best_effort & guaranteed

### DIFF
--- a/e2e-tests/src/bin/api.rs
+++ b/e2e-tests/src/bin/api.rs
@@ -21,13 +21,13 @@ fn call_msg_caller() {
 async fn call_msg_deadline_caller() {
     use ic_cdk::call::Call;
     // Call with best-effort responses.
-    let reply1 = Call::new(canister_self(), "call_msg_deadline")
+    let reply1 = Call::best_effort(canister_self(), "call_msg_deadline")
         .call_raw()
         .await
         .unwrap();
     assert_eq!(reply1, vec![1]);
     // Call with guaranteed responses.
-    let reply1 = Call::new(canister_self(), "call_msg_deadline")
+    let reply1 = Call::best_effort(canister_self(), "call_msg_deadline")
         .with_guaranteed_response()
         .call_raw()
         .await

--- a/e2e-tests/src/bin/api.rs
+++ b/e2e-tests/src/bin/api.rs
@@ -27,8 +27,7 @@ async fn call_msg_deadline_caller() {
         .unwrap();
     assert_eq!(reply1, vec![1]);
     // Call with guaranteed responses.
-    let reply1 = Call::best_effort(canister_self(), "call_msg_deadline")
-        .with_guaranteed_response()
+    let reply1 = Call::guaranteed(canister_self(), "call_msg_deadline")
         .call_raw()
         .await
         .unwrap();

--- a/e2e-tests/src/bin/async.rs
+++ b/e2e-tests/src/bin/async.rs
@@ -32,7 +32,7 @@ async fn panic_after_async() {
     let value = *lock;
     // Do not drop the lock before the await point.
 
-    let _: u64 = Call::new(ic_cdk::api::canister_self(), "inc")
+    let _: u64 = Call::best_effort(ic_cdk::api::canister_self(), "inc")
         .with_arg(value)
         .call()
         .await
@@ -50,7 +50,7 @@ async fn panic_twice() {
 }
 
 async fn async_then_panic() {
-    let _: u64 = Call::new(ic_cdk::api::canister_self(), "on_notify")
+    let _: u64 = Call::best_effort(ic_cdk::api::canister_self(), "on_notify")
         .call()
         .await
         .unwrap();
@@ -69,7 +69,7 @@ fn on_notify() {
 
 #[update]
 fn notify(whom: Principal, method: String) {
-    Call::new(whom, method.as_str())
+    Call::best_effort(whom, method.as_str())
         .call_oneway()
         .unwrap_or_else(|reject| {
             ic_cdk::api::trap(format!(
@@ -86,7 +86,7 @@ fn greet(name: String) -> String {
 
 #[query(composite = true)]
 async fn greet_self(greeter: Principal) -> String {
-    Call::new(greeter, "greet")
+    Call::best_effort(greeter, "greet")
         .with_arg("myself")
         .call()
         .await
@@ -96,7 +96,7 @@ async fn greet_self(greeter: Principal) -> String {
 #[update]
 async fn invalid_reply_payload_does_not_trap() -> String {
     // We're decoding an integer instead of a string, decoding must fail.
-    let result: CallResult<u64> = Call::new(ic_cdk::api::canister_self(), "greet")
+    let result: CallResult<u64> = Call::best_effort(ic_cdk::api::canister_self(), "greet")
         .with_arg("World")
         .call()
         .await;

--- a/e2e-tests/src/bin/call.rs
+++ b/e2e-tests/src/bin/call.rs
@@ -15,30 +15,38 @@ async fn call_foo() {
     let n = 0u32;
     let bytes = Encode!(&n).unwrap();
 
-    let res: u32 = Call::new(canister_self(), "foo").call().await.unwrap();
+    let res: u32 = Call::best_effort(canister_self(), "foo")
+        .call()
+        .await
+        .unwrap();
     assert_eq!(res, n);
-    let res: (u32,) = Call::new(canister_self(), "foo")
+    let res: (u32,) = Call::best_effort(canister_self(), "foo")
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res = Call::new(canister_self(), "foo").call_raw().await.unwrap();
+    let res = Call::best_effort(canister_self(), "foo")
+        .call_raw()
+        .await
+        .unwrap();
     assert_eq!(res, bytes);
-    Call::new(canister_self(), "foo").call_oneway().unwrap();
+    Call::best_effort(canister_self(), "foo")
+        .call_oneway()
+        .unwrap();
 
-    let res: (u32,) = Call::new(canister_self(), "foo")
+    let res: (u32,) = Call::best_effort(canister_self(), "foo")
         .with_guaranteed_response()
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res: (u32,) = Call::new(canister_self(), "foo")
+    let res: (u32,) = Call::best_effort(canister_self(), "foo")
         .change_timeout(5)
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res: (u32,) = Call::new(canister_self(), "foo")
+    let res: (u32,) = Call::best_effort(canister_self(), "foo")
         .with_cycles(1000)
         .call_tuple()
         .await
@@ -58,44 +66,44 @@ async fn call_echo_with_arg() {
     let n = 1u32;
     let bytes = Encode!(&n).unwrap();
     // call*
-    let res: u32 = Call::new(canister_self(), "echo")
+    let res: u32 = Call::best_effort(canister_self(), "echo")
         .with_arg(n)
         .call()
         .await
         .unwrap();
     assert_eq!(res, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::best_effort(canister_self(), "echo")
         .with_arg(n)
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res = Call::new(canister_self(), "echo")
+    let res = Call::best_effort(canister_self(), "echo")
         .with_arg(n)
         .call_raw()
         .await
         .unwrap();
     assert_eq!(res, bytes);
-    Call::new(canister_self(), "echo")
+    Call::best_effort(canister_self(), "echo")
         .with_arg(n)
         .call_oneway()
         .unwrap();
     // with*
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::best_effort(canister_self(), "echo")
         .with_arg(n)
         .with_guaranteed_response()
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::best_effort(canister_self(), "echo")
         .with_arg(n)
         .change_timeout(5)
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::best_effort(canister_self(), "echo")
         .with_arg(n)
         .with_cycles(1000)
         .call_tuple()
@@ -110,44 +118,44 @@ async fn call_echo_with_args() {
     let n = 1u32;
     let bytes = Encode!(&n).unwrap();
     // call*
-    let res: u32 = Call::new(canister_self(), "echo")
+    let res: u32 = Call::best_effort(canister_self(), "echo")
         .with_args(&(n,))
         .call()
         .await
         .unwrap();
     assert_eq!(res, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::best_effort(canister_self(), "echo")
         .with_args(&(n,))
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res = Call::new(canister_self(), "echo")
+    let res = Call::best_effort(canister_self(), "echo")
         .with_args(&(n,))
         .call_raw()
         .await
         .unwrap();
     assert_eq!(res, bytes);
-    Call::new(canister_self(), "echo")
+    Call::best_effort(canister_self(), "echo")
         .with_args(&(n,))
         .call_oneway()
         .unwrap();
     // with*
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::best_effort(canister_self(), "echo")
         .with_args(&(n,))
         .with_guaranteed_response()
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::best_effort(canister_self(), "echo")
         .with_args(&(n,))
         .change_timeout(5)
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::best_effort(canister_self(), "echo")
         .with_args(&(n,))
         .with_cycles(1000)
         .call_tuple()
@@ -162,44 +170,44 @@ async fn call_echo_with_raw_args() {
     let n = 1u32;
     let bytes: Vec<u8> = Encode!(&n).unwrap();
     // call*
-    let res: u32 = Call::new(canister_self(), "echo")
+    let res: u32 = Call::best_effort(canister_self(), "echo")
         .with_raw_args(&bytes)
         .call()
         .await
         .unwrap();
     assert_eq!(res, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::best_effort(canister_self(), "echo")
         .with_raw_args(&bytes)
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res = Call::new(canister_self(), "echo")
+    let res = Call::best_effort(canister_self(), "echo")
         .with_raw_args(&bytes)
         .call_raw()
         .await
         .unwrap();
     assert_eq!(res, bytes);
-    Call::new(canister_self(), "echo")
+    Call::best_effort(canister_self(), "echo")
         .with_raw_args(&bytes)
         .call_oneway()
         .unwrap();
     // with*
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::best_effort(canister_self(), "echo")
         .with_raw_args(&bytes)
         .with_guaranteed_response()
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::best_effort(canister_self(), "echo")
         .with_raw_args(&bytes)
         .change_timeout(5)
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::best_effort(canister_self(), "echo")
         .with_raw_args(&bytes)
         .with_cycles(1000)
         .call_tuple()
@@ -228,15 +236,15 @@ async fn retry(call_to_retry: Call<'_, '_>) -> u32 {
 #[update]
 async fn retry_calls() {
     let n: u32 = 1u32;
-    let call = Call::new(canister_self(), "foo");
+    let call = Call::best_effort(canister_self(), "foo");
     assert_eq!(retry(call).await, 0);
-    let call_with_arg = Call::new(canister_self(), "echo").with_arg(n);
+    let call_with_arg = Call::best_effort(canister_self(), "echo").with_arg(n);
     assert_eq!(retry(call_with_arg).await, 0);
     let args = (n,);
-    let call_with_args = Call::new(canister_self(), "echo").with_args(&args);
+    let call_with_args = Call::best_effort(canister_self(), "echo").with_args(&args);
     assert_eq!(retry(call_with_args).await, 0);
     let raw_args = Encode!(&n).unwrap();
-    let call_with_raw_args = Call::new(canister_self(), "echo").with_raw_args(&raw_args);
+    let call_with_raw_args = Call::best_effort(canister_self(), "echo").with_raw_args(&raw_args);
     assert_eq!(retry(call_with_raw_args).await, 0);
 }
 fn main() {}

--- a/e2e-tests/src/bin/call.rs
+++ b/e2e-tests/src/bin/call.rs
@@ -9,12 +9,16 @@ async fn foo() -> u32 {
     0
 }
 
-/// `Call::new(...)` can be configured and called.
+/// `Call` without args can be configured and called.
 #[update]
 async fn call_foo() {
     let n = 0u32;
     let bytes = Encode!(&n).unwrap();
-
+    let res: (u32,) = Call::guaranteed(canister_self(), "foo")
+        .call_tuple()
+        .await
+        .unwrap();
+    assert_eq!(res.0, n);
     let res: u32 = Call::best_effort(canister_self(), "foo")
         .call()
         .await
@@ -33,13 +37,6 @@ async fn call_foo() {
     Call::best_effort(canister_self(), "foo")
         .call_oneway()
         .unwrap();
-
-    let res: (u32,) = Call::best_effort(canister_self(), "foo")
-        .with_guaranteed_response()
-        .call_tuple()
-        .await
-        .unwrap();
-    assert_eq!(res.0, n);
     let res: (u32,) = Call::best_effort(canister_self(), "foo")
         .change_timeout(5)
         .call_tuple()
@@ -60,12 +57,18 @@ async fn echo(arg: u32) -> u32 {
     arg
 }
 
-/// `Call::new(...).with_arg(...)` can be configured and called.
+/// `Call::with_arg(...)` can be configured and called.
 #[update]
 async fn call_echo_with_arg() {
     let n = 1u32;
     let bytes = Encode!(&n).unwrap();
-    // call*
+
+    let res: (u32,) = Call::guaranteed(canister_self(), "echo")
+        .with_arg(n)
+        .call_tuple()
+        .await
+        .unwrap();
+    assert_eq!(res.0, n);
     let res: u32 = Call::best_effort(canister_self(), "echo")
         .with_arg(n)
         .call()
@@ -88,14 +91,6 @@ async fn call_echo_with_arg() {
         .with_arg(n)
         .call_oneway()
         .unwrap();
-    // with*
-    let res: (u32,) = Call::best_effort(canister_self(), "echo")
-        .with_arg(n)
-        .with_guaranteed_response()
-        .call_tuple()
-        .await
-        .unwrap();
-    assert_eq!(res.0, n);
     let res: (u32,) = Call::best_effort(canister_self(), "echo")
         .with_arg(n)
         .change_timeout(5)
@@ -112,12 +107,18 @@ async fn call_echo_with_arg() {
     assert_eq!(res.0, n);
 }
 
-/// `Call::new(...).with_args(...)` can be configured and called.
+/// `Call::with_args(...)` can be configured and called.
 #[update]
 async fn call_echo_with_args() {
     let n = 1u32;
     let bytes = Encode!(&n).unwrap();
-    // call*
+
+    let res: (u32,) = Call::guaranteed(canister_self(), "echo")
+        .with_args(&(n,))
+        .call_tuple()
+        .await
+        .unwrap();
+    assert_eq!(res.0, n);
     let res: u32 = Call::best_effort(canister_self(), "echo")
         .with_args(&(n,))
         .call()
@@ -140,14 +141,6 @@ async fn call_echo_with_args() {
         .with_args(&(n,))
         .call_oneway()
         .unwrap();
-    // with*
-    let res: (u32,) = Call::best_effort(canister_self(), "echo")
-        .with_args(&(n,))
-        .with_guaranteed_response()
-        .call_tuple()
-        .await
-        .unwrap();
-    assert_eq!(res.0, n);
     let res: (u32,) = Call::best_effort(canister_self(), "echo")
         .with_args(&(n,))
         .change_timeout(5)
@@ -164,12 +157,18 @@ async fn call_echo_with_args() {
     assert_eq!(res.0, n);
 }
 
-/// Call::new(...).with_raw_args(...) can be configured and called.
+/// `Call::with_raw_args(...)` can be configured and called.
 #[update]
 async fn call_echo_with_raw_args() {
     let n = 1u32;
     let bytes: Vec<u8> = Encode!(&n).unwrap();
-    // call*
+
+    let res: (u32,) = Call::guaranteed(canister_self(), "echo")
+        .with_raw_args(&bytes)
+        .call_tuple()
+        .await
+        .unwrap();
+    assert_eq!(res.0, n);
     let res: u32 = Call::best_effort(canister_self(), "echo")
         .with_raw_args(&bytes)
         .call()
@@ -192,14 +191,6 @@ async fn call_echo_with_raw_args() {
         .with_raw_args(&bytes)
         .call_oneway()
         .unwrap();
-    // with*
-    let res: (u32,) = Call::best_effort(canister_self(), "echo")
-        .with_raw_args(&bytes)
-        .with_guaranteed_response()
-        .call_tuple()
-        .await
-        .unwrap();
-    assert_eq!(res.0, n);
     let res: (u32,) = Call::best_effort(canister_self(), "echo")
         .with_raw_args(&bytes)
         .change_timeout(5)

--- a/ic-cdk-timers/src/lib.rs
+++ b/ic-cdk-timers/src/lib.rs
@@ -113,7 +113,7 @@ extern "C" fn global_timer() {
                             call_futures.push(async move {
                                 (
                                     timer,
-                                    Call::new(
+                                    Call::best_effort(
                                         ic_cdk::api::canister_self(),
                                         "<ic-cdk internal> timer_executor",
                                     )

--- a/ic-cdk/src/api/call.rs
+++ b/ic-cdk/src/api/call.rs
@@ -233,7 +233,7 @@ fn add_payment(payment: u128) {
 ///     on the underlying implementation of one-way calls.
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_arg(,,).with_cycles(..).call_oneway()` instead."
+    note = "Please use `ic_cdk::call::Call::guaranteed(...).with_arg(...).with_cycles(...).call_oneway()` instead."
 )]
 pub fn notify_with_payment128<T: ArgumentEncoder>(
     id: Principal,
@@ -248,7 +248,7 @@ pub fn notify_with_payment128<T: ArgumentEncoder>(
 /// Like [notify_with_payment128], but sets the payment to zero.
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_arg(,,).with_cycles(..).call_oneway()` instead."
+    note = "Please use `ic_cdk::call::Call::guaranteed(...).with_arg(...).with_cycles(...).call_oneway()` instead."
 )]
 pub fn notify<T: ArgumentEncoder>(
     id: Principal,
@@ -261,7 +261,7 @@ pub fn notify<T: ArgumentEncoder>(
 /// Like [notify], but sends the argument as raw bytes, skipping Candid serialization.
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_raw_args(..).with_cycles(..).call_oneway()` instead."
+    note = "Please use `ic_cdk::call::Call::guaranteed(...).with_raw_args(...).with_cycles(...).call_oneway()` instead."
 )]
 pub fn notify_raw(
     id: Principal,
@@ -321,7 +321,7 @@ pub fn notify_raw(
 /// ```
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_raw_args(..).with_cycles(..).call()` instead."
+    note = "Please use `ic_cdk::call::Call::guaranteed(...).with_raw_args(...).with_cycles(...).call()` instead."
 )]
 pub fn call_raw<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
     id: Principal,
@@ -348,7 +348,7 @@ pub fn call_raw<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
 /// ```
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_raw_args(..).with_cycles(..).call()` instead."
+    note = "Please use `ic_cdk::call::Call::guaranteed(...).with_raw_args(...).with_cycles(...).call()` instead."
 )]
 pub fn call_raw128<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
     id: Principal,
@@ -418,7 +418,7 @@ fn decoder_error_to_reject<T>(err: candid::error::Error) -> (RejectionCode, Stri
 /// * If the reply payload is not a valid encoding of the expected type `T`, the call results in [RejectionCode::CanisterError] error.
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_arg(..).call()` instead."
+    note = "Please use `ic_cdk::call::Call::guaranteed(...).with_arg(...).call()` instead."
 )]
 pub fn call<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     id: Principal,
@@ -464,7 +464,7 @@ pub fn call<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
 /// * If the reply payload is not a valid encoding of the expected type `T`, the call results in [RejectionCode::CanisterError] error.
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_arg(..).with_cycles(..).call()` instead."
+    note = "Please use `ic_cdk::call::Call::guaranteed(...).with_arg(...).with_cycles(...).call()` instead."
 )]
 pub fn call_with_payment<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     id: Principal,
@@ -511,7 +511,7 @@ pub fn call_with_payment<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
 /// * If the reply payload is not a valid encoding of the expected type `T`, the call results in [RejectionCode::CanisterError] error.
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_arg(..).with_cycles(..).call()` instead."
+    note = "Please use `ic_cdk::call::Call::guaranteed(...).with_arg(...).with_cycles(...).call()` instead."
 )]
 pub fn call_with_payment128<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     id: Principal,
@@ -561,7 +561,7 @@ pub fn call_with_payment128<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
 /// ```
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_arg(..).with_cycles(..).with_decoder_config(..).call()` instead."
+    note = "Please use `ic_cdk::call::Call::guaranteed(...).with_arg(...).with_cycles(...).call_raw()` instead and decode the response bytes separately."
 )]
 pub fn call_with_config<'b, T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     id: Principal,
@@ -864,7 +864,7 @@ impl Default for ArgDecoderConfig {
 /// decoded.
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::msg_arg_data` instead."
+    note = "Please use `ic_cdk::call::msg_arg_data` instead and decode the arg separately."
 )]
 pub fn arg_data<R: for<'a> ArgumentDecoder<'a>>(arg_config: ArgDecoderConfig) -> R {
     let bytes = arg_data_raw();

--- a/ic-cdk/src/call.rs
+++ b/ic-cdk/src/call.rs
@@ -155,6 +155,9 @@ pub struct Call<'m, 'a> {
     canister_id: Principal,
     method: &'m str,
     cycles: Option<u128>,
+    /// Timeout in seconds for best-effort responses.
+    ///
+    /// If `None`, the call will have a guaranteed response.
     timeout_seconds: Option<u32>,
     encoded_args: EncodedArgs<'a>,
 }
@@ -254,15 +257,6 @@ impl<'m, 'a> Call<'m, 'a> {
         self
     }
 
-    /// Sets the call to have a guaranteed response.
-    ///
-    /// If [`change_timeout`](Self::change_timeout) is invoked after this method,
-    /// the call will instead be set with best-effort responses.
-    pub fn with_guaranteed_response(mut self) -> Self {
-        self.timeout_seconds = None;
-        self
-    }
-
     /// Sets the timeout for best-effort responses.
     ///
     /// If not set, the call defaults to a 10-second timeout.
@@ -280,7 +274,10 @@ impl<'m, 'a> Call<'m, 'a> {
     /// To make the call with a guaranteed response,
     /// use the [`with_guaranteed_response`](Self::with_guaranteed_response) method.
     pub fn change_timeout(mut self, timeout_seconds: u32) -> Self {
-        self.timeout_seconds = Some(timeout_seconds);
+        match self.timeout_seconds {
+            Some(_) => self.timeout_seconds = Some(timeout_seconds),
+            None => panic!("Cannot set timeout for guaranteed responses"),
+        }
         self
     }
 

--- a/ic-cdk/src/call.rs
+++ b/ic-cdk/src/call.rs
@@ -173,20 +173,36 @@ enum EncodedArgs<'a> {
 }
 
 impl<'m, 'a> Call<'m, 'a> {
-    /// Constructs a new [`Call`] with the Canister ID and method name.
+    /// Constructs a new best-effort responses [`Call`] with the Canister ID and method name.
     ///
     /// # Note
     ///
-    /// The [`Call`] defaults to a 10-second timeout for best-effort Responses.
+    /// The best-effort responses [`Call`] defaults to a 10-second timeout.
     /// To change the timeout, invoke the [`change_timeout`][Self::change_timeout] method.
-    /// To get a guaranteed response, invoke the [`with_guaranteed_response`][Self::with_guaranteed_response] method.
-    pub fn new(canister_id: Principal, method: &'m str) -> Self {
+    ///
+    /// To get guaranteed responses, use the [`Call::guaranteed`] constructor instead.
+    pub fn best_effort(canister_id: Principal, method: &'m str) -> Self {
         Self {
             canister_id,
             method,
             cycles: None,
             // Default to 10 seconds.
             timeout_seconds: Some(10),
+            // Bytes for empty arguments.
+            // `candid::Encode!(&()).unwrap()`
+            encoded_args: EncodedArgs::Owned(vec![0x44, 0x49, 0x44, 0x4c, 0x00, 0x00]),
+        }
+    }
+
+    /// Constructs a new guaranteed responses [`Call`] with the Canister ID and method name.
+    ///
+    /// To get best-effort responses, use the  [`Call::best_effort`] constructor instead.
+    pub fn guaranteed(canister_id: Principal, method: &'m str) -> Self {
+        Self {
+            canister_id,
+            method,
+            cycles: None,
+            timeout_seconds: None,
             // Bytes for empty arguments.
             // `candid::Encode!(&()).unwrap()`
             encoded_args: EncodedArgs::Owned(vec![0x44, 0x49, 0x44, 0x4c, 0x00, 0x00]),

--- a/ic-cdk/src/management_canister.rs
+++ b/ic-cdk/src/management_canister.rs
@@ -59,7 +59,7 @@ pub async fn create_canister(
         settings: arg.settings.clone(),
         sender_canister_version: Some(canister_version()),
     };
-    Call::new(Principal::management_canister(), "create_canister")
+    Call::best_effort(Principal::management_canister(), "create_canister")
         .with_arg(&complete_arg)
         .with_guaranteed_response()
         .with_cycles(cycles)
@@ -91,7 +91,7 @@ pub async fn update_settings(arg: &UpdateSettingsArgs) -> CallResult<()> {
         settings: arg.settings.clone(),
         sender_canister_version: Some(canister_version()),
     };
-    Call::new(Principal::management_canister(), "update_settings")
+    Call::best_effort(Principal::management_canister(), "update_settings")
         .with_arg(&complete_arg)
         .call()
         .await
@@ -118,7 +118,7 @@ pub struct UpdateSettingsArgs {
 ///
 /// See [IC method `upload_chunk`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-upload_chunk).
 pub async fn upload_chunk(arg: &UploadChunkArgs) -> CallResult<UploadChunkResult> {
-    Call::new(Principal::management_canister(), "upload_chunk")
+    Call::best_effort(Principal::management_canister(), "upload_chunk")
         .with_arg(arg)
         .call()
         .await
@@ -128,7 +128,7 @@ pub async fn upload_chunk(arg: &UploadChunkArgs) -> CallResult<UploadChunkResult
 ///
 /// See [IC method `clear_chunk_store`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-clear_chunk_store).
 pub async fn clear_chunk_store(arg: &ClearChunkStoreArgs) -> CallResult<()> {
-    Call::new(Principal::management_canister(), "clear_chunk_store")
+    Call::best_effort(Principal::management_canister(), "clear_chunk_store")
         .with_arg(arg)
         .call()
         .await
@@ -138,7 +138,7 @@ pub async fn clear_chunk_store(arg: &ClearChunkStoreArgs) -> CallResult<()> {
 ///
 /// See [IC method `stored_chunks`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-stored_chunks).
 pub async fn stored_chunks(arg: &StoredChunksArgs) -> CallResult<StoredChunksResult> {
-    Call::new(Principal::management_canister(), "stored_chunks")
+    Call::best_effort(Principal::management_canister(), "stored_chunks")
         .with_arg(arg)
         .call()
         .await
@@ -155,7 +155,7 @@ pub async fn install_code(arg: &InstallCodeArgs) -> CallResult<()> {
         arg: arg.arg.clone(),
         sender_canister_version: Some(canister_version()),
     };
-    Call::new(Principal::management_canister(), "install_code")
+    Call::best_effort(Principal::management_canister(), "install_code")
         .with_arg(&complete_arg)
         .call()
         .await
@@ -196,7 +196,7 @@ pub async fn install_chunked_code(arg: &InstallChunkedCodeArgs) -> CallResult<()
         arg: arg.arg.clone(),
         sender_canister_version: Some(canister_version()),
     };
-    Call::new(Principal::management_canister(), "install_chunked_code")
+    Call::best_effort(Principal::management_canister(), "install_chunked_code")
         .with_arg(&complete_arg)
         .call()
         .await
@@ -237,7 +237,7 @@ pub async fn uninstall_code(arg: &UninstallCodeArgs) -> CallResult<()> {
         canister_id: arg.canister_id,
         sender_canister_version: Some(canister_version()),
     };
-    Call::new(Principal::management_canister(), "uninstall_code")
+    Call::best_effort(Principal::management_canister(), "uninstall_code")
         .with_arg(&complete_arg)
         .call()
         .await
@@ -262,7 +262,7 @@ pub struct UninstallCodeArgs {
 ///
 /// See [IC method `start_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-start_canister).
 pub async fn start_canister(arg: &StartCanisterArgs) -> CallResult<()> {
-    Call::new(Principal::management_canister(), "start_canister")
+    Call::best_effort(Principal::management_canister(), "start_canister")
         .with_arg(arg)
         .call()
         .await
@@ -272,7 +272,7 @@ pub async fn start_canister(arg: &StartCanisterArgs) -> CallResult<()> {
 ///
 /// See [IC method `stop_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-stop_canister).
 pub async fn stop_canister(arg: &StopCanisterArgs) -> CallResult<()> {
-    Call::new(Principal::management_canister(), "stop_canister")
+    Call::best_effort(Principal::management_canister(), "stop_canister")
         .with_arg(arg)
         .call()
         .await
@@ -282,7 +282,7 @@ pub async fn stop_canister(arg: &StopCanisterArgs) -> CallResult<()> {
 ///
 /// See [IC method `canister_status`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-canister_status).
 pub async fn canister_status(arg: &CanisterStatusArgs) -> CallResult<CanisterStatusResult> {
-    Call::new(Principal::management_canister(), "canister_status")
+    Call::best_effort(Principal::management_canister(), "canister_status")
         .with_arg(arg)
         .call()
         .await
@@ -292,7 +292,7 @@ pub async fn canister_status(arg: &CanisterStatusArgs) -> CallResult<CanisterSta
 ///
 /// See [IC method `canister_info`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-canister_info).
 pub async fn canister_info(arg: &CanisterInfoArgs) -> CallResult<CanisterInfoResult> {
-    Call::new(Principal::management_canister(), "canister_info")
+    Call::best_effort(Principal::management_canister(), "canister_info")
         .with_arg(arg)
         .call()
         .await
@@ -302,7 +302,7 @@ pub async fn canister_info(arg: &CanisterInfoArgs) -> CallResult<CanisterInfoRes
 ///
 /// See [IC method `delete_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-delete_canister).
 pub async fn delete_canister(arg: &DeleteCanisterArgs) -> CallResult<()> {
-    Call::new(Principal::management_canister(), "delete_canister")
+    Call::best_effort(Principal::management_canister(), "delete_canister")
         .with_arg(arg)
         .call()
         .await
@@ -312,7 +312,7 @@ pub async fn delete_canister(arg: &DeleteCanisterArgs) -> CallResult<()> {
 ///
 /// See [IC method `deposit_cycles`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-deposit_cycles).
 pub async fn deposit_cycles(arg: &DepositCyclesArgs, cycles: u128) -> CallResult<()> {
-    Call::new(Principal::management_canister(), "deposit_cycles")
+    Call::best_effort(Principal::management_canister(), "deposit_cycles")
         .with_arg(arg)
         .with_guaranteed_response()
         .with_cycles(cycles)
@@ -324,7 +324,7 @@ pub async fn deposit_cycles(arg: &DepositCyclesArgs, cycles: u128) -> CallResult
 ///
 /// See [IC method `raw_rand`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-raw_rand).
 pub async fn raw_rand() -> CallResult<Vec<u8>> {
-    Call::new(Principal::management_canister(), "raw_rand")
+    Call::best_effort(Principal::management_canister(), "raw_rand")
         .call()
         .await
 }
@@ -336,7 +336,7 @@ pub async fn raw_rand() -> CallResult<Vec<u8>> {
 /// This call requires cycles payment. The required cycles is a function of the request size and max_response_bytes.
 /// Check [HTTPS outcalls cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost#https-outcalls) for more details.
 pub async fn http_request(arg: &HttpRequestArgs, cycles: u128) -> CallResult<HttpRequestResult> {
-    Call::new(Principal::management_canister(), "http_request")
+    Call::best_effort(Principal::management_canister(), "http_request")
         .with_arg(arg)
         .with_guaranteed_response()
         .with_cycles(cycles)
@@ -440,7 +440,7 @@ pub use transform_closure::http_request_with_closure;
 ///
 /// See [IC method `ecdsa_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-ecdsa_public_key).
 pub async fn ecdsa_public_key(arg: &EcdsaPublicKeyArgs) -> CallResult<EcdsaPublicKeyResult> {
-    Call::new(Principal::management_canister(), "ecdsa_public_key")
+    Call::best_effort(Principal::management_canister(), "ecdsa_public_key")
         .with_arg(arg)
         .call()
         .await
@@ -454,7 +454,7 @@ pub async fn ecdsa_public_key(arg: &EcdsaPublicKeyArgs) -> CallResult<EcdsaPubli
 /// This method handles the cycles cost under the hood.
 /// Check [Threshold signatures](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works) for more details.
 pub async fn sign_with_ecdsa(arg: &SignWithEcdsaArgs) -> CallResult<SignWithEcdsaResult> {
-    Call::new(Principal::management_canister(), "sign_with_ecdsa")
+    Call::best_effort(Principal::management_canister(), "sign_with_ecdsa")
         .with_arg(arg)
         .with_guaranteed_response()
         .with_cycles(SIGN_WITH_ECDSA_FEE)
@@ -469,7 +469,7 @@ const SIGN_WITH_ECDSA_FEE: u128 = 26_153_846_153;
 ///
 /// See [IC method `schnorr_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-schnorr_public_key).
 pub async fn schnorr_public_key(arg: &SchnorrPublicKeyArgs) -> CallResult<SchnorrPublicKeyResult> {
-    Call::new(Principal::management_canister(), "schnorr_public_key")
+    Call::best_effort(Principal::management_canister(), "schnorr_public_key")
         .with_arg(arg)
         .call()
         .await
@@ -483,7 +483,7 @@ pub async fn schnorr_public_key(arg: &SchnorrPublicKeyArgs) -> CallResult<Schnor
 /// This method handles the cycles cost under the hood.
 /// Check [Threshold signatures](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works) for more details.
 pub async fn sign_with_schnorr(arg: &SignWithSchnorrArgs) -> CallResult<SignWithSchnorrResult> {
-    Call::new(Principal::management_canister(), "sign_with_schnorr")
+    Call::best_effort(Principal::management_canister(), "sign_with_schnorr")
         .with_arg(arg)
         .with_guaranteed_response()
         .with_cycles(SIGN_WITH_SCHNORR_FEE)
@@ -502,7 +502,7 @@ const SIGN_WITH_SCHNORR_FEE: u128 = 26_153_846_153;
 pub async fn node_metrics_history(
     arg: &NodeMetricsHistoryArgs,
 ) -> CallResult<NodeMetricsHistoryResult> {
-    Call::new(Principal::management_canister(), "node_metrics_history")
+    Call::best_effort(Principal::management_canister(), "node_metrics_history")
         .with_arg(arg)
         .call()
         .await
@@ -514,7 +514,7 @@ pub async fn node_metrics_history(
 // ! The actual url ends with `ic-subnet-info` instead of `ic-subnet_info`.
 // ! It will likely be changed to be consistent with the other methods soon.
 pub async fn subnet_info(arg: &SubnetInfoArgs) -> CallResult<SubnetInfoResult> {
-    Call::new(Principal::management_canister(), "subnet_info")
+    Call::best_effort(Principal::management_canister(), "subnet_info")
         .with_arg(arg)
         .call()
         .await
@@ -534,7 +534,7 @@ pub async fn provisional_create_canister_with_cycles(
         specified_id: arg.specified_id,
         sender_canister_version: Some(canister_version()),
     };
-    Call::new(
+    Call::best_effort(
         Principal::management_canister(),
         "provisional_create_canister_with_cycles",
     )
@@ -569,7 +569,7 @@ pub struct ProvisionalCreateCanisterWithCyclesArgs {
 ///
 /// See [IC method `provisional_top_up_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-provisional_top_up_canister).
 pub async fn provisional_top_up_canister(arg: &ProvisionalTopUpCanisterArgs) -> CallResult<()> {
-    Call::new(
+    Call::best_effort(
         Principal::management_canister(),
         "provisional_top_up_canister",
     )
@@ -587,7 +587,7 @@ pub async fn provisional_top_up_canister(arg: &ProvisionalTopUpCanisterArgs) -> 
 pub async fn take_canister_snapshot(
     arg: &TakeCanisterSnapshotArgs,
 ) -> CallResult<TakeCanisterSnapshotReturn> {
-    Call::new(Principal::management_canister(), "take_canister_snapshot")
+    Call::best_effort(Principal::management_canister(), "take_canister_snapshot")
         .with_arg(arg)
         .with_guaranteed_response()
         .call()
@@ -605,7 +605,7 @@ pub async fn load_canister_snapshot(arg: &LoadCanisterSnapshotArgs) -> CallResul
         snapshot_id: arg.snapshot_id.clone(),
         sender_canister_version: Some(canister_version()),
     };
-    Call::new(Principal::management_canister(), "load_canister_snapshot")
+    Call::best_effort(Principal::management_canister(), "load_canister_snapshot")
         .with_arg(&complete_arg)
         .with_guaranteed_response()
         .call()
@@ -635,7 +635,7 @@ pub struct LoadCanisterSnapshotArgs {
 pub async fn list_canister_snapshots(
     arg: &ListCanisterSnapshotsArgs,
 ) -> CallResult<ListCanisterSnapshotsReturn> {
-    Call::new(Principal::management_canister(), "list_canister_snapshots")
+    Call::best_effort(Principal::management_canister(), "list_canister_snapshots")
         .with_arg(arg)
         .call()
         .await
@@ -647,7 +647,7 @@ pub async fn list_canister_snapshots(
 ///
 /// See [IC method `delete_canister_snapshot`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-delete_canister_snapshot).
 pub async fn delete_canister_snapshot(arg: &DeleteCanisterSnapshotArgs) -> CallResult<()> {
-    Call::new(Principal::management_canister(), "delete_canister_snapshot")
+    Call::best_effort(Principal::management_canister(), "delete_canister_snapshot")
         .with_arg(arg)
         .call()
         .await

--- a/ic-cdk/src/management_canister.rs
+++ b/ic-cdk/src/management_canister.rs
@@ -59,9 +59,8 @@ pub async fn create_canister(
         settings: arg.settings.clone(),
         sender_canister_version: Some(canister_version()),
     };
-    Call::best_effort(Principal::management_canister(), "create_canister")
+    Call::guaranteed(Principal::management_canister(), "create_canister")
         .with_arg(&complete_arg)
-        .with_guaranteed_response()
         .with_cycles(cycles)
         .call()
         .await
@@ -312,9 +311,8 @@ pub async fn delete_canister(arg: &DeleteCanisterArgs) -> CallResult<()> {
 ///
 /// See [IC method `deposit_cycles`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-deposit_cycles).
 pub async fn deposit_cycles(arg: &DepositCyclesArgs, cycles: u128) -> CallResult<()> {
-    Call::best_effort(Principal::management_canister(), "deposit_cycles")
+    Call::guaranteed(Principal::management_canister(), "deposit_cycles")
         .with_arg(arg)
-        .with_guaranteed_response()
         .with_cycles(cycles)
         .call()
         .await
@@ -336,9 +334,8 @@ pub async fn raw_rand() -> CallResult<Vec<u8>> {
 /// This call requires cycles payment. The required cycles is a function of the request size and max_response_bytes.
 /// Check [HTTPS outcalls cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost#https-outcalls) for more details.
 pub async fn http_request(arg: &HttpRequestArgs, cycles: u128) -> CallResult<HttpRequestResult> {
-    Call::best_effort(Principal::management_canister(), "http_request")
+    Call::guaranteed(Principal::management_canister(), "http_request")
         .with_arg(arg)
-        .with_guaranteed_response()
         .with_cycles(cycles)
         .call()
         .await
@@ -454,9 +451,8 @@ pub async fn ecdsa_public_key(arg: &EcdsaPublicKeyArgs) -> CallResult<EcdsaPubli
 /// This method handles the cycles cost under the hood.
 /// Check [Threshold signatures](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works) for more details.
 pub async fn sign_with_ecdsa(arg: &SignWithEcdsaArgs) -> CallResult<SignWithEcdsaResult> {
-    Call::best_effort(Principal::management_canister(), "sign_with_ecdsa")
+    Call::guaranteed(Principal::management_canister(), "sign_with_ecdsa")
         .with_arg(arg)
-        .with_guaranteed_response()
         .with_cycles(SIGN_WITH_ECDSA_FEE)
         .call()
         .await
@@ -483,9 +479,8 @@ pub async fn schnorr_public_key(arg: &SchnorrPublicKeyArgs) -> CallResult<Schnor
 /// This method handles the cycles cost under the hood.
 /// Check [Threshold signatures](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works) for more details.
 pub async fn sign_with_schnorr(arg: &SignWithSchnorrArgs) -> CallResult<SignWithSchnorrResult> {
-    Call::best_effort(Principal::management_canister(), "sign_with_schnorr")
+    Call::guaranteed(Principal::management_canister(), "sign_with_schnorr")
         .with_arg(arg)
-        .with_guaranteed_response()
         .with_cycles(SIGN_WITH_SCHNORR_FEE)
         .call()
         .await
@@ -534,12 +529,11 @@ pub async fn provisional_create_canister_with_cycles(
         specified_id: arg.specified_id,
         sender_canister_version: Some(canister_version()),
     };
-    Call::best_effort(
+    Call::guaranteed(
         Principal::management_canister(),
         "provisional_create_canister_with_cycles",
     )
     .with_arg(&complete_arg)
-    .with_guaranteed_response()
     .call()
     .await
 }
@@ -569,12 +563,11 @@ pub struct ProvisionalCreateCanisterWithCyclesArgs {
 ///
 /// See [IC method `provisional_top_up_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-provisional_top_up_canister).
 pub async fn provisional_top_up_canister(arg: &ProvisionalTopUpCanisterArgs) -> CallResult<()> {
-    Call::best_effort(
+    Call::guaranteed(
         Principal::management_canister(),
         "provisional_top_up_canister",
     )
     .with_arg(arg)
-    .with_guaranteed_response()
     .call()
     .await
 }
@@ -587,9 +580,8 @@ pub async fn provisional_top_up_canister(arg: &ProvisionalTopUpCanisterArgs) -> 
 pub async fn take_canister_snapshot(
     arg: &TakeCanisterSnapshotArgs,
 ) -> CallResult<TakeCanisterSnapshotReturn> {
-    Call::best_effort(Principal::management_canister(), "take_canister_snapshot")
+    Call::guaranteed(Principal::management_canister(), "take_canister_snapshot")
         .with_arg(arg)
-        .with_guaranteed_response()
         .call()
         .await
 }
@@ -605,9 +597,8 @@ pub async fn load_canister_snapshot(arg: &LoadCanisterSnapshotArgs) -> CallResul
         snapshot_id: arg.snapshot_id.clone(),
         sender_canister_version: Some(canister_version()),
     };
-    Call::best_effort(Principal::management_canister(), "load_canister_snapshot")
+    Call::guaranteed(Principal::management_canister(), "load_canister_snapshot")
         .with_arg(&complete_arg)
-        .with_guaranteed_response()
         .call()
         .await
 }

--- a/library/ic-ledger-types/src/lib.rs
+++ b/library/ic-ledger-types/src/lib.rs
@@ -691,7 +691,7 @@ pub async fn account_balance(
     ledger_canister_id: Principal,
     args: &AccountBalanceArgs,
 ) -> CallResult<Tokens> {
-    Call::new(ledger_canister_id, "account_balance")
+    Call::best_effort(ledger_canister_id, "account_balance")
         .with_arg(args)
         .call()
         .await
@@ -721,7 +721,7 @@ pub async fn transfer(
     ledger_canister_id: Principal,
     args: &TransferArgs,
 ) -> CallResult<TransferResult> {
-    Call::new(ledger_canister_id, "transfer")
+    Call::best_effort(ledger_canister_id, "transfer")
         .with_arg(args)
         .call()
         .await
@@ -745,7 +745,9 @@ pub struct Symbol {
 /// }
 /// ```
 pub async fn token_symbol(ledger_canister_id: Principal) -> CallResult<Symbol> {
-    Call::new(ledger_canister_id, "token_symbol").call().await
+    Call::best_effort(ledger_canister_id, "token_symbol")
+        .call()
+        .await
 }
 
 /// Calls the "query_block" method on the specified canister.
@@ -780,7 +782,7 @@ pub async fn query_blocks(
     ledger_canister_id: Principal,
     args: &GetBlocksArgs,
 ) -> CallResult<QueryBlocksResponse> {
-    Call::new(ledger_canister_id, "query_blocks")
+    Call::best_effort(ledger_canister_id, "query_blocks")
         .with_arg(args)
         .call()
         .await
@@ -820,7 +822,7 @@ pub async fn query_archived_blocks(
     func: &QueryArchiveFn,
     args: &GetBlocksArgs,
 ) -> CallResult<GetBlocksResult> {
-    Call::new(func.0.principal, &func.0.method)
+    Call::best_effort(func.0.principal, &func.0.method)
         .with_arg(args)
         .call()
         .await


### PR DESCRIPTION
SDK-1950

# Description

Instead of one constructor `Call::new()` which set best-effort responses by default,
two constructors are provided so that users need to choose one for their usage.

The migration can start with `Call::guaranteed()` and switch to `Call::best_effort` for suitable cases.

# How Has This Been Tested?

e2e tests are updated.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
