### PR TITLE
feat: subnet_self in ic0 and api

### DIFF
--- a/e2e-tests/src/bin/api.rs
+++ b/e2e-tests/src/bin/api.rs
@@ -105,6 +105,15 @@ fn call_canister_version() {
     msg_reply(vec![]);
 }
 
+#[export_name = "canister_update call_subnet_self"]
+fn call_subnet_self() {
+    let id = subnet_self();
+    debug_print(format!("Subnet ID: {:?}", id.to_text()));
+    // The subnet ID is a Principal which uses all 29 bytes.
+    assert_eq!(id.as_slice().len(), 29);
+    msg_reply(vec![]);
+}
+
 #[export_name = "canister_inspect_message"]
 fn inspect_message() {
     assert!(msg_method_name().starts_with("call_"));

--- a/e2e-tests/tests/api.rs
+++ b/e2e-tests/tests/api.rs
@@ -71,6 +71,10 @@ fn call_api() {
         .update_call(canister_id, sender, "call_canister_version", vec![])
         .unwrap();
     assert!(res.is_empty());
+    let res = pic
+        .update_call(canister_id, sender, "call_subnet_self", vec![])
+        .unwrap();
+    assert!(res.is_empty());
     // `msg_method_name` and `accept_message` are invoked in the inspect_message entry point.
     // Every calls above/below execute the inspect_message entry point.
     // So these two API bindings are tested implicitly.

--- a/ic-cdk/src/api.rs
+++ b/ic-cdk/src/api.rs
@@ -268,6 +268,19 @@ pub fn canister_version() -> u64 {
     unsafe { ic0::canister_version() }
 }
 
+/// Gets the ID of the subnet on which the canister is running.
+pub fn subnet_self() -> Principal {
+    // SAFETY: `ic0.subnet_self_size` is always safe to call.
+    let len = unsafe { ic0::subnet_self_size() };
+    let mut buf = vec![0u8; len];
+    // SAFETY: `buf` is a mutable reference to a `len`-byte buffer, it is safe to be passed to `ic0.subnet_self_copy` with a 0-offset.
+    unsafe {
+        ic0::subnet_self_copy(buf.as_mut_ptr() as usize, 0, len);
+    }
+    // Trust that the system always returns a valid principal.
+    Principal::try_from(&buf).unwrap()
+}
+
 /// Gets the name of the method to be inspected.
 ///
 /// This function is only available in the `canister_inspect_message` context.

--- a/ic0/ic0.txt
+++ b/ic0/ic0.txt
@@ -20,6 +20,8 @@
     ic0.canister_cycle_balance128 : (dst : I) -> ();                                      // *
     ic0.canister_status : () -> i32;                                                      // *
     ic0.canister_version : () -> i64;                                                     // *
+    ic0.subnet_self_size : () -> I;                                                       // *
+    ic0.subnet_self_copy : (dst : I, offset : I, size : I) -> ();                         // *
     ic0.msg_method_name_size : () -> I;                                                   // F
     ic0.msg_method_name_copy : (dst : I, offset : I, size : I) -> ();                     // F
     ic0.accept_message : () -> ();                                                        // F

--- a/ic0/src/ic0.rs
+++ b/ic0/src/ic0.rs
@@ -23,6 +23,8 @@ extern "C" {
     pub fn canister_cycle_balance128(dst: usize);
     pub fn canister_status() -> u32;
     pub fn canister_version() -> u64;
+    pub fn subnet_self_size() -> usize;
+    pub fn subnet_self_copy(dst: usize, offset: usize, size: usize);
     pub fn msg_method_name_size() -> usize;
     pub fn msg_method_name_copy(dst: usize, offset: usize, size: usize);
     pub fn accept_message();
@@ -133,6 +135,12 @@ mod non_wasm {
     }
     pub unsafe fn canister_version() -> u64 {
         panic!("canister_version should only be called inside canisters.");
+    }
+    pub unsafe fn subnet_self_size() -> usize {
+        panic!("subnet_self_size should only be called inside canisters.");
+    }
+    pub unsafe fn subnet_self_copy(dst: usize, offset: usize, size: usize) {
+        panic!("subnet_self_copy should only be called inside canisters.");
     }
     pub unsafe fn msg_method_name_size() -> usize {
         panic!("msg_method_name_size should only be called inside canisters.");


### PR DESCRIPTION
SDK-1959

# Description

subnet_self

# How Has This Been Tested?

e2e api

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
