### PR TITLE
feat: canister_liquid_cycle_balance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ lto = true
 opt-level = 'z'
 
 [workspace.dependencies]
-ic0 = { path = "ic0", version = "0.24.0-alpha.2" }
+ic0 = { path = "ic0", version = "0.24.0-alpha.3" }
 ic-cdk = { path = "ic-cdk", version = "0.18.0-alpha.1" }
 ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.0-alpha.1" }
 ic-management-canister-types = { path = "ic-management-canister-types", version = "0.3.0" }

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -26,5 +26,5 @@ cargo_metadata = "0.19"
 flate2 = "1.1"
 futures = "0.3"
 hex.workspace = true
-pocket-ic = { git = "https://github.com/dfinity/ic", tag = "release-2025-02-27_03-09-base" }
+pocket-ic = { git = "https://github.com/dfinity/ic", tag = "release-2025-03-14_03-10-base" }
 reqwest = "0.12"

--- a/e2e-tests/src/bin/api.rs
+++ b/e2e-tests/src/bin/api.rs
@@ -92,6 +92,12 @@ fn call_canister_cycle_balance() {
     msg_reply(vec![]);
 }
 
+#[export_name = "canister_update call_canister_liquid_cycle_balance"]
+fn call_canister_liquid_cycle_balance() {
+    assert!(canister_liquid_cycle_balance() > 0);
+    msg_reply(vec![]);
+}
+
 #[export_name = "canister_update call_canister_status"]
 fn call_canister_status() {
     assert_eq!(canister_status(), CanisterStatusCode::Running);

--- a/e2e-tests/src/bin/bitcoin_canister.rs
+++ b/e2e-tests/src/bin/bitcoin_canister.rs
@@ -36,7 +36,7 @@ async fn execute_non_query_methods(network: Network) {
         network,
     };
     let err = bitcoin_send_transaction(&arg).await.unwrap_err();
-    assert!(matches!(err, Error::CallFailed { .. }));
+    assert!(matches!(err, Error::CallRejected { .. }));
 }
 
 fn main() {}

--- a/e2e-tests/src/bin/call.rs
+++ b/e2e-tests/src/bin/call.rs
@@ -224,6 +224,24 @@ async fn join_calls() {
 }
 
 #[update]
+async fn insufficient_liquid_cycle_balance_error() {
+    // Attach the current liquid cycle balance to the call
+    // to ensure that the call will fail with an InsufficientLiquidCycleBalance error.
+    let liquid_cycle_balance = ic_cdk::api::canister_cycle_balance();
+    let err = Call::unbounded_wait(canister_self(), "foo")
+        .with_cycles(liquid_cycle_balance)
+        .await
+        .unwrap_err();
+    use ic_cdk::call::{CallFailed, InsufficientLiquidCycleBalance, PreExecutionFailure};
+    assert!(matches!(
+        err,
+        CallFailed::PreExecutionFailure(PreExecutionFailure::InsufficientLiquidCycleBalance(
+            InsufficientLiquidCycleBalance
+        ))
+    ));
+}
+
+#[update]
 async fn call_error_ext() {
     // The trait need to be in scope so that the provided methods can be called.
     use ic_cdk::call::CallErrorExt;

--- a/e2e-tests/src/bin/call.rs
+++ b/e2e-tests/src/bin/call.rs
@@ -232,13 +232,7 @@ async fn insufficient_liquid_cycle_balance_error() {
         .with_cycles(liquid_cycle_balance)
         .await
         .unwrap_err();
-    use ic_cdk::call::{CallFailed, InsufficientLiquidCycleBalance, PreExecutionFailure};
-    assert!(matches!(
-        err,
-        CallFailed::PreExecutionFailure(PreExecutionFailure::InsufficientLiquidCycleBalance(
-            InsufficientLiquidCycleBalance
-        ))
-    ));
+    assert!(matches!(err, ic_cdk::call::CallFailed::InsufficientLiquidCycleBalance(_)));
 }
 
 #[update]

--- a/e2e-tests/src/bin/call.rs
+++ b/e2e-tests/src/bin/call.rs
@@ -232,7 +232,10 @@ async fn insufficient_liquid_cycle_balance_error() {
         .with_cycles(liquid_cycle_balance)
         .await
         .unwrap_err();
-    assert!(matches!(err, ic_cdk::call::CallFailed::InsufficientLiquidCycleBalance(_)));
+    assert!(matches!(
+        err,
+        ic_cdk::call::CallFailed::InsufficientLiquidCycleBalance(_)
+    ));
 }
 
 #[update]

--- a/e2e-tests/tests/api.rs
+++ b/e2e-tests/tests/api.rs
@@ -64,6 +64,15 @@ fn call_api() {
         .unwrap();
     assert!(res.is_empty());
     let res = pic
+        .update_call(
+            canister_id,
+            sender,
+            "call_canister_liquid_cycle_balance",
+            vec![],
+        )
+        .unwrap();
+    assert!(res.is_empty());
+    let res = pic
         .update_call(canister_id, sender, "call_canister_status", vec![])
         .unwrap();
     assert!(res.is_empty());

--- a/e2e-tests/tests/call.rs
+++ b/e2e-tests/tests/call.rs
@@ -12,5 +12,13 @@ fn call() {
     let _: () = update(&pic, canister_id, "call_echo", ()).unwrap();
     let _: () = update(&pic, canister_id, "retry_calls", ()).unwrap();
     let _: () = update(&pic, canister_id, "join_calls", ()).unwrap();
+    let _: () = update(
+        &pic,
+        canister_id,
+        "insufficient_liquid_cycle_balance_error",
+        (),
+    )
+    .unwrap();
+
     let _: () = update(&pic, canister_id, "call_error_ext", ()).unwrap();
 }

--- a/e2e-tests/tests/test_utilities.rs
+++ b/e2e-tests/tests/test_utilities.rs
@@ -4,7 +4,9 @@ use cargo_metadata::MetadataCommand;
 use flate2::read::GzDecoder;
 use pocket_ic::common::rest::RawEffectivePrincipal;
 use pocket_ic::{call_candid, PocketIc, PocketIcBuilder, RejectResponse};
+use std::fs::Permissions;
 use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Once;
@@ -152,6 +154,8 @@ fn cache_pocket_ic_server() -> PathBuf {
         .read_to_end(&mut decompressed_data)
         .expect("failed to decompress pocket-ic-server");
     std::fs::write(&pocket_ic_server, decompressed_data).expect("failed to write pocket-ic-server");
+    let permissions = Permissions::from_mode(0o755); // Make the file executable
+    std::fs::set_permissions(&pocket_ic_server, permissions).expect("failed to set permissions");
     std::fs::write(tag_file, pocket_ic_tag).expect("failed to write pocket-ic-tag");
     pocket_ic_server.into()
 }

--- a/ic-cdk-timers/src/lib.rs
+++ b/ic-cdk-timers/src/lib.rs
@@ -133,8 +133,11 @@ extern "C" fn global_timer() {
                 let task_id = timer.task;
                 if let Err(e) = res {
                     ic_cdk::println!("[ic-cdk-timers] canister_global_timer: {e:?}");
-                    if matches!(e, CallFailed::PreExecutionFailure(_))
-                        || matches!(e, CallFailed::CallRejected(e) if e.reject_code() == Ok(RejectCode::SysTransient))
+                    if matches!(
+                        e,
+                        CallFailed::InsufficientLiquidCycleBalance(_)
+                            | CallFailed::CallPerformFailed(_)
+                    ) || matches!(e, CallFailed::CallRejected(e) if e.reject_code() == Ok(RejectCode::SysTransient))
                     {
                         // Try to execute the timer again later.
                         TIMERS.with(|timers| {

--- a/ic-cdk-timers/src/lib.rs
+++ b/ic-cdk-timers/src/lib.rs
@@ -133,7 +133,7 @@ extern "C" fn global_timer() {
                 let task_id = timer.task;
                 if let Err(e) = res {
                     ic_cdk::println!("[ic-cdk-timers] canister_global_timer: {e:?}");
-                    if matches!(e, CallFailed::CallPerformFailed(_))
+                    if matches!(e, CallFailed::PreExecutionFailure(_))
                         || matches!(e, CallFailed::CallRejected(e) if e.reject_code() == Ok(RejectCode::SysTransient))
                     {
                         // Try to execute the timer again later.

--- a/ic-cdk/src/api.rs
+++ b/ic-cdk/src/api.rs
@@ -196,11 +196,19 @@ pub fn canister_self() -> Principal {
     Principal::try_from(&buf).unwrap()
 }
 
-/// Gets the current cycle balance of the canister
+/// Gets the current cycle balance of the canister.
 pub fn canister_cycle_balance() -> u128 {
     let mut dst = 0u128;
     // SAFETY: `dst` is a mutable reference to a 16-byte buffer, which is the expected size for `ic0.canister_cycle_balance128`.
     unsafe { ic0::canister_cycle_balance128(&mut dst as *mut u128 as usize) }
+    dst
+}
+
+/// Gets the current amount of cycles that is available for spending in calls and execution.
+pub fn canister_liquid_cycle_balance() -> u128 {
+    let mut dst = 0u128;
+    // SAFETY: `dst` is a mutable reference to a 16-byte buffer, which is the expected size for `ic0.canister_liquid_cycle_balance128`.
+    unsafe { ic0::canister_liquid_cycle_balance128(&mut dst as *mut u128 as usize) }
     dst
 }
 

--- a/ic-cdk/src/call.rs
+++ b/ic-cdk/src/call.rs
@@ -387,7 +387,7 @@ pub enum Error {
 
 /// The error type when awaiting a [`CallFuture`].
 ///
-/// This encapsulates all possible [`Error`] except for the [`CandidDecodeFailed`] variant.
+/// This encapsulates all possible [`enum@Error`] except for the [`CandidDecodeFailed`] variant.
 #[derive(Error, Debug, Clone)]
 pub enum CallFailed {
     /// The liquid cycle balance is insufficient to perform the call.
@@ -459,8 +459,6 @@ pub struct InsufficientLiquidCycleBalance {
 ///
 /// This error type indicates that the underlying `ic0.call_perform` operation
 /// returned a non-zero code, signaling a failure.
-///
-/// This is wrapped by the [`PreExecutionFailure::CallPerformFailed`] variant.
 #[derive(Error, Debug, Clone)]
 #[error("call perform failed")]
 pub struct CallPerformFailed;

--- a/ic0/Cargo.toml
+++ b/ic0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic0"
-version = "0.24.0-alpha.2"
+version = "0.24.0-alpha.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ic0/ic0.txt
+++ b/ic0/ic0.txt
@@ -18,6 +18,7 @@
     ic0.canister_self_size : () -> I;                                                     // *
     ic0.canister_self_copy : (dst : I, offset : I, size : I) -> ();                       // *
     ic0.canister_cycle_balance128 : (dst : I) -> ();                                      // *
+    ic0.canister_liquid_cycle_balance128 : (dst : I) -> ();                               // *
     ic0.canister_status : () -> i32;                                                      // *
     ic0.canister_version : () -> i64;                                                     // *
     ic0.subnet_self_size : () -> I;                                                       // *

--- a/ic0/src/ic0.rs
+++ b/ic0/src/ic0.rs
@@ -21,6 +21,7 @@ extern "C" {
     pub fn canister_self_size() -> usize;
     pub fn canister_self_copy(dst: usize, offset: usize, size: usize);
     pub fn canister_cycle_balance128(dst: usize);
+    pub fn canister_liquid_cycle_balance128(dst: usize);
     pub fn canister_status() -> u32;
     pub fn canister_version() -> u64;
     pub fn subnet_self_size() -> usize;
@@ -129,6 +130,9 @@ mod non_wasm {
     }
     pub unsafe fn canister_cycle_balance128(dst: usize) {
         panic!("canister_cycle_balance128 should only be called inside canisters.");
+    }
+    pub unsafe fn canister_liquid_cycle_balance128(dst: usize) {
+        panic!("canister_liquid_cycle_balance128 should only be called inside canisters.");
     }
     pub unsafe fn canister_status() -> u32 {
         panic!("canister_status should only be called inside canisters.");


### PR DESCRIPTION
SDK-2024

# Description

- Added new system API: `ic0. canister_liquid_cycle_balance` in `ic0`.
- Added safe binding in `api.rs`.
- Utilized this method to check if cycle balance is sufficient to call before `ic0.perform`.
- Added a new error type (`InsufficientLiquidCycleBalance`).
- Restructured the error types to be flatter.

Fixes # (issue)

# How Has This Been Tested?

e2e with updated `pocket-ic`.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
