### PR TITLE
fix: Add field aux to SignWithSchnorrArgument

### DIFF
--- a/src/ic-cdk/src/api/management_canister/schnorr/types.rs
+++ b/src/ic-cdk/src/api/management_canister/schnorr/types.rs
@@ -1,5 +1,6 @@
 use candid::CandidType;
 use serde::{Deserialize, Serialize};
+use serde_bytes::ByteBuf;
 
 use super::super::main::CanisterId;
 
@@ -27,6 +28,31 @@ pub struct SchnorrPublicKeyResponse {
     pub chain_code: Vec<u8>,
 }
 
+/// SignWithBip341 auxiliary parameter
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default,
+)]
+pub struct SignWithBip341Aux {
+    /// The merkle_root_hash must be generated in accordance with BIP341's specification for taproot_output_script. 
+    /// 
+    /// Specifically it should be either an empty bytestring (for the script == None case)
+    /// or else 32 bytes generated using the procedure documented as taproot_tree_helper.
+    pub merkle_root_hash: ByteBuf,
+}
+
+/// The auxiliary parameter type SignWithSchnorrAux is an enumeration.
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub enum SignWithSchnorrAux {
+    ///  The only currently supported variant is bip341 which allows passing a Merkle tree root hash, 
+    ///  which is required to implement Taproot signatures as defined in BIP341. 
+    /// 
+    ///  The bip341 variant is only allowed for bip340secp256k1 signatures.
+    #[serde(rename = "bip341")]
+    Bip341(SignWithBip341Aux),
+}
+
 /// Argument Type of [sign_with_schnorr](super::sign_with_schnorr).
 #[derive(
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default,
@@ -38,6 +64,12 @@ pub struct SignWithSchnorrArgument {
     pub derivation_path: Vec<Vec<u8>>,
     /// See [SchnorrKeyId].
     pub key_id: SchnorrKeyId,
+    /// An optional auxiliary parameter. 
+    /// 
+    /// If no auxiliary parameter is provided, then bip340secp256k1 signatures are generated in accordance with BIP340.
+    /// 
+    /// Check [sign_with_schnorr](https://internetcomputer.org/docs/references/ic-interface-spec#ic-sign_with_schnorr) for more details.
+    pub aux: Option<SignWithSchnorrAux>,
 }
 
 /// Response Type of [sign_with_schnorr](super::sign_with_schnorr).


### PR DESCRIPTION
IC's interface documentation and examples repository both mention that the `sign_with_schnorr` function parameters contain an `optional aux` field when introducing the  function. 

If this field is provided, the Taproot signature will be executed according to the BIP341 standard. 

However, the `SignWithSchnorrArgument` structure in the ic-cdk crate did not have this field. 
For developers who rely on `ic-cdk` to call `IC Managemet Canister`, it may cause difficulties in development.

I encountered this problem today. I directly used the `sign_with_schnorr` interface of `ic-cdk` to sign a bitcoin Taproot transaction, but when I broadcast the transaction, the bitcoin node always reported an error that the signature verification failed. After I consulted the official documentation and examples, it took a lot of time to solve this problem.

So I think the `SignWithSchnorrArgument` structure should add this `optional aux` field.

IC Interface Doc : https://internetcomputer.org/docs/references/ic-interface-spec#ic-sign_with_schnorr

Example Repo : https://github.com/dfinity/examples/blob/master/rust/basic_bitcoin/src/basic_bitcoin/src/schnorr_api.rs