### PR TITLE
feat: Add types for fetching canister logs

### DIFF
--- a/ic-management-canister-types/CHANGELOG.md
+++ b/ic-management-canister-types/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.2.1] - 2025-02-28
+
 ### Added
 
-- Types for IC management canister method `fetch_canister_logs`.
+- Types for `fetch_canister_logs`.
+- `CanisterIdRecord`, an alias for various argument and result types to enhance inter-operability.
 
 ### Fixed
 

--- a/ic-management-canister-types/CHANGELOG.md
+++ b/ic-management-canister-types/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+
+### Added
+
+- Types for IC management canister method `fetch_canister_logs`.
 
 ### Fixed
 

--- a/ic-management-canister-types/Cargo.toml
+++ b/ic-management-canister-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-management-canister-types"
-version = "0.2.0"
+version = "0.2.1"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/ic-management-canister-types/src/lib.rs
+++ b/ic-management-canister-types/src/lib.rs
@@ -8,7 +8,9 @@ pub type CanisterId = Principal;
 
 /// # Canister ID Record
 ///
-/// Alias for argument and result types of various IC management canister methods.
+/// A record containing only a `canister_id` field.
+///
+/// The argument or result type of various Management Canister methods are aliases of this type.
 #[derive(
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
@@ -149,13 +151,7 @@ pub struct CreateCanisterArgs {
 /// # Create Canister Result
 ///
 /// Result type of [`create_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-create_canister).
-#[derive(
-    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy,
-)]
-pub struct CreateCanisterResult {
-    /// Canister ID of the created canister.
-    pub canister_id: CanisterId,
-}
+pub type CreateCanisterResult = CanisterIdRecord;
 
 /// # Update Settings Args
 ///
@@ -194,24 +190,12 @@ pub type UploadChunkResult = ChunkHash;
 /// # Clear Chunk Store Args
 ///
 /// Argument type of [`clear_chunk_store`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-clear_chunk_store).
-#[derive(
-    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
-)]
-pub struct ClearChunkStoreArgs {
-    /// The canister whose chunk store will be cleared.
-    pub canister_id: CanisterId,
-}
+pub type ClearChunkStoreArgs = CanisterIdRecord;
 
 /// # Stored Chunks Args
 ///
 /// Argument type of [`stored_chunks`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-stored_chunks).
-#[derive(
-    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
-)]
-pub struct StoredChunksArgs {
-    /// The canister whose chunk store will be queried.
-    pub canister_id: CanisterId,
-}
+pub type StoredChunksArgs = CanisterIdRecord;
 
 /// # Stored Chunks Result
 ///
@@ -363,36 +347,16 @@ pub struct UninstallCodeArgs {
 /// # Start Canister Args
 ///
 /// Argument type of [`start_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-start_canister).
-#[derive(
-    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
-)]
-pub struct StartCanisterArgs {
-    /// Canister ID.
-    pub canister_id: CanisterId,
-}
-
+pub type StartCanisterArgs = CanisterIdRecord;
 /// # Stop Canister Args
 ///
 /// Argument type of [`stop_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-stop_canister).
-#[derive(
-    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
-)]
-pub struct StopCanisterArgs {
-    /// Canister ID.
-    pub canister_id: CanisterId,
-}
+pub type StopCanisterArgs = CanisterIdRecord;
 
 /// # Canister Status Args
 ///
 /// Argument type of [`canister_status`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-canister_status).
-#[derive(
-    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
-)]
-pub struct CanisterStatusArgs {
-    /// Canister ID.
-    pub canister_id: CanisterId,
-}
-
+pub type CanisterStatusArgs = CanisterIdRecord;
 /// # Canister Status Result
 ///
 /// Result type of [`canister_status`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-canister_status).
@@ -668,24 +632,12 @@ pub struct Change {
 /// # Delete Canister Args
 ///
 /// Argument type of [`delete_canister`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-delete_canister).
-#[derive(
-    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
-)]
-pub struct DeleteCanisterArgs {
-    /// Canister ID.
-    pub canister_id: CanisterId,
-}
+pub type DeleteCanisterArgs = CanisterIdRecord;
 
 /// # Deposit Cycles Args
 ///
 /// Argument type of [`deposit_cycles`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-deposit_cycles).
-#[derive(
-    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
-)]
-pub struct DepositCyclesArgs {
-    /// Canister ID.
-    pub canister_id: CanisterId,
-}
+pub type DepositCyclesArgs = CanisterIdRecord;
 
 /// # Raw Rand Result
 ///
@@ -1143,13 +1095,7 @@ pub struct ProvisionalCreateCanisterWithCyclesArgs {
 /// # Provisional Create Canister With Cycles Result.
 ///
 /// Result type of [`provisional_create_canister_with_cycles`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-provisional_create_canister_with_cycles).
-#[derive(
-    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
-)]
-pub struct ProvisionalCreateCanisterWithCyclesResult {
-    /// Canister ID of the created canister.
-    pub canister_id: CanisterId,
-}
+pub type ProvisionalCreateCanisterWithCyclesResult = CanisterIdRecord;
 
 /// # Provisional Top Up Canister Args.
 ///
@@ -1222,13 +1168,7 @@ pub struct LoadCanisterSnapshotArgs {
 /// # List Canister Snapshots Args.
 ///
 /// Argument type of [`list_canister_snapshots`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-list_canister_snapshots).
-#[derive(
-    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
-)]
-pub struct ListCanisterSnapshotsArgs {
-    /// Canister ID.
-    pub canister_id: CanisterId,
-}
+pub type ListCanisterSnapshotsArgs = CanisterIdRecord;
 
 /// # List Canister Snapshots Result.
 ///
@@ -1251,13 +1191,7 @@ pub struct DeleteCanisterSnapshotArgs {
 /// # Fetch Canister Logs Args.
 ///
 /// Argument type of [`fetch_canister_logs`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-fetch_canister_logs).
-#[derive(
-    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
-)]
-pub struct FetchCanisterLogsArgs {
-    /// Canister ID.
-    pub canister_id: CanisterId,
-}
+pub type FetchCanisterLogsArgs = CanisterIdRecord;
 
 /// # Canister Log Record
 ///

--- a/ic-management-canister-types/src/lib.rs
+++ b/ic-management-canister-types/src/lib.rs
@@ -1236,3 +1236,25 @@ pub struct DeleteCanisterSnapshotArgs {
     /// ID of the snapshot to be deleted.
     pub snapshot_id: SnapshotId,
 }
+
+/// # Canister Log Record
+///
+/// See [`FetchCanisterLogsResult::canister_log_records`].
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub struct CanisterLogRecord {
+    pub idx: u64,
+    pub timestamp_nanos: u64,
+    pub content: Vec<u8>,
+}
+
+/// # Fetch Canister Logs Result.
+///
+/// Result type of [`fetch_canister_logs`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-fetch_canister_logs).
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub struct FetchCanisterLogsResult {
+    pub canister_log_records: Vec<CanisterLogRecord>,
+}

--- a/ic-management-canister-types/src/lib.rs
+++ b/ic-management-canister-types/src/lib.rs
@@ -6,6 +6,17 @@ use serde::{Deserialize, Serialize};
 /// # Canister ID.
 pub type CanisterId = Principal;
 
+/// # Canister ID Record
+///
+/// Alias for argument and result types of various IC management canister methods.
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub struct CanisterIdRecord {
+    /// Canister ID.
+    pub canister_id: CanisterId,
+}
+
 /// # Chunk hash.
 #[derive(
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,

--- a/ic-management-canister-types/src/lib.rs
+++ b/ic-management-canister-types/src/lib.rs
@@ -1237,6 +1237,17 @@ pub struct DeleteCanisterSnapshotArgs {
     pub snapshot_id: SnapshotId,
 }
 
+/// # Fetch Canister Logs Args.
+///
+/// Argument type of [`fetch_canister_logs`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-fetch_canister_logs).
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub struct FetchCanisterLogsArgs {
+    /// Canister ID.
+    pub canister_id: CanisterId,
+}
+
 /// # Canister Log Record
 ///
 /// See [`FetchCanisterLogsResult::canister_log_records`].

--- a/ic-management-canister-types/tests/candid_equality.rs
+++ b/ic-management-canister-types/tests/candid_equality.rs
@@ -144,7 +144,7 @@ fn delete_canister_snapshot(_: DeleteCanisterSnapshotArgs) {
     unreachable!()
 }
 
-#[candid_method(update)]
+#[candid_method(query)]
 fn fetch_canister_logs(_: FetchCanisterLogsArgs) -> FetchCanisterLogsResult {
     unreachable!()
 }

--- a/ic-management-canister-types/tests/candid_equality.rs
+++ b/ic-management-canister-types/tests/candid_equality.rs
@@ -144,6 +144,11 @@ fn delete_canister_snapshot(_: DeleteCanisterSnapshotArgs) {
     unreachable!()
 }
 
+#[candid_method(update)]
+fn fetch_canister_logs(_: FetchCanisterLogsArgs) -> FetchCanisterLogsResult {
+    unreachable!()
+}
+
 #[cfg(test)]
 mod test {
     use candid_parser::utils::{service_equal, CandidSource};

--- a/ic-management-canister-types/tests/ic.did
+++ b/ic-management-canister-types/tests/ic.did
@@ -474,5 +474,5 @@ service ic : {
     delete_canister_snapshot : (delete_canister_snapshot_args) -> ();
 
     // canister logging
-    // fetch_canister_logs : (fetch_canister_logs_args) -> (fetch_canister_logs_result) query;
+    fetch_canister_logs : (fetch_canister_logs_args) -> (fetch_canister_logs_result) query;
 };


### PR DESCRIPTION
# Description

The specification mentions these types, but they are not in the ic-management-canister-types yet. 

# How Has This Been Tested?

The new type was added to the candid_equality.rs test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
