### PR TITLE
chore: MSRV back to 1.75.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,10 +185,10 @@ jobs:
   aggregate:
     name: ci:required
     if: ${{ always() }}
-    needs: [build, test, wasm64, fmt, clippy, doc]
+    needs: [msrv, test, wasm64, fmt, clippy, doc]
     runs-on: ubuntu-24.04
     steps:
-      - name: check build result
+      - name: check msrv result
         if: ${{ needs.msrv.result != 'success' }}
         run: exit 1
       - name: check test result

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: cargo build
+  msrv:
+    name: cargo build with MSRV
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-13-large]
       fail-fast: false
     steps:
+      - name: Install specific Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.75.0 # MSRV, should sync with `rust-toolchain` in `Cargo.toml`
+          target: wasm32-unknown-unknown
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Cache
@@ -32,9 +37,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-build-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
+          key: ${{ runner.os }}-msrv-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
           restore-keys: |
-            ${{ runner.os }}-build-
+            ${{ runner.os }}-msrv-
             ${{ runner.os }}-
       - name: Run builds
         run: |
@@ -184,7 +189,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: check build result
-        if: ${{ needs.build.result != 'success' }}
+        if: ${{ needs.msrv.result != 'success' }}
         run: exit 1
       - name: check test result
         if: ${{ needs.test.result != 'success' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ repository = "https://github.com/dfinity/cdk-rs"
 # MSRV
 # Avoid updating this field unless we use new Rust features
 # Sync with rust-toolchain.toml
-rust-version = "1.78.0"
+rust-version = "1.75.0"
 license = "Apache-2.0"
 
 [profile.canister-release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 repository = "https://github.com/dfinity/cdk-rs"
 # MSRV
-# Avoid updating this field unless we use new Rust features
-# Sync with rust-toolchain.toml
+# Avoid updating this field unless we use new Rust features.
+# Sync with the `toolchain` field when setting up Rust toolchain in ci.yml msrv job.
 rust-version = "1.75.0"
 license = "Apache-2.0"
 

--- a/ic-cdk/src/api/stable/mod.rs
+++ b/ic-cdk/src/api/stable/mod.rs
@@ -161,8 +161,7 @@ impl<M: StableMemory> StableIO<M> {
     /// When it cannot grow the memory to accommodate the new data.
     pub fn write(&mut self, buf: &[u8]) -> Result<usize, StableMemoryError> {
         let required_capacity_bytes = self.offset + buf.len() as u64;
-        let required_capacity_pages =
-            (required_capacity_bytes + WASM_PAGE_SIZE_IN_BYTES - 1) / WASM_PAGE_SIZE_IN_BYTES;
+        let required_capacity_pages = required_capacity_bytes.div_ceil(WASM_PAGE_SIZE_IN_BYTES);
         let current_pages = self.capacity;
         let additional_pages_required = required_capacity_pages.saturating_sub(current_pages);
 

--- a/ic-cdk/src/call.rs
+++ b/ic-cdk/src/call.rs
@@ -158,7 +158,7 @@ pub struct Call<'m, 'a> {
 }
 
 // Constructors
-impl<'m, 'a> Call<'m, 'a> {
+impl<'m> Call<'m, '_> {
     /// Constructs a [`Call`] which will **boundedly** wait for response.
     ///
     /// # Note
@@ -197,7 +197,7 @@ impl<'m, 'a> Call<'m, 'a> {
 }
 
 // Configuration
-impl<'m, 'a> Call<'m, 'a> {
+impl<'a> Call<'_, 'a> {
     /// Sets the argument for the call.
     ///
     /// The argument must implement [`CandidType`].
@@ -550,7 +550,7 @@ impl<'m, 'a> IntoFuture for Call<'m, 'a> {
 }
 
 // Execution
-impl<'m, 'a> Call<'m, 'a> {
+impl Call<'_, '_> {
     /// Sends the call and ignores the reply.
     pub fn oneway(&self) -> Result<(), CallPerformFailed> {
         match self.perform(None) {
@@ -708,7 +708,7 @@ pub struct CallFuture<'m, 'a> {
     state: Arc<RwLock<CallFutureState<'m, 'a>>>,
 }
 
-impl<'m, 'a> std::future::Future for CallFuture<'m, 'a> {
+impl std::future::Future for CallFuture<'_, '_> {
     type Output = Result<Response, CallFailed>;
 
     fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
@@ -747,7 +747,7 @@ impl<'m, 'a> std::future::Future for CallFuture<'m, 'a> {
     }
 }
 
-impl<'m, 'a> Drop for CallFuture<'m, 'a> {
+impl Drop for CallFuture<'_, '_> {
     fn drop(&mut self) {
         // If this future is dropped while is_recovering_from_trap is true,
         // then it has been canceled due to a trap in another future.

--- a/ic-cdk/src/stable.rs
+++ b/ic-cdk/src/stable.rs
@@ -199,8 +199,7 @@ impl<M: StableMemory> StableIO<M> {
     /// When it cannot grow the memory to accommodate the new data.
     pub fn write(&mut self, buf: &[u8]) -> Result<usize, StableMemoryError> {
         let required_capacity_bytes = self.offset + buf.len() as u64;
-        let required_capacity_pages =
-            (required_capacity_bytes + WASM_PAGE_SIZE_IN_BYTES - 1) / WASM_PAGE_SIZE_IN_BYTES;
+        let required_capacity_pages = required_capacity_bytes.div_ceil(WASM_PAGE_SIZE_IN_BYTES);
         let current_pages = self.capacity;
         let additional_pages_required = required_capacity_pages.saturating_sub(current_pages);
 
@@ -570,7 +569,7 @@ mod tests {
 
     fn pages_required(bytes_len: usize) -> u64 {
         let page_size = WASM_PAGE_SIZE_IN_BYTES;
-        (bytes_len as u64 + page_size - 1) / page_size
+        (bytes_len as u64).div_ceil(page_size)
     }
 
     mod stable_writer_tests {
@@ -643,8 +642,7 @@ mod tests {
             writer.flush().unwrap();
 
             let capacity_pages = TestStableMemory::new(memory).stable_size();
-            let min_pages_required =
-                (total_bytes as u64 + WASM_PAGE_SIZE_IN_BYTES - 1) / WASM_PAGE_SIZE_IN_BYTES;
+            let min_pages_required = (total_bytes as u64).div_ceil(WASM_PAGE_SIZE_IN_BYTES);
 
             assert_eq!(capacity_pages, min_pages_required);
         }

--- a/library/ic-certified-map/src/rbtree.rs
+++ b/library/ic-certified-map/src/rbtree.rs
@@ -55,7 +55,7 @@ impl AsHashTree for Hash {
     }
 }
 
-impl<'t, K: 't + AsRef<[u8]>, V: AsHashTree + 't> AsHashTree for RbTree<K, V> {
+impl<K: AsRef<[u8]>, V: AsHashTree> AsHashTree for RbTree<K, V> {
     fn root_hash(&self) -> Hash {
         match self.root.as_ref() {
             None => Empty.reconstruct(),
@@ -102,7 +102,7 @@ struct Node<K, V> {
     subtree_hash: Hash,
 }
 
-impl<'t, K: 't + AsRef<[u8]>, V: AsHashTree + 't> Node<K, V> {
+impl<K: AsRef<[u8]>, V: AsHashTree> Node<K, V> {
     fn new(key: K, value: V) -> Box<Node<K, V>> {
         let value_hash = value.root_hash();
         let data_hash = labeled_hash(key.as_ref(), &value_hash);
@@ -205,7 +205,7 @@ pub struct Iter<'a, K, V> {
     parents: Vec<&'a Node<K, V>>,
 }
 
-impl<'a, K, V> Iter<'a, K, V> {
+impl<K, V> Iter<'_, K, V> {
     /// This function is an adaptation of the traverse_step procedure described in
     /// section 7.2 "Bidirectional Bifurcate Coordinates" of
     /// "Elements of Programming" by A. Stepanov and P. McJones, p. 118.
@@ -274,47 +274,47 @@ pub struct RbTree<K, V> {
     root: NodeRef<K, V>,
 }
 
-impl<'t, K, V> PartialEq for RbTree<K, V>
+impl<K, V> PartialEq for RbTree<K, V>
 where
-    K: 't + AsRef<[u8]> + PartialEq,
-    V: 't + AsHashTree + PartialEq,
+    K: AsRef<[u8]> + PartialEq,
+    V: AsHashTree + PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         self.iter().eq(other.iter())
     }
 }
 
-impl<'t, K, V> Eq for RbTree<K, V>
+impl<K, V> Eq for RbTree<K, V>
 where
-    K: 't + AsRef<[u8]> + Eq,
-    V: 't + AsHashTree + Eq,
+    K: AsRef<[u8]> + Eq,
+    V: AsHashTree + Eq,
 {
 }
 
-impl<'t, K, V> PartialOrd for RbTree<K, V>
+impl<K, V> PartialOrd for RbTree<K, V>
 where
-    K: 't + AsRef<[u8]> + PartialOrd,
-    V: 't + AsHashTree + PartialOrd,
+    K: AsRef<[u8]> + PartialOrd,
+    V: AsHashTree + PartialOrd,
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.iter().partial_cmp(other.iter())
     }
 }
 
-impl<'t, K, V> Ord for RbTree<K, V>
+impl<K, V> Ord for RbTree<K, V>
 where
-    K: 't + AsRef<[u8]> + Ord,
-    V: 't + AsHashTree + Ord,
+    K: AsRef<[u8]> + Ord,
+    V: AsHashTree + Ord,
 {
     fn cmp(&self, other: &Self) -> Ordering {
         self.iter().cmp(other.iter())
     }
 }
 
-impl<'t, K, V> std::iter::FromIterator<(K, V)> for RbTree<K, V>
+impl<K, V> std::iter::FromIterator<(K, V)> for RbTree<K, V>
 where
-    K: 't + AsRef<[u8]>,
-    V: 't + AsHashTree,
+    K: AsRef<[u8]>,
+    V: AsHashTree,
 {
     fn from_iter<T>(iter: T) -> Self
     where
@@ -328,10 +328,10 @@ where
     }
 }
 
-impl<'t, K, V> std::fmt::Debug for RbTree<K, V>
+impl<K, V> std::fmt::Debug for RbTree<K, V>
 where
-    K: 't + AsRef<[u8]> + std::fmt::Debug,
-    V: 't + AsHashTree + std::fmt::Debug,
+    K: AsRef<[u8]> + std::fmt::Debug,
+    V: AsHashTree + std::fmt::Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "[")?;
@@ -359,7 +359,7 @@ impl<K, V> RbTree<K, V> {
     }
 }
 
-impl<'t, K: 't + AsRef<[u8]>, V: AsHashTree + 't> RbTree<K, V> {
+impl<K: AsRef<[u8]>, V: AsHashTree> RbTree<K, V> {
     /// Looks up the key in the map and returns the associated value, if there is one.
     pub fn get(&self, key: &[u8]) -> Option<&V> {
         let mut root = self.root.as_ref();
@@ -890,10 +890,10 @@ impl<'t, K: 't + AsRef<[u8]>, V: AsHashTree + 't> RbTree<K, V> {
 
 use candid::CandidType;
 
-impl<'t, K, V> CandidType for RbTree<K, V>
+impl<K, V> CandidType for RbTree<K, V>
 where
-    K: CandidType + AsRef<[u8]> + 't,
-    V: CandidType + AsHashTree + 't,
+    K: CandidType + AsRef<[u8]>,
+    V: CandidType + AsHashTree,
 {
     fn _ty() -> candid::types::internal::Type {
         <Vec<(&K, &V)> as CandidType>::_ty()
@@ -910,10 +910,10 @@ use serde::{
 };
 use std::marker::PhantomData;
 
-impl<'t, K, V> Serialize for RbTree<K, V>
+impl<K, V> Serialize for RbTree<K, V>
 where
-    K: Serialize + AsRef<[u8]> + 't,
-    V: Serialize + AsHashTree + 't,
+    K: Serialize + AsRef<[u8]>,
+    V: Serialize + AsHashTree,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -940,10 +940,10 @@ impl<K, V> RbTreeSerdeVisitor<K, V> {
     }
 }
 
-impl<'de, 't, K, V> Visitor<'de> for RbTreeSerdeVisitor<K, V>
+impl<'de, K, V> Visitor<'de> for RbTreeSerdeVisitor<K, V>
 where
-    K: Deserialize<'de> + AsRef<[u8]> + 't,
-    V: Deserialize<'de> + AsHashTree + 't,
+    K: Deserialize<'de> + AsRef<[u8]>,
+    V: Deserialize<'de> + AsHashTree,
 {
     type Value = RbTree<K, V>;
 
@@ -963,10 +963,10 @@ where
     }
 }
 
-impl<'de, 't, K, V> Deserialize<'de> for RbTree<K, V>
+impl<'de, K, V> Deserialize<'de> for RbTree<K, V>
 where
-    K: Deserialize<'de> + AsRef<[u8]> + 't,
-    V: Deserialize<'de> + AsHashTree + 't,
+    K: Deserialize<'de> + AsRef<[u8]>,
+    V: Deserialize<'de> + AsHashTree,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -1080,7 +1080,7 @@ fn is_balanced<K, V>(root: &NodeRef<K, V>) -> bool {
 #[allow(dead_code)]
 struct DebugView<'a, K, V>(&'a NodeRef<K, V>);
 
-impl<'a, K: AsRef<[u8]>, V> fmt::Debug for DebugView<'a, K, V> {
+impl<K: AsRef<[u8]>, V> fmt::Debug for DebugView<'_, K, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn go<K: AsRef<[u8]>, V>(
             f: &mut fmt::Formatter<'_>,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,6 @@
 [toolchain]
-channel = "1.78.0" # sync with rust-version in root Cargo.toml
+# This is not the MSRV, we just want to use the latest stable Rust for development
+# MSRV is defined in the `Cargo.toml` file
+channel = "stable"
 targets = ["wasm32-unknown-unknown"]
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
# Description

The MSRV is downgraded to 1.75.0 which is the same as v0.17.0.
I upgraded the MSRV 3 months ago just because some indirect dependencies introduced by `pocket-ic` in `e2e-tests` requires Rust v1.78.0.

- Set `channel = "stable"` in `rust-toolchain.toml` so that we always use the latest stable toolchain for development.
   - Will have the latest `clippy` ruleset for better code quality
   - No need to deal with MSRV issue in `e2e-tests` dependencies (e.g. this [comment](https://github.com/dfinity/cdk-rs/pull/563#issuecomment-2689242196)).
 - Changed the `build` job in `ci.yml` to `msrv` which ensures `cargo build` with MSRV.

# How Has This Been Tested?

CI

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
