### PR TITLE
feat: finalize call api

### DIFF
--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -24,3 +24,4 @@ sha2.workspace = true
 cargo_metadata = "0.19"
 hex.workspace = true
 pocket-ic = { git = "https://github.com/dfinity/ic", tag = "release-2024-11-28_03-15-base" }
+futures = "0.3"

--- a/e2e-tests/src/bin/api.rs
+++ b/e2e-tests/src/bin/api.rs
@@ -16,19 +16,16 @@ fn call_msg_caller() {
     msg_reply(vec![]);
 }
 
-/// This entrypoint will call [`call_msg_deadline`] with both best-effort and guaranteed responses.
+/// This entrypoint will call [`call_msg_deadline`] with both bounded_wait and unbounded_wait.
 #[ic_cdk::update]
 async fn call_msg_deadline_caller() {
     use ic_cdk::call::Call;
-    // Call with best-effort responses.
-    let reply1 = Call::new(canister_self(), "call_msg_deadline")
+    let reply1 = Call::bounded_wait(canister_self(), "call_msg_deadline")
         .call_raw()
         .await
         .unwrap();
     assert_eq!(reply1, vec![1]);
-    // Call with guaranteed responses.
-    let reply1 = Call::new(canister_self(), "call_msg_deadline")
-        .with_guaranteed_response()
+    let reply1 = Call::unbounded_wait(canister_self(), "call_msg_deadline")
         .call_raw()
         .await
         .unwrap();
@@ -36,8 +33,8 @@ async fn call_msg_deadline_caller() {
 }
 
 /// This entrypoint is to be called by [`call_msg_deadline_caller`].
-/// If the call was made with best-effort responses, `msg_deadline` should be `Some`, then return 1.
-/// If the call was made with guaranteed responses, `msg_deadline` should be `None`, then return 0.
+/// If the call was made with bounded_wait, `msg_deadline` should be `Some`, then return 1.
+/// If the call was made with unbounded_wait, `msg_deadline` should be `None`, then return 0.
 #[export_name = "canister_update call_msg_deadline"]
 fn call_msg_deadline() {
     let reply = match msg_deadline() {

--- a/e2e-tests/src/bin/api.rs
+++ b/e2e-tests/src/bin/api.rs
@@ -21,14 +21,14 @@ fn call_msg_caller() {
 async fn call_msg_deadline_caller() {
     use ic_cdk::call::Call;
     let reply1 = Call::bounded_wait(canister_self(), "call_msg_deadline")
-        .call_raw()
         .await
-        .unwrap();
+        .unwrap()
+        .into_bytes();
     assert_eq!(reply1, vec![1]);
     let reply1 = Call::unbounded_wait(canister_self(), "call_msg_deadline")
-        .call_raw()
         .await
-        .unwrap();
+        .unwrap()
+        .into_bytes();
     assert_eq!(reply1, vec![0]);
 }
 

--- a/e2e-tests/src/bin/async.rs
+++ b/e2e-tests/src/bin/async.rs
@@ -1,5 +1,5 @@
 use candid::Principal;
-use ic_cdk::call::{Call, CallError, CallResult};
+use ic_cdk::call::Call;
 use ic_cdk::{query, update};
 use lazy_static::lazy_static;
 use std::sync::RwLock;
@@ -32,9 +32,8 @@ async fn panic_after_async() {
     let value = *lock;
     // Do not drop the lock before the await point.
 
-    let _: u64 = Call::bounded_wait(ic_cdk::api::canister_self(), "inc")
+    Call::bounded_wait(ic_cdk::api::canister_self(), "inc")
         .with_arg(value)
-        .call()
         .await
         .unwrap();
     ic_cdk::api::trap("Goodbye, cruel world.")
@@ -50,8 +49,7 @@ async fn panic_twice() {
 }
 
 async fn async_then_panic() {
-    let _: u64 = Call::bounded_wait(ic_cdk::api::canister_self(), "on_notify")
-        .call()
+    Call::bounded_wait(ic_cdk::api::canister_self(), "on_notify")
         .await
         .unwrap();
     panic!();
@@ -70,7 +68,7 @@ fn on_notify() {
 #[update]
 fn notify(whom: Principal, method: String) {
     Call::bounded_wait(whom, method.as_str())
-        .call_oneway()
+        .oneway()
         .unwrap_or_else(|reject| {
             ic_cdk::api::trap(format!(
                 "failed to notify (callee={}, method={}): {:?}",
@@ -88,29 +86,24 @@ fn greet(name: String) -> String {
 async fn greet_self(greeter: Principal) -> String {
     Call::bounded_wait(greeter, "greet")
         .with_arg("myself")
-        .call()
         .await
+        .unwrap()
+        .candid()
         .unwrap()
 }
 
 #[update]
 async fn invalid_reply_payload_does_not_trap() -> String {
     // We're decoding an integer instead of a string, decoding must fail.
-    let result: CallResult<u64> = Call::bounded_wait(ic_cdk::api::canister_self(), "greet")
+    let result = Call::bounded_wait(ic_cdk::api::canister_self(), "greet")
         .with_arg("World")
-        .call()
-        .await;
+        .await
+        .unwrap()
+        .candid::<u64>();
 
     match result {
         Ok(_) => ic_cdk::api::trap("expected the decoding to fail"),
-        Err(e) => match e {
-            CallError::CandidDecodeFailed(candid_err) => {
-                format!("handled decoding error gracefully with candid error: {candid_err}")
-            }
-            other_err => ic_cdk::api::trap(format!(
-                "expected a CandidDecodeFailed error, got {other_err}"
-            )),
-        },
+        Err(e) => format!("handled decoding error gracefully: {e}"),
     }
 }
 
@@ -120,8 +113,9 @@ async fn await_channel_completion() -> String {
     ic_cdk::futures::spawn(async move {
         let greeting: String = Call::bounded_wait(ic_cdk::api::canister_self(), "greet")
             .with_arg("myself")
-            .call()
             .await
+            .unwrap()
+            .candid()
             .unwrap();
         tx.send(greeting).await.unwrap();
     });

--- a/e2e-tests/src/bin/call.rs
+++ b/e2e-tests/src/bin/call.rs
@@ -1,4 +1,4 @@
-use candid::Encode;
+use candid::{Encode, Principal};
 use ic_cdk::api::canister_self;
 use ic_cdk::call::Call;
 use ic_cdk::update;
@@ -221,6 +221,18 @@ async fn join_calls() {
         vec![Box::pin(future1), Box::pin(future2)];
     let results = join_all(futures).await;
     assert_eq!(results, vec![0, 1]);
+}
+
+#[update]
+async fn call_error_ext() {
+    // The trait need to be in scope so that the provided methods can be called.
+    use ic_cdk::call::CallErrorExt;
+    // Trigger a DestinationInvalid rejection
+    let err = Call::bounded_wait(Principal::anonymous(), "foobar")
+        .await
+        .unwrap_err();
+    assert!(err.is_clean_reject());
+    assert!(!err.is_immediately_retryable());
 }
 
 fn main() {}

--- a/e2e-tests/src/bin/call.rs
+++ b/e2e-tests/src/bin/call.rs
@@ -15,30 +15,37 @@ async fn call_foo() {
     let n = 0u32;
     let bytes = Encode!(&n).unwrap();
 
-    let res: u32 = Call::new(canister_self(), "foo").call().await.unwrap();
+    let res: u32 = Call::bounded_wait(canister_self(), "foo")
+        .call()
+        .await
+        .unwrap();
     assert_eq!(res, n);
-    let res: (u32,) = Call::new(canister_self(), "foo")
+    let res: (u32,) = Call::bounded_wait(canister_self(), "foo")
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res = Call::new(canister_self(), "foo").call_raw().await.unwrap();
+    let res = Call::bounded_wait(canister_self(), "foo")
+        .call_raw()
+        .await
+        .unwrap();
     assert_eq!(res, bytes);
-    Call::new(canister_self(), "foo").call_oneway().unwrap();
+    Call::bounded_wait(canister_self(), "foo")
+        .call_oneway()
+        .unwrap();
 
-    let res: (u32,) = Call::new(canister_self(), "foo")
-        .with_guaranteed_response()
+    let res: (u32,) = Call::unbounded_wait(canister_self(), "foo")
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res: (u32,) = Call::new(canister_self(), "foo")
+    let res: (u32,) = Call::bounded_wait(canister_self(), "foo")
         .change_timeout(5)
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res: (u32,) = Call::new(canister_self(), "foo")
+    let res: (u32,) = Call::bounded_wait(canister_self(), "foo")
         .with_cycles(1000)
         .call_tuple()
         .await
@@ -58,44 +65,43 @@ async fn call_echo_with_arg() {
     let n = 1u32;
     let bytes = Encode!(&n).unwrap();
     // call*
-    let res: u32 = Call::new(canister_self(), "echo")
+    let res: u32 = Call::bounded_wait(canister_self(), "echo")
         .with_arg(n)
         .call()
         .await
         .unwrap();
     assert_eq!(res, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::bounded_wait(canister_self(), "echo")
         .with_arg(n)
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res = Call::new(canister_self(), "echo")
+    let res = Call::bounded_wait(canister_self(), "echo")
         .with_arg(n)
         .call_raw()
         .await
         .unwrap();
     assert_eq!(res, bytes);
-    Call::new(canister_self(), "echo")
+    Call::bounded_wait(canister_self(), "echo")
         .with_arg(n)
         .call_oneway()
         .unwrap();
     // with*
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::unbounded_wait(canister_self(), "echo")
         .with_arg(n)
-        .with_guaranteed_response()
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::bounded_wait(canister_self(), "echo")
         .with_arg(n)
         .change_timeout(5)
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::bounded_wait(canister_self(), "echo")
         .with_arg(n)
         .with_cycles(1000)
         .call_tuple()
@@ -110,44 +116,43 @@ async fn call_echo_with_args() {
     let n = 1u32;
     let bytes = Encode!(&n).unwrap();
     // call*
-    let res: u32 = Call::new(canister_self(), "echo")
+    let res: u32 = Call::bounded_wait(canister_self(), "echo")
         .with_args(&(n,))
         .call()
         .await
         .unwrap();
     assert_eq!(res, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::bounded_wait(canister_self(), "echo")
         .with_args(&(n,))
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res = Call::new(canister_self(), "echo")
+    let res = Call::bounded_wait(canister_self(), "echo")
         .with_args(&(n,))
         .call_raw()
         .await
         .unwrap();
     assert_eq!(res, bytes);
-    Call::new(canister_self(), "echo")
+    Call::bounded_wait(canister_self(), "echo")
         .with_args(&(n,))
         .call_oneway()
         .unwrap();
     // with*
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::unbounded_wait(canister_self(), "echo")
         .with_args(&(n,))
-        .with_guaranteed_response()
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::bounded_wait(canister_self(), "echo")
         .with_args(&(n,))
         .change_timeout(5)
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::bounded_wait(canister_self(), "echo")
         .with_args(&(n,))
         .with_cycles(1000)
         .call_tuple()
@@ -162,44 +167,43 @@ async fn call_echo_with_raw_args() {
     let n = 1u32;
     let bytes: Vec<u8> = Encode!(&n).unwrap();
     // call*
-    let res: u32 = Call::new(canister_self(), "echo")
+    let res: u32 = Call::bounded_wait(canister_self(), "echo")
         .with_raw_args(&bytes)
         .call()
         .await
         .unwrap();
     assert_eq!(res, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::bounded_wait(canister_self(), "echo")
         .with_raw_args(&bytes)
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res = Call::new(canister_self(), "echo")
+    let res = Call::bounded_wait(canister_self(), "echo")
         .with_raw_args(&bytes)
         .call_raw()
         .await
         .unwrap();
     assert_eq!(res, bytes);
-    Call::new(canister_self(), "echo")
+    Call::bounded_wait(canister_self(), "echo")
         .with_raw_args(&bytes)
         .call_oneway()
         .unwrap();
     // with*
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::unbounded_wait(canister_self(), "echo")
         .with_raw_args(&bytes)
-        .with_guaranteed_response()
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::bounded_wait(canister_self(), "echo")
         .with_raw_args(&bytes)
         .change_timeout(5)
         .call_tuple()
         .await
         .unwrap();
     assert_eq!(res.0, n);
-    let res: (u32,) = Call::new(canister_self(), "echo")
+    let res: (u32,) = Call::bounded_wait(canister_self(), "echo")
         .with_raw_args(&bytes)
         .with_cycles(1000)
         .call_tuple()
@@ -228,15 +232,15 @@ async fn retry(call_to_retry: Call<'_, '_>) -> u32 {
 #[update]
 async fn retry_calls() {
     let n: u32 = 1u32;
-    let call = Call::new(canister_self(), "foo");
+    let call = Call::bounded_wait(canister_self(), "foo");
     assert_eq!(retry(call).await, 0);
-    let call_with_arg = Call::new(canister_self(), "echo").with_arg(n);
+    let call_with_arg = Call::bounded_wait(canister_self(), "echo").with_arg(n);
     assert_eq!(retry(call_with_arg).await, 0);
     let args = (n,);
-    let call_with_args = Call::new(canister_self(), "echo").with_args(&args);
+    let call_with_args = Call::bounded_wait(canister_self(), "echo").with_args(&args);
     assert_eq!(retry(call_with_args).await, 0);
     let raw_args = Encode!(&n).unwrap();
-    let call_with_raw_args = Call::new(canister_self(), "echo").with_raw_args(&raw_args);
+    let call_with_raw_args = Call::bounded_wait(canister_self(), "echo").with_raw_args(&raw_args);
     assert_eq!(retry(call_with_raw_args).await, 0);
 }
 fn main() {}

--- a/e2e-tests/tests/call.rs
+++ b/e2e-tests/tests/call.rs
@@ -35,4 +35,12 @@ fn call() {
         (),
     )
     .unwrap();
+    let _: () = call_candid(
+        &pic,
+        canister_id,
+        RawEffectivePrincipal::None,
+        "join_calls",
+        (),
+    )
+    .unwrap();
 }

--- a/e2e-tests/tests/call.rs
+++ b/e2e-tests/tests/call.rs
@@ -43,4 +43,12 @@ fn call() {
         (),
     )
     .unwrap();
+    let _: () = call_candid(
+        &pic,
+        canister_id,
+        RawEffectivePrincipal::None,
+        "call_error_ext",
+        (),
+    )
+    .unwrap();
 }

--- a/e2e-tests/tests/call.rs
+++ b/e2e-tests/tests/call.rs
@@ -23,23 +23,7 @@ fn call() {
         &pic,
         canister_id,
         RawEffectivePrincipal::None,
-        "call_echo_with_arg",
-        (),
-    )
-    .unwrap();
-    let _: () = call_candid(
-        &pic,
-        canister_id,
-        RawEffectivePrincipal::None,
-        "call_echo_with_args",
-        (),
-    )
-    .unwrap();
-    let _: () = call_candid(
-        &pic,
-        canister_id,
-        RawEffectivePrincipal::None,
-        "call_echo_with_raw_args",
+        "call_echo",
         (),
     )
     .unwrap();

--- a/ic-cdk-timers/src/lib.rs
+++ b/ic-cdk-timers/src/lib.rs
@@ -113,7 +113,7 @@ extern "C" fn global_timer() {
                                 call_futures.push(async move {
                                     (
                                         timer,
-                                        Call::new(
+                                        Call::bounded_wait(
                                             ic_cdk::api::canister_self(),
                                             "<ic-cdk internal> timer_executor",
                                         )

--- a/ic-cdk/src/api/call.rs
+++ b/ic-cdk/src/api/call.rs
@@ -291,7 +291,7 @@ fn add_payment(payment: u128) {
 ///     on the underlying implementation of one-way calls.
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_arg(,,).with_cycles(..).call_oneway()` instead."
+    note = "Please use `ic_cdk::call::Call::unbounded_wait()` instead."
 )]
 pub fn notify_with_payment128<T: ArgumentEncoder>(
     id: Principal,
@@ -306,7 +306,7 @@ pub fn notify_with_payment128<T: ArgumentEncoder>(
 /// Like [notify_with_payment128], but sets the payment to zero.
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_arg(,,).with_cycles(..).call_oneway()` instead."
+    note = "Please use `ic_cdk::call::Call::unbounded_wait()` instead."
 )]
 pub fn notify<T: ArgumentEncoder>(
     id: Principal,
@@ -319,7 +319,7 @@ pub fn notify<T: ArgumentEncoder>(
 /// Like [notify], but sends the argument as raw bytes, skipping Candid serialization.
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_raw_args(..).with_cycles(..).call_oneway()` instead."
+    note = "Please use `ic_cdk::call::Call::unbounded_wait()` instead."
 )]
 pub fn notify_raw(
     id: Principal,
@@ -379,7 +379,7 @@ pub fn notify_raw(
 /// ```
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_raw_args(..).with_cycles(..).call()` instead."
+    note = "Please use `ic_cdk::call::Call::unbounded_wait()` instead."
 )]
 pub fn call_raw<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
     id: Principal,
@@ -406,7 +406,7 @@ pub fn call_raw<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
 /// ```
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_raw_args(..).with_cycles(..).call()` instead."
+    note = "Please use `ic_cdk::call::Call::unbounded_wait()` instead."
 )]
 pub fn call_raw128<'a, T: AsRef<[u8]> + Send + Sync + 'a>(
     id: Principal,
@@ -474,7 +474,7 @@ fn decoder_error_to_reject<T>(err: candid::error::Error) -> (RejectionCode, Stri
 /// * If the reply payload is not a valid encoding of the expected type `T`, the call results in [RejectionCode::CanisterError] error.
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_arg(..).call()` instead."
+    note = "Please use `ic_cdk::call::Call::unbounded_wait()` instead."
 )]
 pub fn call<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     id: Principal,
@@ -520,7 +520,7 @@ pub fn call<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
 /// * If the reply payload is not a valid encoding of the expected type `T`, the call results in [RejectionCode::CanisterError] error.
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_arg(..).with_cycles(..).call()` instead."
+    note = "Please use `ic_cdk::call::Call::unbounded_wait()` instead."
 )]
 pub fn call_with_payment<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     id: Principal,
@@ -567,7 +567,7 @@ pub fn call_with_payment<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
 /// * If the reply payload is not a valid encoding of the expected type `T`, the call results in [RejectionCode::CanisterError] error.
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_arg(..).with_cycles(..).call()` instead."
+    note = "Please use `ic_cdk::call::Call::unbounded_wait()` instead."
 )]
 pub fn call_with_payment128<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     id: Principal,
@@ -617,7 +617,7 @@ pub fn call_with_payment128<T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
 /// ```
 #[deprecated(
     since = "0.18.0",
-    note = "Please use `ic_cdk::call::Call::new().with_arg(..).with_cycles(..).with_decoder_config(..).call()` instead."
+    note = "Please use `ic_cdk::call::Call::unbounded_wait()` instead."
 )]
 pub fn call_with_config<'b, T: ArgumentEncoder, R: for<'a> ArgumentDecoder<'a>>(
     id: Principal,

--- a/ic-cdk/src/call.rs
+++ b/ic-cdk/src/call.rs
@@ -330,10 +330,13 @@ impl std::borrow::Borrow<[u8]> for Response {
     }
 }
 
+// Errors ---------------------------------------------------------------------
+
 /// Represents errors that can occur during inter-canister calls.
 ///
 /// This is the top-level error type for the inter-canister call API.
-/// It encapsulates all possible errors that can arise, including:
+///
+/// This encapsulates all possible errors that can arise, including:
 /// - Call failures (e.g., `ic0.call_perform` failed or asynchronously rejected).
 /// - Candid decoding failures (e.g.,  the response cannot be decoded).
 #[derive(Error, Debug, Clone)]
@@ -356,7 +359,7 @@ pub enum Error {
 ///
 /// This is the error type when awaiting a [`CallFuture`].
 ///
-/// It is wrapped by the top-level [`Error::CallFailed`] variant.
+/// This is wrapped by the top-level [`Error::CallFailed`] variant.
 #[derive(Error, Debug, Clone)]
 pub enum CallFailed {
     /// The `ic0.call_perform` operation returned a non-zero code, indicating a failure.
@@ -371,9 +374,9 @@ pub enum CallFailed {
 /// Represents an error that occurs when an inter-canister call is rejected.
 ///
 /// The [`reject_code`][`Self::reject_code`] and [`reject_message`][`Self::reject_message`]
-/// are exposed to provide information about the rejection.
+/// are exposed to provide details of the rejection.
 ///
-/// It is wrapped by the [`CallFailed::CallRejected`] variant.
+/// This is wrapped by the [`CallFailed::CallRejected`] variant.
 #[derive(Error, Debug, Clone)]
 #[error("Call rejected: {reject_code} - {reject_message}")]
 pub struct CallRejected {
@@ -387,16 +390,15 @@ pub struct CallRejected {
 
 impl CallRejected {
     /// Gets the [`RejectCode`].
+    ///
+    /// This code is obtained from [`api::msg_reject_code`](`msg_reject_code`).
     pub fn reject_code(&self) -> RejectCode {
         self.reject_code
     }
 
     /// Retrieves the reject message associated with the call.
     ///
-    /// - For an asynchronous rejection (when the IC rejects the call after it was enqueued),
-    ///   the message is obtained from [`api::msg_reject_msg`](`msg_reject_msg`).
-    /// - For a synchronous rejection (when `ic0.call_perform` returns a non-zero code),
-    ///   the message is set to a fixed string: `"call_perform failed"`.
+    /// This message is obtained from [`api::msg_reject_msg`](`msg_reject_msg`).
     pub fn reject_message(&self) -> &str {
         &self.reject_message
     }
@@ -409,7 +411,7 @@ impl CallRejected {
 ///
 /// This is the only possible error that can occur in [`Call::oneway`].
 ///
-/// It is wrapped by the [`CallFailed::CallPerformFailed`] variant.
+/// This is wrapped by the [`CallFailed::CallPerformFailed`] variant.
 #[derive(Error, Debug, Clone)]
 #[error("Call perform failed")]
 pub struct CallPerformFailed;
@@ -430,7 +432,9 @@ pub struct CandidDecodeFailed {
     candid_error: String,
 }
 
-/// Result of a inter-canister call and decoding the response.
+// Errors END -----------------------------------------------------------------
+
+/// Result of a inter-canister call.
 pub type CallResult<R> = Result<R, Error>;
 
 impl<'m, 'a> IntoFuture for Call<'m, 'a> {

--- a/ic-cdk/src/call.rs
+++ b/ic-cdk/src/call.rs
@@ -440,11 +440,10 @@ pub trait CallErrorExt {
     /// Determines if the failed call can be retried immediately within the update method
     /// that's handling the error, as opposed to relying on a background timer or heartbeat.
     ///
-    /// A return value of `true` indicates that an immediate retry *might* succeed,
-    /// but does not guarantee a clean rejection. Callers should also check [`is_clean_reject`](CallErrorExt::is_clean_reject)
-    /// to decide if retrying is appropriate.
-    ///
-    /// For idempotent endpoints, immediate retries are generally safe when this returns `true`.
+    /// A return value of `true` indicates that an immediate retry *might* succeed, i.e., not result in another error.
+    /// However, the caller is responsible for ensuring that retries are safe in their specific context.
+    /// For idempotent endpoints, immediate retries are generally safe. For non-idempotent ones,
+    /// checking [`is_clean_reject`](CallErrorExt::is_clean_reject) before retrying is recommended.
     fn is_immediately_retryable(&self) -> bool;
 }
 

--- a/ic-cdk/src/management_canister.rs
+++ b/ic-cdk/src/management_canister.rs
@@ -59,9 +59,8 @@ pub async fn create_canister(
         settings: arg.settings.clone(),
         sender_canister_version: Some(canister_version()),
     };
-    Call::new(Principal::management_canister(), "create_canister")
+    Call::unbounded_wait(Principal::management_canister(), "create_canister")
         .with_arg(&complete_arg)
-        .with_guaranteed_response()
         .with_cycles(cycles)
         .call()
         .await
@@ -91,7 +90,7 @@ pub async fn update_settings(arg: &UpdateSettingsArgs) -> CallResult<()> {
         settings: arg.settings.clone(),
         sender_canister_version: Some(canister_version()),
     };
-    Call::new(Principal::management_canister(), "update_settings")
+    Call::bounded_wait(Principal::management_canister(), "update_settings")
         .with_arg(&complete_arg)
         .call()
         .await
@@ -118,7 +117,7 @@ pub struct UpdateSettingsArgs {
 ///
 /// See [IC method `upload_chunk`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-upload_chunk).
 pub async fn upload_chunk(arg: &UploadChunkArgs) -> CallResult<UploadChunkResult> {
-    Call::new(Principal::management_canister(), "upload_chunk")
+    Call::bounded_wait(Principal::management_canister(), "upload_chunk")
         .with_arg(arg)
         .call()
         .await
@@ -128,7 +127,7 @@ pub async fn upload_chunk(arg: &UploadChunkArgs) -> CallResult<UploadChunkResult
 ///
 /// See [IC method `clear_chunk_store`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-clear_chunk_store).
 pub async fn clear_chunk_store(arg: &ClearChunkStoreArgs) -> CallResult<()> {
-    Call::new(Principal::management_canister(), "clear_chunk_store")
+    Call::bounded_wait(Principal::management_canister(), "clear_chunk_store")
         .with_arg(arg)
         .call()
         .await
@@ -138,7 +137,7 @@ pub async fn clear_chunk_store(arg: &ClearChunkStoreArgs) -> CallResult<()> {
 ///
 /// See [IC method `stored_chunks`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-stored_chunks).
 pub async fn stored_chunks(arg: &StoredChunksArgs) -> CallResult<StoredChunksResult> {
-    Call::new(Principal::management_canister(), "stored_chunks")
+    Call::bounded_wait(Principal::management_canister(), "stored_chunks")
         .with_arg(arg)
         .call()
         .await
@@ -155,7 +154,7 @@ pub async fn install_code(arg: &InstallCodeArgs) -> CallResult<()> {
         arg: arg.arg.clone(),
         sender_canister_version: Some(canister_version()),
     };
-    Call::new(Principal::management_canister(), "install_code")
+    Call::bounded_wait(Principal::management_canister(), "install_code")
         .with_arg(&complete_arg)
         .call()
         .await
@@ -196,7 +195,7 @@ pub async fn install_chunked_code(arg: &InstallChunkedCodeArgs) -> CallResult<()
         arg: arg.arg.clone(),
         sender_canister_version: Some(canister_version()),
     };
-    Call::new(Principal::management_canister(), "install_chunked_code")
+    Call::bounded_wait(Principal::management_canister(), "install_chunked_code")
         .with_arg(&complete_arg)
         .call()
         .await
@@ -237,7 +236,7 @@ pub async fn uninstall_code(arg: &UninstallCodeArgs) -> CallResult<()> {
         canister_id: arg.canister_id,
         sender_canister_version: Some(canister_version()),
     };
-    Call::new(Principal::management_canister(), "uninstall_code")
+    Call::bounded_wait(Principal::management_canister(), "uninstall_code")
         .with_arg(&complete_arg)
         .call()
         .await
@@ -262,7 +261,7 @@ pub struct UninstallCodeArgs {
 ///
 /// See [IC method `start_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-start_canister).
 pub async fn start_canister(arg: &StartCanisterArgs) -> CallResult<()> {
-    Call::new(Principal::management_canister(), "start_canister")
+    Call::bounded_wait(Principal::management_canister(), "start_canister")
         .with_arg(arg)
         .call()
         .await
@@ -272,7 +271,7 @@ pub async fn start_canister(arg: &StartCanisterArgs) -> CallResult<()> {
 ///
 /// See [IC method `stop_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-stop_canister).
 pub async fn stop_canister(arg: &StopCanisterArgs) -> CallResult<()> {
-    Call::new(Principal::management_canister(), "stop_canister")
+    Call::bounded_wait(Principal::management_canister(), "stop_canister")
         .with_arg(arg)
         .call()
         .await
@@ -282,7 +281,7 @@ pub async fn stop_canister(arg: &StopCanisterArgs) -> CallResult<()> {
 ///
 /// See [IC method `canister_status`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-canister_status).
 pub async fn canister_status(arg: &CanisterStatusArgs) -> CallResult<CanisterStatusResult> {
-    Call::new(Principal::management_canister(), "canister_status")
+    Call::bounded_wait(Principal::management_canister(), "canister_status")
         .with_arg(arg)
         .call()
         .await
@@ -292,7 +291,7 @@ pub async fn canister_status(arg: &CanisterStatusArgs) -> CallResult<CanisterSta
 ///
 /// See [IC method `canister_info`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-canister_info).
 pub async fn canister_info(arg: &CanisterInfoArgs) -> CallResult<CanisterInfoResult> {
-    Call::new(Principal::management_canister(), "canister_info")
+    Call::bounded_wait(Principal::management_canister(), "canister_info")
         .with_arg(arg)
         .call()
         .await
@@ -302,7 +301,7 @@ pub async fn canister_info(arg: &CanisterInfoArgs) -> CallResult<CanisterInfoRes
 ///
 /// See [IC method `delete_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-delete_canister).
 pub async fn delete_canister(arg: &DeleteCanisterArgs) -> CallResult<()> {
-    Call::new(Principal::management_canister(), "delete_canister")
+    Call::bounded_wait(Principal::management_canister(), "delete_canister")
         .with_arg(arg)
         .call()
         .await
@@ -312,9 +311,8 @@ pub async fn delete_canister(arg: &DeleteCanisterArgs) -> CallResult<()> {
 ///
 /// See [IC method `deposit_cycles`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-deposit_cycles).
 pub async fn deposit_cycles(arg: &DepositCyclesArgs, cycles: u128) -> CallResult<()> {
-    Call::new(Principal::management_canister(), "deposit_cycles")
+    Call::unbounded_wait(Principal::management_canister(), "deposit_cycles")
         .with_arg(arg)
-        .with_guaranteed_response()
         .with_cycles(cycles)
         .call()
         .await
@@ -324,7 +322,7 @@ pub async fn deposit_cycles(arg: &DepositCyclesArgs, cycles: u128) -> CallResult
 ///
 /// See [IC method `raw_rand`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-raw_rand).
 pub async fn raw_rand() -> CallResult<Vec<u8>> {
-    Call::new(Principal::management_canister(), "raw_rand")
+    Call::bounded_wait(Principal::management_canister(), "raw_rand")
         .call()
         .await
 }
@@ -336,9 +334,8 @@ pub async fn raw_rand() -> CallResult<Vec<u8>> {
 /// This call requires cycles payment. The required cycles is a function of the request size and max_response_bytes.
 /// Check [HTTPS outcalls cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost#https-outcalls) for more details.
 pub async fn http_request(arg: &HttpRequestArgs, cycles: u128) -> CallResult<HttpRequestResult> {
-    Call::new(Principal::management_canister(), "http_request")
+    Call::unbounded_wait(Principal::management_canister(), "http_request")
         .with_arg(arg)
-        .with_guaranteed_response()
         .with_cycles(cycles)
         .call()
         .await
@@ -440,7 +437,7 @@ pub use transform_closure::http_request_with_closure;
 ///
 /// See [IC method `ecdsa_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-ecdsa_public_key).
 pub async fn ecdsa_public_key(arg: &EcdsaPublicKeyArgs) -> CallResult<EcdsaPublicKeyResult> {
-    Call::new(Principal::management_canister(), "ecdsa_public_key")
+    Call::bounded_wait(Principal::management_canister(), "ecdsa_public_key")
         .with_arg(arg)
         .call()
         .await
@@ -454,9 +451,8 @@ pub async fn ecdsa_public_key(arg: &EcdsaPublicKeyArgs) -> CallResult<EcdsaPubli
 /// This method handles the cycles cost under the hood.
 /// Check [Threshold signatures](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works) for more details.
 pub async fn sign_with_ecdsa(arg: &SignWithEcdsaArgs) -> CallResult<SignWithEcdsaResult> {
-    Call::new(Principal::management_canister(), "sign_with_ecdsa")
+    Call::unbounded_wait(Principal::management_canister(), "sign_with_ecdsa")
         .with_arg(arg)
-        .with_guaranteed_response()
         .with_cycles(SIGN_WITH_ECDSA_FEE)
         .call()
         .await
@@ -469,7 +465,7 @@ const SIGN_WITH_ECDSA_FEE: u128 = 26_153_846_153;
 ///
 /// See [IC method `schnorr_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-schnorr_public_key).
 pub async fn schnorr_public_key(arg: &SchnorrPublicKeyArgs) -> CallResult<SchnorrPublicKeyResult> {
-    Call::new(Principal::management_canister(), "schnorr_public_key")
+    Call::bounded_wait(Principal::management_canister(), "schnorr_public_key")
         .with_arg(arg)
         .call()
         .await
@@ -483,9 +479,8 @@ pub async fn schnorr_public_key(arg: &SchnorrPublicKeyArgs) -> CallResult<Schnor
 /// This method handles the cycles cost under the hood.
 /// Check [Threshold signatures](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works) for more details.
 pub async fn sign_with_schnorr(arg: &SignWithSchnorrArgs) -> CallResult<SignWithSchnorrResult> {
-    Call::new(Principal::management_canister(), "sign_with_schnorr")
+    Call::unbounded_wait(Principal::management_canister(), "sign_with_schnorr")
         .with_arg(arg)
-        .with_guaranteed_response()
         .with_cycles(SIGN_WITH_SCHNORR_FEE)
         .call()
         .await
@@ -502,7 +497,7 @@ const SIGN_WITH_SCHNORR_FEE: u128 = 26_153_846_153;
 pub async fn node_metrics_history(
     arg: &NodeMetricsHistoryArgs,
 ) -> CallResult<NodeMetricsHistoryResult> {
-    Call::new(Principal::management_canister(), "node_metrics_history")
+    Call::bounded_wait(Principal::management_canister(), "node_metrics_history")
         .with_arg(arg)
         .call()
         .await
@@ -514,7 +509,7 @@ pub async fn node_metrics_history(
 // ! The actual url ends with `ic-subnet-info` instead of `ic-subnet_info`.
 // ! It will likely be changed to be consistent with the other methods soon.
 pub async fn subnet_info(arg: &SubnetInfoArgs) -> CallResult<SubnetInfoResult> {
-    Call::new(Principal::management_canister(), "subnet_info")
+    Call::bounded_wait(Principal::management_canister(), "subnet_info")
         .with_arg(arg)
         .call()
         .await
@@ -534,12 +529,11 @@ pub async fn provisional_create_canister_with_cycles(
         specified_id: arg.specified_id,
         sender_canister_version: Some(canister_version()),
     };
-    Call::new(
+    Call::unbounded_wait(
         Principal::management_canister(),
         "provisional_create_canister_with_cycles",
     )
     .with_arg(&complete_arg)
-    .with_guaranteed_response()
     .call()
     .await
 }
@@ -569,12 +563,11 @@ pub struct ProvisionalCreateCanisterWithCyclesArgs {
 ///
 /// See [IC method `provisional_top_up_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-provisional_top_up_canister).
 pub async fn provisional_top_up_canister(arg: &ProvisionalTopUpCanisterArgs) -> CallResult<()> {
-    Call::new(
+    Call::unbounded_wait(
         Principal::management_canister(),
         "provisional_top_up_canister",
     )
     .with_arg(arg)
-    .with_guaranteed_response()
     .call()
     .await
 }
@@ -587,9 +580,8 @@ pub async fn provisional_top_up_canister(arg: &ProvisionalTopUpCanisterArgs) -> 
 pub async fn take_canister_snapshot(
     arg: &TakeCanisterSnapshotArgs,
 ) -> CallResult<TakeCanisterSnapshotReturn> {
-    Call::new(Principal::management_canister(), "take_canister_snapshot")
+    Call::unbounded_wait(Principal::management_canister(), "take_canister_snapshot")
         .with_arg(arg)
-        .with_guaranteed_response()
         .call()
         .await
 }
@@ -605,9 +597,8 @@ pub async fn load_canister_snapshot(arg: &LoadCanisterSnapshotArgs) -> CallResul
         snapshot_id: arg.snapshot_id.clone(),
         sender_canister_version: Some(canister_version()),
     };
-    Call::new(Principal::management_canister(), "load_canister_snapshot")
+    Call::unbounded_wait(Principal::management_canister(), "load_canister_snapshot")
         .with_arg(&complete_arg)
-        .with_guaranteed_response()
         .call()
         .await
 }
@@ -635,7 +626,7 @@ pub struct LoadCanisterSnapshotArgs {
 pub async fn list_canister_snapshots(
     arg: &ListCanisterSnapshotsArgs,
 ) -> CallResult<ListCanisterSnapshotsReturn> {
-    Call::new(Principal::management_canister(), "list_canister_snapshots")
+    Call::bounded_wait(Principal::management_canister(), "list_canister_snapshots")
         .with_arg(arg)
         .call()
         .await
@@ -647,7 +638,7 @@ pub async fn list_canister_snapshots(
 ///
 /// See [IC method `delete_canister_snapshot`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-delete_canister_snapshot).
 pub async fn delete_canister_snapshot(arg: &DeleteCanisterSnapshotArgs) -> CallResult<()> {
-    Call::new(Principal::management_canister(), "delete_canister_snapshot")
+    Call::bounded_wait(Principal::management_canister(), "delete_canister_snapshot")
         .with_arg(arg)
         .call()
         .await

--- a/ic-cdk/src/management_canister.rs
+++ b/ic-cdk/src/management_canister.rs
@@ -59,11 +59,13 @@ pub async fn create_canister(
         settings: arg.settings.clone(),
         sender_canister_version: Some(canister_version()),
     };
-    Call::unbounded_wait(Principal::management_canister(), "create_canister")
-        .with_arg(&complete_arg)
-        .with_cycles(cycles)
-        .call()
-        .await
+    Ok(
+        Call::unbounded_wait(Principal::management_canister(), "create_canister")
+            .with_arg(&complete_arg)
+            .with_cycles(cycles)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Argument type of [`create_canister`].
@@ -90,10 +92,12 @@ pub async fn update_settings(arg: &UpdateSettingsArgs) -> CallResult<()> {
         settings: arg.settings.clone(),
         sender_canister_version: Some(canister_version()),
     };
-    Call::bounded_wait(Principal::management_canister(), "update_settings")
-        .with_arg(&complete_arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "update_settings")
+            .with_arg(&complete_arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Argument type of [`update_settings`]
@@ -117,30 +121,36 @@ pub struct UpdateSettingsArgs {
 ///
 /// See [IC method `upload_chunk`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-upload_chunk).
 pub async fn upload_chunk(arg: &UploadChunkArgs) -> CallResult<UploadChunkResult> {
-    Call::bounded_wait(Principal::management_canister(), "upload_chunk")
-        .with_arg(arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "upload_chunk")
+            .with_arg(arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Clears the chunk store of a canister.
 ///
 /// See [IC method `clear_chunk_store`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-clear_chunk_store).
 pub async fn clear_chunk_store(arg: &ClearChunkStoreArgs) -> CallResult<()> {
-    Call::bounded_wait(Principal::management_canister(), "clear_chunk_store")
-        .with_arg(arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "clear_chunk_store")
+            .with_arg(arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Gets the hashes of all chunks stored in the chunk store of a canister.
 ///
 /// See [IC method `stored_chunks`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-stored_chunks).
 pub async fn stored_chunks(arg: &StoredChunksArgs) -> CallResult<StoredChunksResult> {
-    Call::bounded_wait(Principal::management_canister(), "stored_chunks")
-        .with_arg(arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "stored_chunks")
+            .with_arg(arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Installs code into a canister.
@@ -154,10 +164,12 @@ pub async fn install_code(arg: &InstallCodeArgs) -> CallResult<()> {
         arg: arg.arg.clone(),
         sender_canister_version: Some(canister_version()),
     };
-    Call::bounded_wait(Principal::management_canister(), "install_code")
-        .with_arg(&complete_arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "install_code")
+            .with_arg(&complete_arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Argument type of [`install_code`].
@@ -195,10 +207,12 @@ pub async fn install_chunked_code(arg: &InstallChunkedCodeArgs) -> CallResult<()
         arg: arg.arg.clone(),
         sender_canister_version: Some(canister_version()),
     };
-    Call::bounded_wait(Principal::management_canister(), "install_chunked_code")
-        .with_arg(&complete_arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "install_chunked_code")
+            .with_arg(&complete_arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Argument type of [`install_chunked_code`].
@@ -236,10 +250,12 @@ pub async fn uninstall_code(arg: &UninstallCodeArgs) -> CallResult<()> {
         canister_id: arg.canister_id,
         sender_canister_version: Some(canister_version()),
     };
-    Call::bounded_wait(Principal::management_canister(), "uninstall_code")
-        .with_arg(&complete_arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "uninstall_code")
+            .with_arg(&complete_arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Argument type of [`uninstall_code`].
@@ -261,70 +277,84 @@ pub struct UninstallCodeArgs {
 ///
 /// See [IC method `start_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-start_canister).
 pub async fn start_canister(arg: &StartCanisterArgs) -> CallResult<()> {
-    Call::bounded_wait(Principal::management_canister(), "start_canister")
-        .with_arg(arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "start_canister")
+            .with_arg(arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Stops a canister.
 ///
 /// See [IC method `stop_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-stop_canister).
 pub async fn stop_canister(arg: &StopCanisterArgs) -> CallResult<()> {
-    Call::bounded_wait(Principal::management_canister(), "stop_canister")
-        .with_arg(arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "stop_canister")
+            .with_arg(arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Gets status information about the canister.
 ///
 /// See [IC method `canister_status`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-canister_status).
 pub async fn canister_status(arg: &CanisterStatusArgs) -> CallResult<CanisterStatusResult> {
-    Call::bounded_wait(Principal::management_canister(), "canister_status")
-        .with_arg(arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "canister_status")
+            .with_arg(arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Gets public information about the canister.
 ///
 /// See [IC method `canister_info`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-canister_info).
 pub async fn canister_info(arg: &CanisterInfoArgs) -> CallResult<CanisterInfoResult> {
-    Call::bounded_wait(Principal::management_canister(), "canister_info")
-        .with_arg(arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "canister_info")
+            .with_arg(arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Deletes a canister.
 ///
 /// See [IC method `delete_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-delete_canister).
 pub async fn delete_canister(arg: &DeleteCanisterArgs) -> CallResult<()> {
-    Call::bounded_wait(Principal::management_canister(), "delete_canister")
-        .with_arg(arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "delete_canister")
+            .with_arg(arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Deposits cycles to a canister.
 ///
 /// See [IC method `deposit_cycles`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-deposit_cycles).
 pub async fn deposit_cycles(arg: &DepositCyclesArgs, cycles: u128) -> CallResult<()> {
-    Call::unbounded_wait(Principal::management_canister(), "deposit_cycles")
-        .with_arg(arg)
-        .with_cycles(cycles)
-        .call()
-        .await
+    Ok(
+        Call::unbounded_wait(Principal::management_canister(), "deposit_cycles")
+            .with_arg(arg)
+            .with_cycles(cycles)
+            .await?
+            .candid()?,
+    )
 }
 
 // Gets 32 pseudo-random bytes.
 ///
 /// See [IC method `raw_rand`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-raw_rand).
 pub async fn raw_rand() -> CallResult<Vec<u8>> {
-    Call::bounded_wait(Principal::management_canister(), "raw_rand")
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "raw_rand")
+            .await?
+            .candid()?,
+    )
 }
 
 /// Makes an HTTP request to a given URL and return the HTTP response, possibly after a transformation.
@@ -334,11 +364,13 @@ pub async fn raw_rand() -> CallResult<Vec<u8>> {
 /// This call requires cycles payment. The required cycles is a function of the request size and max_response_bytes.
 /// Check [HTTPS outcalls cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost#https-outcalls) for more details.
 pub async fn http_request(arg: &HttpRequestArgs, cycles: u128) -> CallResult<HttpRequestResult> {
-    Call::unbounded_wait(Principal::management_canister(), "http_request")
-        .with_arg(arg)
-        .with_cycles(cycles)
-        .call()
-        .await
+    Ok(
+        Call::unbounded_wait(Principal::management_canister(), "http_request")
+            .with_arg(arg)
+            .with_cycles(cycles)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Constructs a [`TransformContext`] from a query method name and context.
@@ -437,10 +469,12 @@ pub use transform_closure::http_request_with_closure;
 ///
 /// See [IC method `ecdsa_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-ecdsa_public_key).
 pub async fn ecdsa_public_key(arg: &EcdsaPublicKeyArgs) -> CallResult<EcdsaPublicKeyResult> {
-    Call::bounded_wait(Principal::management_canister(), "ecdsa_public_key")
-        .with_arg(arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "ecdsa_public_key")
+            .with_arg(arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Gets a new ECDSA signature of the given message_hash that can be separately verified against a derived ECDSA public key.
@@ -451,11 +485,13 @@ pub async fn ecdsa_public_key(arg: &EcdsaPublicKeyArgs) -> CallResult<EcdsaPubli
 /// This method handles the cycles cost under the hood.
 /// Check [Threshold signatures](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works) for more details.
 pub async fn sign_with_ecdsa(arg: &SignWithEcdsaArgs) -> CallResult<SignWithEcdsaResult> {
-    Call::unbounded_wait(Principal::management_canister(), "sign_with_ecdsa")
-        .with_arg(arg)
-        .with_cycles(SIGN_WITH_ECDSA_FEE)
-        .call()
-        .await
+    Ok(
+        Call::unbounded_wait(Principal::management_canister(), "sign_with_ecdsa")
+            .with_arg(arg)
+            .with_cycles(SIGN_WITH_ECDSA_FEE)
+            .await?
+            .candid()?,
+    )
 }
 
 /// https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key
@@ -465,10 +501,12 @@ const SIGN_WITH_ECDSA_FEE: u128 = 26_153_846_153;
 ///
 /// See [IC method `schnorr_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-schnorr_public_key).
 pub async fn schnorr_public_key(arg: &SchnorrPublicKeyArgs) -> CallResult<SchnorrPublicKeyResult> {
-    Call::bounded_wait(Principal::management_canister(), "schnorr_public_key")
-        .with_arg(arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "schnorr_public_key")
+            .with_arg(arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Gets a new Schnorr signature of the given message that can be separately verified against a derived Schnorr public key.
@@ -479,11 +517,13 @@ pub async fn schnorr_public_key(arg: &SchnorrPublicKeyArgs) -> CallResult<Schnor
 /// This method handles the cycles cost under the hood.
 /// Check [Threshold signatures](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works) for more details.
 pub async fn sign_with_schnorr(arg: &SignWithSchnorrArgs) -> CallResult<SignWithSchnorrResult> {
-    Call::unbounded_wait(Principal::management_canister(), "sign_with_schnorr")
-        .with_arg(arg)
-        .with_cycles(SIGN_WITH_SCHNORR_FEE)
-        .call()
-        .await
+    Ok(
+        Call::unbounded_wait(Principal::management_canister(), "sign_with_schnorr")
+            .with_arg(arg)
+            .with_cycles(SIGN_WITH_SCHNORR_FEE)
+            .await?
+            .candid()?,
+    )
 }
 
 /// https://internetcomputer.org/docs/current/references/t-sigs-how-it-works/#fees-for-the-t-schnorr-production-key
@@ -497,10 +537,12 @@ const SIGN_WITH_SCHNORR_FEE: u128 = 26_153_846_153;
 pub async fn node_metrics_history(
     arg: &NodeMetricsHistoryArgs,
 ) -> CallResult<NodeMetricsHistoryResult> {
-    Call::bounded_wait(Principal::management_canister(), "node_metrics_history")
-        .with_arg(arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "node_metrics_history")
+            .with_arg(arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Gets the metadata about a subnet.
@@ -509,10 +551,12 @@ pub async fn node_metrics_history(
 // ! The actual url ends with `ic-subnet-info` instead of `ic-subnet_info`.
 // ! It will likely be changed to be consistent with the other methods soon.
 pub async fn subnet_info(arg: &SubnetInfoArgs) -> CallResult<SubnetInfoResult> {
-    Call::bounded_wait(Principal::management_canister(), "subnet_info")
-        .with_arg(arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "subnet_info")
+            .with_arg(arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Creates a new canister with specified amount of cycles balance.
@@ -529,13 +573,13 @@ pub async fn provisional_create_canister_with_cycles(
         specified_id: arg.specified_id,
         sender_canister_version: Some(canister_version()),
     };
-    Call::unbounded_wait(
+    Ok(Call::unbounded_wait(
         Principal::management_canister(),
         "provisional_create_canister_with_cycles",
     )
     .with_arg(&complete_arg)
-    .call()
-    .await
+    .await?
+    .candid()?)
 }
 
 /// Argument type of [`provisional_create_canister_with_cycles`].
@@ -563,13 +607,13 @@ pub struct ProvisionalCreateCanisterWithCyclesArgs {
 ///
 /// See [IC method `provisional_top_up_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-provisional_top_up_canister).
 pub async fn provisional_top_up_canister(arg: &ProvisionalTopUpCanisterArgs) -> CallResult<()> {
-    Call::unbounded_wait(
+    Ok(Call::unbounded_wait(
         Principal::management_canister(),
         "provisional_top_up_canister",
     )
     .with_arg(arg)
-    .call()
-    .await
+    .await?
+    .candid()?)
 }
 
 /// Take a snapshot of the specified canister.
@@ -580,10 +624,12 @@ pub async fn provisional_top_up_canister(arg: &ProvisionalTopUpCanisterArgs) -> 
 pub async fn take_canister_snapshot(
     arg: &TakeCanisterSnapshotArgs,
 ) -> CallResult<TakeCanisterSnapshotReturn> {
-    Call::unbounded_wait(Principal::management_canister(), "take_canister_snapshot")
-        .with_arg(arg)
-        .call()
-        .await
+    Ok(
+        Call::unbounded_wait(Principal::management_canister(), "take_canister_snapshot")
+            .with_arg(arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Load a snapshot onto the canister.
@@ -597,10 +643,12 @@ pub async fn load_canister_snapshot(arg: &LoadCanisterSnapshotArgs) -> CallResul
         snapshot_id: arg.snapshot_id.clone(),
         sender_canister_version: Some(canister_version()),
     };
-    Call::unbounded_wait(Principal::management_canister(), "load_canister_snapshot")
-        .with_arg(&complete_arg)
-        .call()
-        .await
+    Ok(
+        Call::unbounded_wait(Principal::management_canister(), "load_canister_snapshot")
+            .with_arg(&complete_arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Argument type of [`load_canister_snapshot`].
@@ -626,10 +674,12 @@ pub struct LoadCanisterSnapshotArgs {
 pub async fn list_canister_snapshots(
     arg: &ListCanisterSnapshotsArgs,
 ) -> CallResult<ListCanisterSnapshotsReturn> {
-    Call::bounded_wait(Principal::management_canister(), "list_canister_snapshots")
-        .with_arg(arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "list_canister_snapshots")
+            .with_arg(arg)
+            .await?
+            .candid()?,
+    )
 }
 
 /// Delete a specified snapshot that belongs to an existing canister.
@@ -638,8 +688,10 @@ pub async fn list_canister_snapshots(
 ///
 /// See [IC method `delete_canister_snapshot`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-delete_canister_snapshot).
 pub async fn delete_canister_snapshot(arg: &DeleteCanisterSnapshotArgs) -> CallResult<()> {
-    Call::bounded_wait(Principal::management_canister(), "delete_canister_snapshot")
-        .with_arg(arg)
-        .call()
-        .await
+    Ok(
+        Call::bounded_wait(Principal::management_canister(), "delete_canister_snapshot")
+            .with_arg(arg)
+            .await?
+            .candid()?,
+    )
 }

--- a/ic-response-codes/src/lib.rs
+++ b/ic-response-codes/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 use std::error::Error;
+use std::fmt::Display;
 
 /// Classifies why an API request or inter-canister call in the IC is rejected.
 ///
@@ -39,13 +40,27 @@ pub enum RejectCode {
     Unrecognized(u32),
 }
 
+impl Display for RejectCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RejectCode::SysFatal => write!(f, "SysFatal(1)"),
+            RejectCode::SysTransient => write!(f, "SysTransient(2)"),
+            RejectCode::DestinationInvalid => write!(f, "DestinationInvalid(3)"),
+            RejectCode::CanisterReject => write!(f, "CanisterReject(4)"),
+            RejectCode::CanisterError => write!(f, "CanisterError(5)"),
+            RejectCode::SysUnknown => write!(f, "SysUnknown(6)"),
+            RejectCode::Unrecognized(code) => write!(f, "Unrecognized({})", code),
+        }
+    }
+}
+
 /// Error type for [`RejectCode`] conversion.
 ///
 /// The only case where this error can occur is when trying to convert a 0 to a [`RejectCode`].
 #[derive(Clone, Copy, Debug)]
 pub struct ZeroIsInvalidRejectCode;
 
-impl std::fmt::Display for ZeroIsInvalidRejectCode {
+impl Display for ZeroIsInvalidRejectCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "zero is invalid reject code")
     }

--- a/library/ic-ledger-types/src/lib.rs
+++ b/library/ic-ledger-types/src/lib.rs
@@ -691,7 +691,7 @@ pub async fn account_balance(
     ledger_canister_id: Principal,
     args: &AccountBalanceArgs,
 ) -> CallResult<Tokens> {
-    Call::new(ledger_canister_id, "account_balance")
+    Call::bounded_wait(ledger_canister_id, "account_balance")
         .with_arg(args)
         .call()
         .await
@@ -721,7 +721,7 @@ pub async fn transfer(
     ledger_canister_id: Principal,
     args: &TransferArgs,
 ) -> CallResult<TransferResult> {
-    Call::new(ledger_canister_id, "transfer")
+    Call::bounded_wait(ledger_canister_id, "transfer")
         .with_arg(args)
         .call()
         .await
@@ -745,7 +745,9 @@ pub struct Symbol {
 /// }
 /// ```
 pub async fn token_symbol(ledger_canister_id: Principal) -> CallResult<Symbol> {
-    Call::new(ledger_canister_id, "token_symbol").call().await
+    Call::bounded_wait(ledger_canister_id, "token_symbol")
+        .call()
+        .await
 }
 
 /// Calls the "query_block" method on the specified canister.
@@ -780,7 +782,7 @@ pub async fn query_blocks(
     ledger_canister_id: Principal,
     args: &GetBlocksArgs,
 ) -> CallResult<QueryBlocksResponse> {
-    Call::new(ledger_canister_id, "query_blocks")
+    Call::bounded_wait(ledger_canister_id, "query_blocks")
         .with_arg(args)
         .call()
         .await
@@ -820,7 +822,7 @@ pub async fn query_archived_blocks(
     func: &QueryArchiveFn,
     args: &GetBlocksArgs,
 ) -> CallResult<GetBlocksResult> {
-    Call::new(func.0.principal, &func.0.method)
+    Call::bounded_wait(func.0.principal, &func.0.method)
         .with_arg(args)
         .call()
         .await

--- a/library/ic-ledger-types/src/lib.rs
+++ b/library/ic-ledger-types/src/lib.rs
@@ -691,10 +691,10 @@ pub async fn account_balance(
     ledger_canister_id: Principal,
     args: &AccountBalanceArgs,
 ) -> CallResult<Tokens> {
-    Call::bounded_wait(ledger_canister_id, "account_balance")
+    Ok(Call::bounded_wait(ledger_canister_id, "account_balance")
         .with_arg(args)
-        .call()
-        .await
+        .await?
+        .candid()?)
 }
 
 /// Calls the "transfer" method on the specified canister.
@@ -721,10 +721,10 @@ pub async fn transfer(
     ledger_canister_id: Principal,
     args: &TransferArgs,
 ) -> CallResult<TransferResult> {
-    Call::bounded_wait(ledger_canister_id, "transfer")
+    Ok(Call::bounded_wait(ledger_canister_id, "transfer")
         .with_arg(args)
-        .call()
-        .await
+        .await?
+        .candid()?)
 }
 
 /// Return type of the `token_symbol` function.
@@ -745,9 +745,9 @@ pub struct Symbol {
 /// }
 /// ```
 pub async fn token_symbol(ledger_canister_id: Principal) -> CallResult<Symbol> {
-    Call::bounded_wait(ledger_canister_id, "token_symbol")
-        .call()
-        .await
+    Ok(Call::bounded_wait(ledger_canister_id, "token_symbol")
+        .await?
+        .candid()?)
 }
 
 /// Calls the "query_block" method on the specified canister.
@@ -782,10 +782,10 @@ pub async fn query_blocks(
     ledger_canister_id: Principal,
     args: &GetBlocksArgs,
 ) -> CallResult<QueryBlocksResponse> {
-    Call::bounded_wait(ledger_canister_id, "query_blocks")
+    Ok(Call::bounded_wait(ledger_canister_id, "query_blocks")
         .with_arg(args)
-        .call()
-        .await
+        .await?
+        .candid()?)
 }
 
 /// Continues a query started in [`query_blocks`] by calling its returned archive function.
@@ -822,10 +822,10 @@ pub async fn query_archived_blocks(
     func: &QueryArchiveFn,
     args: &GetBlocksArgs,
 ) -> CallResult<GetBlocksResult> {
-    Call::bounded_wait(func.0.principal, &func.0.method)
+    Ok(Call::bounded_wait(func.0.principal, &func.0.method)
         .with_arg(args)
-        .call()
-        .await
+        .await?
+        .candid()?)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
SDK-1950

# Description

For maintainable better user experience, this PR made some fundamental changes to the inter-canister call API (`call.rs`).

## Constructors

Replaced `Call::new()` with `Call::bounded_wait()` and `Call::unbounded_wait()`.

## Execution

- `impl IntoFuture for Call`. So that a `Call` can be `.await` directly instead of invoking the `call*` method. No awkward `Call::new().call()` syntax.

- Replaced the oneway execution with the shorter and clearer `Call::oneway()` method.

- After a `Call` is executed by `await` , a `candid()`/`candid_tuple()` method can be chained to decode the response.

## Errors

- `Error`: The top-level error type encapsulating all possible errors.
- `CallFailed`: Errors related to the execution of the call itself.
- `CallRejected`: Errors when an inter-canister call is rejected.
- `CallPerformFailed`: Errors when the `ic0.call_perform` operation fails.
- `CandidDecodeFailed`: Errors when the response cannot be decoded as Candid.

```text
Error
├── CallFailed
│   ├── CallPerformFailed
│   └── CallRejected
└── CandidDecodeFailed
```

Also a `CallErrorExt` trait is added and implemented for all error types above.
The trait has two methods:
- `is_clean_reject()`
- `is_immediately_retryable()`

> [!NOTE]
> The `CallErrorExt` trait must be explicitly imported to access its methods.

# How Has This Been Tested?

e2e tests: `call.rs`

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
