### PR TITLE
fix: max_response_bytes is 2MB not 2MiB

### DIFF
--- a/examples/management_canister/src/caller/lib.rs
+++ b/examples/management_canister/src/caller/lib.rs
@@ -7,7 +7,7 @@ mod http_request {
     fn http_request_required_cycles(arg: &CanisterHttpRequestArgument) -> u128 {
         let max_response_bytes = match arg.max_response_bytes {
             Some(ref n) => *n as u128,
-            None => 2 * 1024 * 1024u128, // default 2MiB
+            None => 2_000_000u128, // default 2MB
         };
         let arg_raw = candid::utils::encode_args((arg,)).expect("Failed to encode arguments.");
         // The fee is for a 13-node subnet to demonstrate a typical usage.

--- a/src/ic-cdk/CHANGELOG.md
+++ b/src/ic-cdk/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changed
+
+- The `max_response_size` of `CanisterHttpRequestArgument` is capped at 2MB, not 2MiB.
+
 ## [0.17.1] - 2024-12-19
 
 ### Added

--- a/src/ic-cdk/src/api/management_canister/http_request/types.rs
+++ b/src/ic-cdk/src/api/management_canister/http_request/types.rs
@@ -106,7 +106,7 @@ pub enum HttpMethod {
 pub struct CanisterHttpRequestArgument {
     /// The requested URL.
     pub url: String,
-    /// The maximal size of the response in bytes. If None, 2MiB will be the limit.
+    /// The maximal size of the response in bytes. If None, 2MB will be the limit.
     /// This value affects the cost of the http request and it is highly recommended
     /// to set it as low as possible to avoid unnecessary extra costs.
     /// See also the [pricing section of HTTP outcalls documentation](https://internetcomputer.org/docs/current/developer-docs/integrations/http_requests/http_requests-how-it-works#pricing).


### PR DESCRIPTION
# Description

The documentation (and example) for `max_response_bytes` is wrong. According to the interface spec and IC's implementation, the limit is 2MB, not 2MiB.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
