### PR TITLE
chore: release v0.18.0-alpha.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ opt-level = 'z'
 
 [workspace.dependencies]
 ic0 = { path = "ic0", version = "0.24.0-alpha.3" }
-ic-cdk = { path = "ic-cdk", version = "0.18.0-alpha.1" }
-ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.0-alpha.1" }
+ic-cdk = { path = "ic-cdk", version = "0.18.0-alpha.2" }
+ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.0-alpha.2" }
 ic-management-canister-types = { path = "ic-management-canister-types", version = "0.3.0" }
 
 candid = "0.10.13"      # sync with the doc comment in ic-cdk/README.md

--- a/ic-cdk-macros/Cargo.toml
+++ b/ic-cdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-macros"
-version = "0.18.0-alpha.1" # sync with ic-cdk
+version = "0.18.0-alpha.2" # sync with ic-cdk
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ic-cdk-timers/Cargo.toml
+++ b/ic-cdk-timers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-timers"
-version = "0.12.0-alpha.1"
+version = "0.12.0-alpha.2"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ic-cdk/CHANGELOG.md
+++ b/ic-cdk/CHANGELOG.md
@@ -6,17 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-## Changes since [0.18.0-alpha.1]
+## [0.18.0-alpha.2] - 2025-03-19
 
-- Downgrade MSRV to 1.75.0 which is the same as `ic-cdk` v0.17.
-- `update`/`query` macros now support custom result encoders via `encode_with`.
+### Changes since [0.18.0-alpha.1]
+
 - Implemented the `bitcoin_canister.rs` module.
-- Switch `RejectCode` to `ic-error-types`.
-- `CallReject` provides `reject_code()` and `raw_reject_code()` methods.
-- Added System API `cost_*` bindings in `api.rs`.
+- `Call::bounded_wait` default with 300s timeout.
+- Added System API in `ic0` and bindings in `api.rs`.
+  - `cost_*`
+  - `subnet_self`
+  - `canister_liquid_cycle_balance`
 - Removed the `_with_cycles` suffix from some Management canister methods
   - They no longer takes `cycles` as an argument.
   - The cycles cost is calculated using the new `cost_*` API.
+- Upgrade `ic-management-canister-types` to 0.3.0.
+- Switch `RejectCode` to `ic-error-types`.
+- `CallReject` provides `reject_code()` and `raw_reject_code()` methods.
+- `update`/`query` macros now support custom result encoders via `encode_with`.
+- Downgrade MSRV to 1.75.0 which is the same as `ic-cdk` v0.17.
 
 ## [0.18.0-alpha.1] - 2025-02-25
 
@@ -37,7 +44,7 @@ Please check [Version 0.18 Guide](V18_GUIDE.md) for more details.
 - Simplified module hierarchy with one level under the crate root.
   - `api` module offers consistent System API bindings.
   - `management_canister` module for convenient Management Canister calls.
-  - `bitcoin_canister` module for direct Bitcoin Canisters calls (coming soon).
+  - `bitcoin_canister` module for direct Bitcoin Canisters calls.
 
 ### Changed
 

--- a/ic-cdk/Cargo.toml
+++ b/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.18.0-alpha.1" # sync with ic-cdk-macros and the doc comment in README.md
+version = "0.18.0-alpha.2" # sync with ic-cdk-macros and the doc comment in README.md
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -27,7 +27,7 @@ ic0.workspace = true
 # Dependents won't accidentaly upgrading ic-cdk-macros only but not ic-cdk.
 # ic-cdk-macros is a hidden dependency, re-exported by ic-cdk.
 # It should not be included by users direcly.
-ic-cdk-macros = { path = "../ic-cdk-macros", version = "=0.18.0-alpha.1" }
+ic-cdk-macros = { path = "../ic-cdk-macros", version = "=0.18.0-alpha.2" }
 ic-error-types = "0.1.0"
 ic-management-canister-types.workspace = true
 serde.workspace = true

--- a/ic-cdk/V18_GUIDE.md
+++ b/ic-cdk/V18_GUIDE.md
@@ -10,12 +10,12 @@ This guide will go through the major features and changes and help you migrate y
 Update your `Cargo.toml` to use the alpha version of the library:
 ```toml
 [dependencies]
-ic-cdk = "0.18.0-alpha.1"
+ic-cdk = "0.18.0-alpha.2"
 ```
 
 > [!NOTE]
 > The new version relies on the “Bounded-Wait Calls” feature that is not yet fully enabled on the mainnet.
-> To allow users to start experimenting with the new features and provide feedback, we are releasing this version as an alpha (v0.18.0-alpha.1).
+> To allow users to start experimenting with the new features and provide feedback, we are releasing this version as an alpha.
 > A stable release will follow once the “Bounded-Wait Calls” feature is fully enabled on the mainnet.
 >
 > The Canister module built with the new Rust CDK is compatible with:
@@ -79,21 +79,20 @@ rustup component add rust-src --toolchain nightly
 cargo +nightly build -Z build-std=std,panic_abort --target wasm64-unknown-unknown
 ```
 
-### Custom Decoders in `update`/`query`/`init` Macros
+### Custom Encoders/Decoders in `update`/`query`/`init` Macros
 
 The macros are enhanced to accept custom decoders.
 
 ```rust
-// The update method specifies a custom decoder function by its name
-#[update(decode_with = "decode_two_u32")]
-fn expect_two_u32(a: u32, b: u32) {
-    ...
+#[update(decode_with = "decode_args", encode_with = "encode_result")]
+fn update_methods(a: u32, b: u32) -> (u32, u32) {
+    // ...
 }
-// The decoder function should have empty arguments
-// and return the same type(s) that the update method expects.
-fn decode_two_u32() -> (u32, u32) {
-    let arg_bytes = msg_arg_data();
-    decode_args(&arg_bytes).unwrap() // decode with any data format not limited to Candid
+fn decode_args(arg_bytes: Vec<u8>) -> (u32, u32) {
+    // ...
+}
+fn encode_result(result: (u32, u32)) -> Vec<u8> {
+    // ...
 }
 ```
 

--- a/ic-cdk/src/api.rs
+++ b/ic-cdk/src/api.rs
@@ -21,14 +21,16 @@
 use candid::Principal;
 use std::{convert::TryFrom, num::NonZeroU64};
 
-#[doc(hidden)]
 #[deprecated(
     since = "0.18.0",
     note = "The `api::call` module is deprecated. Individual items within this module have their own deprecation notices with specific migration guidance."
 )]
 pub mod call;
+#[deprecated(
+    since = "0.18.0",
+    note = "The `api::management_canister` module is deprecated. Please use the `management_canister` and `bitcoin_canister` modules at the crate root."
+)]
 pub mod management_canister;
-#[doc(hidden)]
 #[deprecated(
     since = "0.18.0",
     note = "The `api::stable` module has been moved to `stable` (crate root)."

--- a/ic-cdk/src/api/management_canister/mod.rs
+++ b/ic-cdk/src/api/management_canister/mod.rs
@@ -10,9 +10,33 @@
 //! [1]: https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-management-canister
 //! [2]: https://internetcomputer.org/assets/files/ic-a45d11feb0ba0494055083f9d2d21ddf.did
 #![allow(deprecated)]
+#[deprecated(
+    since = "0.18.0",
+    note = "The `api::management_canister::bitcoin` module is deprecated. Please use the `bitcoin_canister` module at the crate root."
+)]
 pub mod bitcoin;
+#[deprecated(
+    since = "0.18.0",
+    note = "The `api::management_canister::ecdsa` module is deprecated. Please use the `management_canister` module at the crate root."
+)]
 pub mod ecdsa;
+#[deprecated(
+    since = "0.18.0",
+    note = "The `api::management_canister::http_request` module is deprecated. Please use the `management_canister` module at the crate root."
+)]
 pub mod http_request;
+#[deprecated(
+    since = "0.18.0",
+    note = "The `api::management_canister::main` module is deprecated. Please use the `management_canister` module at the crate root."
+)]
 pub mod main;
+#[deprecated(
+    since = "0.18.0",
+    note = "The `api::management_canister::provisional` module is deprecated. Please use the `management_canister` module at the crate root."
+)]
 pub mod provisional;
+#[deprecated(
+    since = "0.18.0",
+    note = "The `api::management_canister::schnorr` module is deprecated. Please use the `management_canister` module at the crate root."
+)]
 pub mod schnorr;

--- a/library/ic-ledger-types/Cargo.toml
+++ b/library/ic-ledger-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-ledger-types"
-version = "0.15.0-alpha.1"
+version = "0.15.0-alpha.2"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
SDK-2017

# Description

- properly deprecate api/ submodules and items there
  - The modules should not be hidden. Users should still be able to see the deprecated API and check the notes of replacement.
- update changelog to emphasize changes since alpha.1
- update V18_GUIDE.md

# How Has This Been Tested?

CI

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
