### PR TITLE
fix: set the executor context when invoking functions via canister timers 

### DIFF
--- a/ic-cdk-timers/src/lib.rs
+++ b/ic-cdk-timers/src/lib.rs
@@ -281,11 +281,11 @@ extern "C" fn timer_executor() {
     if let Some(mut task) = task {
         match task {
             Task::Once(func) => {
-                func();
+                ic_cdk::futures::in_executor_context(|| func());
                 TASKS.with(|tasks| tasks.borrow_mut().remove(task_id));
             }
             Task::Repeated { ref mut func, .. } => {
-                func();
+                ic_cdk::futures::in_executor_context(|| func());
                 TASKS.with(|tasks| tasks.borrow_mut().get_mut(task_id).map(|slot| *slot = task));
             }
         }

--- a/ic-cdk-timers/src/lib.rs
+++ b/ic-cdk-timers/src/lib.rs
@@ -281,11 +281,11 @@ extern "C" fn timer_executor() {
     if let Some(mut task) = task {
         match task {
             Task::Once(func) => {
-                ic_cdk::futures::in_executor_context(|| func());
+                ic_cdk::futures::in_executor_context(func);
                 TASKS.with(|tasks| tasks.borrow_mut().remove(task_id));
             }
             Task::Repeated { ref mut func, .. } => {
-                ic_cdk::futures::in_executor_context(|| func());
+                ic_cdk::futures::in_executor_context(func);
                 TASKS.with(|tasks| tasks.borrow_mut().get_mut(task_id).map(|slot| *slot = task));
             }
         }


### PR DESCRIPTION
# Description

Set the executor context when invoking functions via canister timers .

# How Has This Been Tested?

The OpenChat tests were all failing before this change with an error saying the following -

```
[ic-cdk-timers] canister_global_timer: CallRejected(CallRejected { reject_code: CanisterError, reject_message: "IC0503: Error from Canister txyno-ch777-77776-aaaaq-cai: Canister called `ic0.trap` with message: 'Panicked at '`spawn` can only be called from an executor context'
```

With this change applied, the tests all pass.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
