### PR TITLE
feat!: update management types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ opt-level = 'z'
 ic0 = { path = "ic0", version = "0.24.0-alpha.2" }
 ic-cdk = { path = "ic-cdk", version = "0.18.0-alpha.1" }
 ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.0-alpha.1" }
-ic-management-canister-types = { path = "ic-management-canister-types", version = "0.2.0" }
+ic-management-canister-types = { path = "ic-management-canister-types", version = "0.3.0" }
 
 candid = "0.10.13"      # sync with the doc comment in ic-cdk/README.md
 candid_parser = "0.1.4"

--- a/e2e-tests/src/bin/canister_info.rs
+++ b/e2e-tests/src/bin/canister_info.rs
@@ -70,6 +70,7 @@ async fn canister_lifecycle() -> Principal {
             reserved_cycles_limit: None,
             log_visibility: None,
             wasm_memory_limit: None,
+            wasm_memory_threshold: None,
         },
         canister_id,
     })

--- a/e2e-tests/src/bin/management_canister.rs
+++ b/e2e-tests/src/bin/management_canister.rs
@@ -17,6 +17,7 @@ async fn basic() {
             reserved_cycles_limit: Some(0u8.into()),
             log_visibility: Some(LogVisibility::Public),
             wasm_memory_limit: Some(0u8.into()),
+            wasm_memory_threshold: Some(0u8.into()),
         }),
     };
     // 500 B is the minimum cycles required to create a canister.
@@ -42,6 +43,7 @@ async fn basic() {
         LogVisibility::Public
     );
     assert_eq!(definite_canister_setting.wasm_memory_limit, 0u8);
+    assert_eq!(definite_canister_setting.wasm_memory_threshold, 0u8);
 
     // update_settings
     let arg = UpdateSettingsArgs {

--- a/ic-management-canister-types/CHANGELOG.md
+++ b/ic-management-canister-types/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.3.0] - 2025-03-17
+
+### Changed
+
+- Added `wasm_memory_threshold` field to `CanisterSettings` and `DefiniteCanisterSettings`.
+- Added the `memory_metrics` field to `CanisterStatusResult`.
+  - Added the type `MemoryMetrics`.
+
 ### Added
 
 - Implemented trait that convert from `EcdsaCurve` and `SchnorrAlgorithm` into `u32`.

--- a/ic-management-canister-types/Cargo.toml
+++ b/ic-management-canister-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-management-canister-types"
-version = "0.2.1"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/ic-management-canister-types/src/lib.rs
+++ b/ic-management-canister-types/src/lib.rs
@@ -382,6 +382,8 @@ pub struct CanisterStatusResult {
     pub module_hash: Option<Vec<u8>>,
     /// The memory size taken by the canister.
     pub memory_size: Nat,
+    /// The detailed metrics on the memory consumption of the canister.
+    pub memory_metrics: MemoryMetrics,
     /// The cycle balance of the canister.
     pub cycles: Nat,
     /// The reserved cycles balance of the canister.
@@ -413,6 +415,33 @@ pub enum CanisterStatusType {
     /// The canister is stopped.
     #[serde(rename = "stopped")]
     Stopped,
+}
+
+/// # Memory Metrics
+///
+/// Memory metrics of a canister.
+///
+/// See [`CanisterStatusResult::memory_metrics`].
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub struct MemoryMetrics {
+    /// Represents the Wasm memory usage of the canister, i.e. the heap memory used by the canister's WebAssembly code.
+    pub wasm_memory_size: Nat,
+    /// Represents the stable memory usage of the canister.
+    pub stable_memory_size: Nat,
+    /// Represents the memory usage of the global variables that the canister is using.
+    pub global_memory_size: Nat,
+    /// Represents the memory occupied by the Wasm binary that is currently installed on the canister.
+    pub wasm_binary_size: Nat,
+    /// Represents the memory used by custom sections defined by the canister.
+    pub custom_sections_size: Nat,
+    /// Represents the memory used for storing the canister's history.
+    pub canister_history_size: Nat,
+    /// Represents the memory used by the Wasm chunk store of the canister.
+    pub wasm_chunk_store_size: Nat,
+    /// Represents the memory consumed by all snapshots that belong to this canister.
+    pub snapshots_size: Nat,
 }
 
 /// # Query Stats

--- a/ic-management-canister-types/src/lib.rs
+++ b/ic-management-canister-types/src/lib.rs
@@ -108,6 +108,14 @@ pub struct CanisterSettings {
     ///
     /// Default value: 3_221_225_472 (3 GiB).
     pub wasm_memory_limit: Option<Nat>,
+    /// Indicates the threshold on the remaining wasm memory size of the canister in bytes.
+    ///
+    /// If the remaining wasm memory size of the canister is below the threshold, execution of the "on low wasm memory" hook is scheduled.
+    ///
+    /// Must be a number between 0 and 2<sup>64</sup>-1, inclusively.
+    ///
+    /// Default value: 0 (i.e., the "on low wasm memory" hook is never scheduled).
+    pub wasm_memory_threshold: Option<Nat>,
 }
 
 /// # Definite Canister Settings
@@ -133,6 +141,8 @@ pub struct DefiniteCanisterSettings {
     pub log_visibility: LogVisibility,
     /// Upper limit on the WASM heap memory (bytes) consumption of the canister.
     pub wasm_memory_limit: Nat,
+    /// Threshold on the remaining wasm memory size of the canister in bytes.
+    pub wasm_memory_threshold: Nat,
 }
 
 /// # Create Canister Args

--- a/ic-management-canister-types/tests/ic.did
+++ b/ic-management-canister-types/tests/ic.did
@@ -16,6 +16,7 @@ type canister_settings = record {
     reserved_cycles_limit : opt nat;
     log_visibility : opt log_visibility;
     wasm_memory_limit : opt nat;
+    wasm_memory_threshold : opt nat;
 };
 
 type definite_canister_settings = record {
@@ -26,6 +27,7 @@ type definite_canister_settings = record {
     reserved_cycles_limit : nat;
     log_visibility : log_visibility;
     wasm_memory_limit : nat;
+    wasm_memory_threshold : nat;
 };
 
 type change_origin = variant {
@@ -248,6 +250,16 @@ type canister_status_result = record {
     settings : definite_canister_settings;
     module_hash : opt blob;
     memory_size : nat;
+    memory_metrics : record {
+        wasm_memory_size : nat;
+        stable_memory_size : nat;
+        global_memory_size : nat;
+        wasm_binary_size : nat;
+        custom_sections_size : nat;
+        canister_history_size : nat;
+        wasm_chunk_store_size : nat;
+        snapshots_size : nat;
+    };
     cycles : nat;
     reserved_cycles : nat;
     idle_cycles_burned_per_day : nat;


### PR DESCRIPTION
SDK-2025

# Description

- wasm_memory_threshold in canister_settting: https://github.com/dfinity/portal/pull/3761 
- memory_metrics in canister_status: https://github.com/dfinity/portal/pull/5240 

# How Has This Been Tested?

Candid equality test with the updated `ic.did`.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
