### PR TITLE
feat: update/query can set custom result encoder

### DIFF
--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -21,7 +21,8 @@ serde_bytes.workspace = true
 sha2.workspace = true
 
 [dev-dependencies]
+candid_parser.workspace = true
 cargo_metadata = "0.19"
+futures = "0.3"
 hex.workspace = true
 pocket-ic = { git = "https://github.com/dfinity/ic", tag = "release-2024-11-28_03-15-base" }
-futures = "0.3"

--- a/e2e-tests/src/bin/macros.rs
+++ b/e2e-tests/src/bin/macros.rs
@@ -1,18 +1,16 @@
 use candid::utils::{decode_args, decode_one};
-use ic_cdk::api::msg_arg_data;
 use ic_cdk::{export_candid, update};
 use std::marker::PhantomData;
 
 #[update(decode_with = "decode_arg0")]
 fn arg0() {}
-fn decode_arg0() {}
+fn decode_arg0(_arg_bytes: Vec<u8>) {}
 
 #[update(decode_with = "decode_arg1")]
 fn arg1(a: u32) {
     assert_eq!(a, 1)
 }
-fn decode_arg1() -> u32 {
-    let arg_bytes = msg_arg_data();
+fn decode_arg1(arg_bytes: Vec<u8>) -> u32 {
     decode_one(&arg_bytes).unwrap()
 }
 
@@ -21,8 +19,7 @@ fn arg2(a: u32, b: u32) {
     assert_eq!(a, 1);
     assert_eq!(b, 2);
 }
-fn decode_arg2() -> (u32, u32) {
-    let arg_bytes = msg_arg_data();
+fn decode_arg2(arg_bytes: Vec<u8>) -> (u32, u32) {
     decode_args(&arg_bytes).unwrap()
 }
 

--- a/e2e-tests/src/bin/macros.rs
+++ b/e2e-tests/src/bin/macros.rs
@@ -3,31 +3,53 @@ use ic_cdk::api::msg_arg_data;
 use ic_cdk::{export_candid, update};
 use std::marker::PhantomData;
 
-#[update(decode_with = "decode_u0")]
-fn u0() {}
-fn decode_u0() {}
+#[update(decode_with = "decode_arg0")]
+fn arg0() {}
+fn decode_arg0() {}
 
-#[update(decode_with = "decode_u1")]
-fn u1(a: u32) {
+#[update(decode_with = "decode_arg1")]
+fn arg1(a: u32) {
     assert_eq!(a, 1)
 }
-fn decode_u1() -> u32 {
+fn decode_arg1() -> u32 {
     let arg_bytes = msg_arg_data();
     decode_one(&arg_bytes).unwrap()
 }
 
-#[update(decode_with = "decode_u2")]
-fn u2(a: u32, b: u32) {
+#[update(decode_with = "decode_arg2")]
+fn arg2(a: u32, b: u32) {
     assert_eq!(a, 1);
     assert_eq!(b, 2);
 }
-fn decode_u2() -> (u32, u32) {
+fn decode_arg2() -> (u32, u32) {
     let arg_bytes = msg_arg_data();
     decode_args(&arg_bytes).unwrap()
 }
 
+#[update(encode_with = "encode_ret0")]
+fn ret0() {}
+fn encode_ret0() -> Vec<u8> {
+    vec![0]
+}
+
+#[update(encode_with = "encode_ret1")]
+fn ret1() -> u32 {
+    42
+}
+fn encode_ret1(v1: u32) -> Vec<u8> {
+    vec![v1 as u8]
+}
+
+#[update(encode_with = "encode_ret2")]
+fn ret2() -> (u32, u32) {
+    (1, 2)
+}
+fn encode_ret2(ret: (u32, u32)) -> Vec<u8> {
+    vec![ret.0 as u8, ret.1 as u8]
+}
+
 #[update(manual_reply = true)]
-fn u_manual_reply() -> PhantomData<u32> {
+fn manual_reply() -> PhantomData<u32> {
     let v: u32 = 1;
     let reply_bytes = candid::encode_one(v).unwrap();
     ic_cdk::api::msg_reply(reply_bytes);
@@ -42,15 +64,25 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
+    use candid_parser::utils::{service_equal, CandidSource};
 
     #[test]
-    fn check_candid() {
+    fn candid_equality_test() {
         let expected = "service : {
-  u0 : () -> ();
-  u1 : (nat32) -> ();
-  u2 : (nat32, nat32) -> ();
-  u_manual_reply : () -> (nat32);
-}";
-        assert_eq!(expected, super::__export_service());
+            arg0 : () -> ();
+            arg1 : (nat32) -> ();
+            arg2 : (nat32, nat32) -> ();
+            ret0 : () -> ();
+            ret1 : () -> (nat32);
+            ret2 : () -> (nat32, nat32);
+            manual_reply : () -> (nat32);
+          }";
+        let expected_candid = CandidSource::Text(expected);
+
+        let actual = super::__export_service();
+        let actual_candid = CandidSource::Text(&actual);
+
+        let result = service_equal(expected_candid, actual_candid);
+        assert!(result.is_ok(), "{:?}", result.unwrap_err());
     }
 }

--- a/e2e-tests/tests/macros.rs
+++ b/e2e-tests/tests/macros.rs
@@ -1,5 +1,6 @@
-use pocket_ic::call_candid;
+use candid::Principal;
 use pocket_ic::common::rest::RawEffectivePrincipal;
+use pocket_ic::{call_candid, WasmResult};
 
 mod test_utilities;
 use test_utilities::{cargo_build_canister, pocket_ic};
@@ -11,12 +12,12 @@ fn call_macros() {
     let canister_id = pic.create_canister();
     pic.add_cycles(canister_id, 100_000_000_000_000);
     pic.install_canister(canister_id, wasm, vec![], None);
-    let _: () = call_candid(&pic, canister_id, RawEffectivePrincipal::None, "u0", ()).unwrap();
+    let _: () = call_candid(&pic, canister_id, RawEffectivePrincipal::None, "arg0", ()).unwrap();
     let _: () = call_candid(
         &pic,
         canister_id,
         RawEffectivePrincipal::None,
-        "u1",
+        "arg1",
         (1u32,),
     )
     .unwrap();
@@ -24,15 +25,28 @@ fn call_macros() {
         &pic,
         canister_id,
         RawEffectivePrincipal::None,
-        "u2",
+        "arg2",
         (1u32, 2u32),
     )
     .unwrap();
+    let sender = Principal::anonymous();
+    let res = pic
+        .update_call(canister_id, sender, "ret0", vec![])
+        .unwrap();
+    assert_eq!(res, WasmResult::Reply(vec![0]));
+    let res = pic
+        .update_call(canister_id, sender, "ret1", vec![])
+        .unwrap();
+    assert_eq!(res, WasmResult::Reply(vec![42]));
+    let res = pic
+        .update_call(canister_id, sender, "ret2", vec![])
+        .unwrap();
+    assert_eq!(res, WasmResult::Reply(vec![1, 2]));
     let _: (u32,) = call_candid(
         &pic,
         canister_id,
         RawEffectivePrincipal::None,
-        "u_manual_reply",
+        "manual_reply",
         (),
     )
     .unwrap();

--- a/ic-cdk-macros/src/export.rs
+++ b/ic-cdk-macros/src/export.rs
@@ -225,9 +225,14 @@ fn dfn_macro(
         let decode_with_ident = syn::Ident::new(&decode_with, Span::call_site());
         if arg_tuple.len() == 1 {
             let arg_one = &arg_tuple[0];
-            quote! { let #arg_one = #decode_with_ident(); }
+            quote! {
+                let arg_bytes = ::ic_cdk::api::msg_arg_data();
+                let #arg_one = #decode_with_ident(arg_bytes);
+            }
         } else {
-            quote! { let ( #( #arg_tuple, )* ) = #decode_with_ident(); }
+            quote! {
+            let arg_bytes = ::ic_cdk::api::msg_arg_data();
+            let ( #( #arg_tuple, )* ) = #decode_with_ident(arg_bytes); }
         }
     } else if arg_tuple.is_empty() {
         quote! {}

--- a/ic-cdk/CHANGELOG.md
+++ b/ic-cdk/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-## [0.18.0-alpha.1] - 2025-02-25
+## [0.18.0-alpha.2] - upcoming
 
 Please check [Version 0.18 Guide](V18_GUIDE.md) for more details.
 
@@ -19,7 +19,9 @@ Please check [Version 0.18 Guide](V18_GUIDE.md) for more details.
   - Provides ergonomic Rust error handling to encourage best practices.
 - Support for Wasm64 module compilation.
   - Seamlessly handles 32-bit and 64-bit System APIs.
-- Enhanced `update`/`query`/`init` macros with support for custom decoders.
+- Enhanced macros for flexible argument decoding and result encoding.
+  - `update`/`query`/`init` macros now support custom argument decoders via `decode_with`.
+  - `update`/`query` macros now support custom result encoders via `encode_with`.
 - Simplified module hierarchy with one level under the crate root.
   - `api` module offers consistent System API bindings.
   - `management_canister` module for convenient Management Canister calls.

--- a/ic-cdk/src/macros.rs
+++ b/ic-cdk/src/macros.rs
@@ -59,6 +59,38 @@ pub use ic_cdk_macros::export_candid;
 /// }
 /// ```
 ///
+/// You can specify a custom function to decode the arguments.
+/// The function must take a `Vec<u8>` as an argument and return the same type as the query arguments.
+///
+/// ```rust
+/// # use ic_cdk::query;
+/// fn decode_args(arg_bytes: Vec<u8>) -> (u32, u32) {
+///    // ...
+/// # unimplemented!()
+/// }
+/// #[query(decode_with = "decode_args")]
+/// fn query_function(a: u32, b: u32) {
+///    // ...
+/// # unimplemented!()
+/// }
+/// ```
+///
+/// You can specify a custom function to encode the return value.
+/// The function must take the query return value as argument and return a `Vec<u8>`.
+///
+/// ```rust
+/// # use ic_cdk::query;
+/// fn encode_result(result: (u32, u32)) -> Vec<u8> {
+///   // ...
+/// # unimplemented!()
+/// }
+/// #[query(encode_with = "encode_result")]
+/// fn query_function() -> (u32, u32) {
+///  // ...
+/// # unimplemented!()
+/// }
+/// ```
+///
 /// To be able to make inter-canister calls from a query call, it must be a *composite* query (which cannot be executed in replicated mode).
 ///
 /// ```rust
@@ -141,6 +173,37 @@ pub use ic_cdk_macros::query;
 /// }
 /// ```
 ///
+/// You can specify a custom function to decode the arguments.
+/// The function must take a `Vec<u8>` as an argument and return the same type as the update arguments.
+///
+/// ```rust
+/// # use ic_cdk::update;
+/// fn decode_args(arg_bytes: Vec<u8>) -> (u32, u32) {
+///    // ...
+/// # unimplemented!()
+/// }
+/// #[update(decode_with = "decode_args")]
+/// fn update_function(a: u32, b: u32) {
+///    // ...
+/// # unimplemented!()
+/// }
+/// ```
+///
+/// You can specify a custom function to encode the return value.
+/// The function must take the update return value as an argument and return a `Vec<u8>`.
+///
+/// ```rust
+/// # use ic_cdk::update;
+/// fn encode_result(result: (u32, u32)) -> Vec<u8> {
+///   // ...
+/// # unimplemented!()
+/// }
+/// #[update(encode_with = "encode_result")]
+/// fn update_function() -> (u32, u32) {
+///  // ...
+/// # unimplemented!()
+/// }
+/// ```
 /// If you would rather call the [`reply()`](crate::api::call::reply) function than return a value,
 /// you will need to set `manual_reply` to `true` so that the canister does not trap.
 ///
@@ -201,6 +264,26 @@ pub use ic_cdk_macros::update;
 /// In this case, the argument will be read from `ic0.msg_arg_data_size/copy` and passed to the
 /// init function upon successful deserialization.
 ///
+/// You can specify a custom function to decode the arguments.
+/// The function must take a `Vec<u8>` as an argument and return the same type as the init arguments.
+///
+/// ```rust
+/// # use ic_cdk::init;
+/// # use candid::*;
+/// # #[derive(Clone, Debug, CandidType, Deserialize)]
+/// # struct InitArg {
+/// #    foo: u8,
+/// # }
+/// fn decode_args(arg_bytes: Vec<u8>) -> InitArg {
+///     // ...
+/// # unimplemented!()
+/// }
+/// #[init(decode_with = "decode_args")]
+/// fn init_function(arg: InitArg) {
+///     // ...
+/// # unimplemented!()
+/// }
+/// ```
 ///
 /// Refer to the [`canister_init` Specification](https://internetcomputer.org/docs/current/references/ic-interface-spec/#system-api-init) for more information.
 pub use ic_cdk_macros::init;

--- a/ic-management-canister-types/Cargo.toml
+++ b/ic-management-canister-types/Cargo.toml
@@ -16,6 +16,8 @@ include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
 candid.workspace = true
-candid_parser.workspace = true
 serde.workspace = true
 serde_bytes.workspace = true
+
+[dev-dependencies]
+candid_parser.workspace = true

--- a/ic-management-canister-types/tests/candid_equality.rs
+++ b/ic-management-canister-types/tests/candid_equality.rs
@@ -165,6 +165,6 @@ mod test {
         let implemented_interface = CandidSource::Text(&implemented_interface_str);
 
         let result = service_equal(declared_interface, implemented_interface);
-        assert!(result.is_ok(), "{:?}\n\n", result.unwrap_err());
+        assert!(result.is_ok(), "{:?}", result.unwrap_err());
     }
 }


### PR DESCRIPTION
# Description

Requested and inspired by the `OpenChat` [fork](https://github.com/hpeebles/cdk-rs/commit/19f04d7d996d77b1c2f938e4c7e1efd8e3f12910).

- Enabled `update`/`query` macros to set custom result encoder via `encode_with`.
  - The encoder function should takes the same type of the result and returns a `Vec<u8>`.
- For consistency, the custom argument decoder is also changed to take a `Vec<u8>` as an argument. No need to call `msg_arg_data()`.
- Added explanation of `decode_with`/`encode_with` in macros documentation.

# How Has This Been Tested?

e2e-tests - macros.rs

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
