### PR TITLE
ci: fix pocket-ic server download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,14 @@ jobs:
             ${{ runner.os }}-
       - name: Download pocket-ic server
         run: bash scripts/download_pocket_ic_server.sh
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+      - name: Install protoc (macOS)
+        if: runner.os == 'macOS'
+        run: brew install protobuf
+      - name: Install protoc (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - name: Run tests
         run:
           | # https://github.com/rust-lang/cargo/issues/6669 we have to run ALL tests with two commands
@@ -112,8 +118,14 @@ jobs:
             ${{ runner.os }}-
       - name: Download pocket-ic server
         run: bash scripts/download_pocket_ic_server.sh
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+      - name: Install protoc (macOS)
+        if: runner.os == 'macOS'
+        run: brew install protobuf
+      - name: Install protoc (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - name: Run tests
         run: WASM64=1 cargo test --package ic-cdk-e2e-tests --no-fail-fast
 
@@ -163,8 +175,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-clippy-
             ${{ runner.os }}-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+      - name: Install protoc (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - name: Run clippy
         run: |
           cargo clippy --tests --benches -- -D warnings
@@ -190,8 +205,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-doc-
             ${{ runner.os }}-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+      - name: Install protoc (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - name: Run doc
         run: |
           RUSTDOCFLAGS="-D warnings" cargo doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-test-
             ${{ runner.os }}-
+      - name: Download pocket-ic server
+        run: bash scripts/download_pocket_ic_server.sh
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
       - name: Run tests
@@ -108,6 +110,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-wasm64-
             ${{ runner.os }}-
+      - name: Download pocket-ic server
+        run: bash scripts/download_pocket_ic_server.sh
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
       - name: Run tests

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -26,7 +26,7 @@ candid_parser.workspace = true
 cargo_metadata = "0.19"
 futures = "0.3"
 hex.workspace = true
-pocket-ic = { git = "https://github.com/dfinity/ic", tag = "release-2025-03-14_03-10-base" }
+pocket-ic = { git = "https://github.com/dfinity/ic", tag = "release-2025-04-03_03-15-base" }
 reqwest = "0.12"
 
 [build-dependencies]

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -24,8 +24,6 @@ prost = "0.13.5"
 [dev-dependencies]
 candid_parser.workspace = true
 cargo_metadata = "0.19"
-fd-lock = "4.0.4"
-flate2 = "1.1"
 futures = "0.3"
 hex.workspace = true
 pocket-ic = { git = "https://github.com/dfinity/ic", tag = "release-2025-03-14_03-10-base" }

--- a/e2e-tests/src/bin/management_canister.rs
+++ b/e2e-tests/src/bin/management_canister.rs
@@ -13,7 +13,8 @@ async fn basic() {
             controllers: Some(vec![self_id]),
             compute_allocation: Some(0u8.into()),
             memory_allocation: Some(0u8.into()),
-            freezing_threshold: Some(0u8.into()),
+            // Since around 2025-04, the freezing threshold is enforced to be at least 604800 seconds (7 days).
+            freezing_threshold: Some(604_800u32.into()),
             reserved_cycles_limit: Some(0u8.into()),
             log_visibility: Some(LogVisibility::Public),
             wasm_memory_limit: Some(0u8.into()),
@@ -36,7 +37,7 @@ async fn basic() {
     assert_eq!(definite_canister_setting.controllers, vec![self_id]);
     assert_eq!(definite_canister_setting.compute_allocation, 0u8);
     assert_eq!(definite_canister_setting.memory_allocation, 0u8);
-    assert_eq!(definite_canister_setting.freezing_threshold, 0u8);
+    assert_eq!(definite_canister_setting.freezing_threshold, 604_800u32);
     assert_eq!(definite_canister_setting.reserved_cycles_limit, 0u8);
     assert_eq!(
         definite_canister_setting.log_visibility,
@@ -49,7 +50,7 @@ async fn basic() {
     let arg = UpdateSettingsArgs {
         canister_id,
         settings: CanisterSettings {
-            freezing_threshold: Some(0u16.into()),
+            freezing_threshold: Some(2_592_000u32.into()),
             log_visibility: Some(LogVisibility::AllowedViewers(vec![self_id])),
             ..Default::default()
         },

--- a/scripts/download_pocket_ic_server.sh
+++ b/scripts/download_pocket_ic_server.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+uname_sys=$(uname -s | tr '[:upper:]' '[:lower:]')
+echo "uname_sys: $uname_sys"
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPTS_DIR/../e2e-tests"
+# extract the tag from e2e-tests/Cargo.toml
+tag=$(grep -E 'pocket-ic.*tag' Cargo.toml | sed -n "s/.*tag *= *\"\([^\"]*\)\".*/\1/p")
+
+ARTIFACTS_DIR="$SCRIPTS_DIR/../target/e2e-tests-artifacts"
+mkdir -p "$ARTIFACTS_DIR"
+cd "$ARTIFACTS_DIR"
+echo -n "$tag" > pocket-ic-tag
+curl -sL "https://github.com/dfinity/ic/releases/download/$tag/pocket-ic-x86_64-$uname_sys.gz" --output pocket-ic.gz
+gzip -df pocket-ic.gz
+chmod a+x pocket-ic
+./pocket-ic --version
+
+if [[ "$uname_sys" == "darwin" ]]; then
+    xattr -dr com.apple.quarantine pocket-ic
+fi


### PR DESCRIPTION
# Description

Since https://github.com/dfinity/cdk-rs/pull/568, the pocket-ic server binary is cached during the e2e tests.
It is hard to implement correctly. https://github.com/dfinity/cdk-rs/pull/584 fixed the flaky cases but failed to handle [tag updates](https://github.com/dfinity/cdk-rs/actions/runs/14249470133/job/39938524676#step:7:194).

This PR brings back the shell script which downloads the pocket-ic server. In e2e tests, a utility function still checks the tag and inform to run the shell script if tag mismatch or the server binary doesn't exist.

## Other changes

* Updated the pocket-ic tag to `release-2025-04-03_03-15-base`.
  * The `freezing_threshold` is enforced to be at least 604800 seconds. So the test code is adjusted.
* Replaces the GitHub action `arduino/setup-protoc@v3` with the native package manager commands.
  * The action makes CI flaky, e.g. this [failure](https://github.com/dfinity/cdk-rs/actions/runs/14271179478/job/40004535383#step:6:6).

# How Has This Been Tested?

CI

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
