### PR TITLE
feat: add _with_cycles postfix to management canister methods that require cycles

### DIFF
--- a/e2e-tests/src/bin/canister_info.rs
+++ b/e2e-tests/src/bin/canister_info.rs
@@ -1,6 +1,6 @@
 use candid::Principal;
 use ic_cdk::management_canister::{
-    canister_info, create_canister, install_code, uninstall_code, update_settings,
+    canister_info, create_canister_with_cycles, install_code, uninstall_code, update_settings,
     CanisterInfoArgs, CanisterInfoResult,
     CanisterInstallMode::{Install, Reinstall, Upgrade},
     CanisterSettings, CreateCanisterArgs, InstallCodeArgs, UninstallCodeArgs, UpdateSettingsArgs,
@@ -17,10 +17,11 @@ async fn info(canister_id: Principal) -> CanisterInfoResult {
 
 #[ic_cdk::update]
 async fn canister_lifecycle() -> Principal {
-    let canister_id = create_canister(&CreateCanisterArgs { settings: None }, 1_000_000_000_000)
-        .await
-        .unwrap()
-        .canister_id;
+    let canister_id =
+        create_canister_with_cycles(&CreateCanisterArgs::default(), 1_000_000_000_000)
+            .await
+            .unwrap()
+            .canister_id;
     install_code(&InstallCodeArgs {
         mode: Install,
         arg: vec![],

--- a/e2e-tests/src/bin/chunk.rs
+++ b/e2e-tests/src/bin/chunk.rs
@@ -1,16 +1,14 @@
 use candid::Principal;
 use ic_cdk::management_canister::{
-    clear_chunk_store, create_canister, install_chunked_code, stored_chunks, upload_chunk,
-    CanisterInstallMode, ChunkHash, ClearChunkStoreArgs, CreateCanisterArgs,
+    clear_chunk_store, create_canister_with_cycles, install_chunked_code, stored_chunks,
+    upload_chunk, CanisterInstallMode, ChunkHash, ClearChunkStoreArgs, CreateCanisterArgs,
     InstallChunkedCodeArgs, StoredChunksArgs, UploadChunkArgs,
 };
 use ic_cdk::update;
 
 #[update]
 async fn call_create_canister() -> Principal {
-    let arg = CreateCanisterArgs::default();
-
-    create_canister(&arg, 1_000_000_000_000u128)
+    create_canister_with_cycles(&CreateCanisterArgs::default(), 1_000_000_000_000u128)
         .await
         .unwrap()
         .canister_id
@@ -22,7 +20,6 @@ async fn call_upload_chunk(canister_id: Principal, chunk: Vec<u8>) -> Vec<u8> {
         canister_id,
         chunk: chunk.to_vec(),
     };
-
     upload_chunk(&arg).await.unwrap().hash
 }
 

--- a/e2e-tests/src/bin/http_request.rs
+++ b/e2e-tests/src/bin/http_request.rs
@@ -1,6 +1,6 @@
 use ic_cdk::management_canister::{
-    http_request, http_request_with_closure, transform_context_from_query, HttpHeader, HttpMethod,
-    HttpRequestArgs, HttpRequestResult, TransformArgs,
+    http_request_with_closure, http_request_with_cycles, transform_context_from_query, HttpHeader,
+    HttpMethod, HttpRequestArgs, HttpRequestResult, TransformArgs,
 };
 use ic_cdk::{query, update};
 
@@ -38,7 +38,7 @@ async fn get_without_transform() {
         transform: None,
     };
     let cycles = cycles_cost(&args);
-    let res = http_request(&args, cycles).await.unwrap();
+    let res = http_request_with_cycles(&args, cycles).await.unwrap();
     assert_eq!(res.status, 200u32);
     assert_eq!(
         res.headers,
@@ -59,7 +59,7 @@ async fn post() {
         ..Default::default()
     };
     let cycles = cycles_cost(&args);
-    http_request(&args, cycles).await.unwrap();
+    http_request_with_cycles(&args, cycles).await.unwrap();
 }
 
 /// Method is HEAD.
@@ -71,7 +71,7 @@ async fn head() {
         ..Default::default()
     };
     let cycles = cycles_cost(&args);
-    http_request(&args, cycles).await.unwrap();
+    http_request_with_cycles(&args, cycles).await.unwrap();
 }
 
 /// The standard way to define a transform function.
@@ -101,7 +101,7 @@ async fn get_with_transform() {
         ..Default::default()
     };
     let cycles = cycles_cost(&args);
-    let res = http_request(&args, cycles).await.unwrap();
+    let res = http_request_with_cycles(&args, cycles).await.unwrap();
     assert_eq!(res.status, 200u32);
     assert_eq!(
         res.headers,

--- a/e2e-tests/src/bin/http_request.rs
+++ b/e2e-tests/src/bin/http_request.rs
@@ -1,6 +1,6 @@
 use ic_cdk::management_canister::{
-    http_request_with_closure, http_request_with_cycles, transform_context_from_query, HttpHeader,
-    HttpMethod, HttpRequestArgs, HttpRequestResult, TransformArgs,
+    http_request_with_closure_with_cycles, http_request_with_cycles, transform_context_from_query,
+    HttpHeader, HttpMethod, HttpRequestArgs, HttpRequestResult, TransformArgs,
 };
 use ic_cdk::{query, update};
 
@@ -134,7 +134,7 @@ async fn get_with_transform_closure() {
     };
     // The transform closure takes 40 bytes.
     let cycles = cycles_cost(&args) + 40 * 400 * 13;
-    let res = http_request_with_closure(&args, cycles, transform)
+    let res = http_request_with_closure_with_cycles(&args, transform, cycles)
         .await
         .unwrap();
     assert_eq!(res.status, 200u32);

--- a/e2e-tests/src/bin/management_canister.rs
+++ b/e2e-tests/src/bin/management_canister.rs
@@ -21,7 +21,7 @@ async fn basic() {
     };
     // 500 B is the minimum cycles required to create a canister.
     // Here we set 1 T cycles for other operations below.
-    let canister_id = create_canister(&arg, 1_000_000_000_000u128)
+    let canister_id = create_canister_with_cycles(&arg, 1_000_000_000_000u128)
         .await
         .unwrap()
         .canister_id;
@@ -117,7 +117,13 @@ async fn ecdsa() {
         derivation_path,
         key_id,
     };
-    let SignWithEcdsaResult { signature } = sign_with_ecdsa(&arg).await.unwrap();
+    // The test key resides on a regular-sized (13-node) application subnet.
+    // So the fee is 10 T cycles.
+    // https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-test-key
+    const SIGN_WITH_ECDSA_FEE: u128 = 10_000_000_000;
+    let SignWithEcdsaResult { signature } = sign_with_ecdsa_with_cycles(&arg, SIGN_WITH_ECDSA_FEE)
+        .await
+        .unwrap();
     assert_eq!(signature.len(), 64);
 }
 
@@ -163,7 +169,14 @@ async fn schnorr() {
         key_id,
         aux: None,
     };
-    let SignWithSchnorrResult { signature } = sign_with_schnorr(&arg).await.unwrap();
+    // The test key resides on a regular-sized (13-node) application subnet.
+    // So the fee is 10 T cycles.
+    // https://internetcomputer.org/docs/current/references/t-sigs-how-it-works/#fees-for-the-t-schnorr-test-key
+    const SIGN_WITH_SCHNORR_FEE: u128 = 10_000_000_000;
+    let SignWithSchnorrResult { signature } =
+        sign_with_schnorr_with_cycles(&arg, SIGN_WITH_SCHNORR_FEE)
+            .await
+            .unwrap();
     assert_eq!(signature.len(), 64);
 }
 
@@ -219,7 +232,7 @@ async fn provisional() {
 #[update]
 async fn snapshots() {
     let arg = CreateCanisterArgs::default();
-    let canister_id = create_canister(&arg, 2_000_000_000_000u128)
+    let canister_id = create_canister_with_cycles(&arg, 2_000_000_000_000u128)
         .await
         .unwrap()
         .canister_id;

--- a/ic-cdk/src/management_canister.rs
+++ b/ic-cdk/src/management_canister.rs
@@ -46,13 +46,14 @@ use ic_management_canister_types::{
     UpdateSettingsArgs as UpdateSettingsArgsComplete,
 };
 
-/// Registers a new canister and get its canister id.
+/// Creates a new canister with a user-specified amount of cycles.
 ///
 /// See [IC method `create_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-create_canister).
 ///
-/// This call requires cycles payment. The required cycles varies according to the subnet size (number of nodes).
-/// Check [Gas and cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost) for more details.
-pub async fn create_canister(
+/// Canister creation costs cycles. That amount will be deducted from the newly created canister.
+/// Therefore, the caller must provide enough cycles to cover the cost.
+/// Check [Gas and cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost#canister-creation) for more details.
+pub async fn create_canister_with_cycles(
     arg: &CreateCanisterArgs,
     cycles: u128,
 ) -> CallResult<CreateCanisterResult> {
@@ -347,7 +348,7 @@ pub async fn deposit_cycles(arg: &DepositCyclesArgs, cycles: u128) -> CallResult
     )
 }
 
-// Gets 32 pseudo-random bytes.
+/// Gets 32 pseudo-random bytes.
 ///
 /// See [IC method `raw_rand`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-raw_rand).
 pub async fn raw_rand() -> CallResult<RawRandResult> {
@@ -358,13 +359,16 @@ pub async fn raw_rand() -> CallResult<RawRandResult> {
     )
 }
 
-/// Makes an HTTP request to a given URL and return the HTTP response, possibly after a transformation.
+/// Makes an HTTP outcall with a user-specified amount of cycles.
 ///
 /// See [IC method `http_request`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-http_request).
 ///
 /// This call requires cycles payment. The required cycles is a function of the request size and max_response_bytes.
 /// Check [HTTPS outcalls cycles cost](https://internetcomputer.org/docs/current/developer-docs/gas-cost#https-outcalls) for more details.
-pub async fn http_request(arg: &HttpRequestArgs, cycles: u128) -> CallResult<HttpRequestResult> {
+pub async fn http_request_with_cycles(
+    arg: &HttpRequestArgs,
+    cycles: u128,
+) -> CallResult<HttpRequestResult> {
     Ok(
         Call::unbounded_wait(Principal::management_canister(), "http_request")
             .with_arg(arg)
@@ -392,8 +396,8 @@ pub fn transform_context_from_query(
 #[cfg(feature = "transform-closure")]
 mod transform_closure {
     use super::{
-        http_request, transform_context_from_query, CallResult, HttpRequestArgs, HttpRequestResult,
-        Principal, TransformArgs,
+        http_request_with_cycles, transform_context_from_query, CallResult, HttpRequestArgs,
+        HttpRequestResult, Principal, TransformArgs,
     };
     use candid::{decode_one, encode_one};
     use slotmap::{DefaultKey, Key, KeyData, SlotMap};
@@ -459,7 +463,7 @@ mod transform_closure {
             )),
             ..arg.clone()
         };
-        http_request(&arg, cycles).await
+        http_request_with_cycles(&arg, cycles).await
     }
 }
 
@@ -478,25 +482,26 @@ pub async fn ecdsa_public_key(arg: &EcdsaPublicKeyArgs) -> CallResult<EcdsaPubli
     )
 }
 
-/// Gets a new ECDSA signature of the given message_hash that can be separately verified against a derived ECDSA public key.
+/// Gets a new ECDSA signature of the given message_hash with a user-specified amount of cycles.
+///
+/// The signature can be separately verified against a derived ECDSA public key.
 ///
 /// See [IC method `sign_with_ecdsa`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_ecdsa).
 ///
-/// This call requires cycles payment.
-/// This method handles the cycles cost under the hood.
-/// Check [Threshold signatures](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works) for more details.
-pub async fn sign_with_ecdsa(arg: &SignWithEcdsaArgs) -> CallResult<SignWithEcdsaResult> {
+/// This call requires cycles payment which varies for different keys.
+/// Check [Threshold signatures](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works/#api-fees) for more details.
+pub async fn sign_with_ecdsa_with_cycles(
+    arg: &SignWithEcdsaArgs,
+    cycles: u128,
+) -> CallResult<SignWithEcdsaResult> {
     Ok(
         Call::unbounded_wait(Principal::management_canister(), "sign_with_ecdsa")
             .with_arg(arg)
-            .with_cycles(SIGN_WITH_ECDSA_FEE)
+            .with_cycles(cycles)
             .await?
             .candid()?,
     )
 }
-
-/// https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key
-const SIGN_WITH_ECDSA_FEE: u128 = 26_153_846_153;
 
 /// Gets a SEC1 encoded Schnorr public key for the given canister using the given derivation path.
 ///
@@ -510,25 +515,26 @@ pub async fn schnorr_public_key(arg: &SchnorrPublicKeyArgs) -> CallResult<Schnor
     )
 }
 
-/// Gets a new Schnorr signature of the given message that can be separately verified against a derived Schnorr public key.
+/// Gets a new Schnorr signature of the given message with a user-specified amount of cycles.
+///
+/// The signature can be separately verified against a derived Schnorr public key.
 ///
 /// See [IC method `sign_with_schnorr`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_schnorr).
 ///
-/// This call requires cycles payment.
-/// This method handles the cycles cost under the hood.
-/// Check [Threshold signatures](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works) for more details.
-pub async fn sign_with_schnorr(arg: &SignWithSchnorrArgs) -> CallResult<SignWithSchnorrResult> {
+/// This call requires cycles payment which varies for different keys.
+/// Check [Threshold signatures](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works/#api-fees) for more details.
+pub async fn sign_with_schnorr_with_cycles(
+    arg: &SignWithSchnorrArgs,
+    cycles: u128,
+) -> CallResult<SignWithSchnorrResult> {
     Ok(
         Call::unbounded_wait(Principal::management_canister(), "sign_with_schnorr")
             .with_arg(arg)
-            .with_cycles(SIGN_WITH_SCHNORR_FEE)
+            .with_cycles(cycles)
             .await?
             .candid()?,
     )
 }
-
-/// https://internetcomputer.org/docs/current/references/t-sigs-how-it-works/#fees-for-the-t-schnorr-production-key
-const SIGN_WITH_SCHNORR_FEE: u128 = 26_153_846_153;
 
 /// Gets a time series of subnet's node metrics.
 ///

--- a/ic-management-canister-types/CHANGELOG.md
+++ b/ic-management-canister-types/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+
+- Doc: `HttpRequestArgs::max_response_bytes` is capped at 2MB, not 2MiB.
+
 ## [0.2.0] - 2025-02-18
 
 ### Changed

--- a/ic-management-canister-types/src/lib.rs
+++ b/ic-management-canister-types/src/lib.rs
@@ -690,11 +690,11 @@ pub struct HttpRequestArgs {
     pub url: String,
     /// The maximal size of the response in bytes.
     ///
-    /// If None, 2MiB will be the limit.
+    /// If None, 2MB will be the limit.
     /// This value affects the cost of the http request and it is highly recommended
     /// to set it as low as possible to avoid unnecessary extra costs.
     ///
-    /// See also the [pricing section of HTTP outcalls documentation](https://internetcomputer.org/docs/current/developer-docs/integrations/http_requests/http_requests-how-it-works#pricing).
+    /// See also the [pricing section of HTTP outcalls documentation](https://internetcomputer.org/docs/current/references/https-outcalls-how-it-works#pricing).
     pub max_response_bytes: Option<u64>,
     /// The method of HTTP request.
     pub method: HttpMethod,


### PR DESCRIPTION
# Description

Renamed:
- `create_canister` -> `create_canister_with_cycles`
- `sign_with_ecdsa` -> `sign_with_ecdsa_with_cycles`
- `sign_with_schnorr` -> `sign_with_schnorr_with_cycles`
- `http_request` -> `http_request_with_cycles`
- `http_request_with_closure` -> `http_request_with_closure_with_cycles`

It is intended to make the method names longer. Because we will soon have the [System API to calculate cycle cost](https://github.com/dfinity/portal/pull/4110) for these management canister API. Once it is available, we can provide the methods without the postfix which handle the cycle cost calculation under the hood.

Also did a minor doc fix in `ic-management-canister-types`.

# How Has This Been Tested?

e2e

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
