### PR TITLE
feat: introduce multiple `guards`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.2"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -2225,15 +2225,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -2633,12 +2632,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sptr"

--- a/src/ic-cdk-macros/CHANGELOG.md
+++ b/src/ic-cdk-macros/CHANGELOG.md
@@ -15,6 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `cargo build` should no longer give a confusing linkage error on Linux.
 
+### Added
+
+- Add multiple `guards` to `#[update]` and `#[query]` macros. (#590)
+
+    ```rust
+    #[update(guards = ["only_admin", "non_reentrant"])]
+    fn do_something() {
+      ...
+    }
+    ```
+
 ## [0.13.2] - 2024-04-08
 
 ### Changed

--- a/src/ic-cdk/src/macros.rs
+++ b/src/ic-cdk/src/macros.rs
@@ -57,7 +57,27 @@ pub use ic_cdk_macros::export_candid;
 ///     // ...
 /// # unimplemented!()
 /// }
+///
+/// You can specify several guards and they will be executed in the order.
+/// When a guard function returns an error, the query function will not proceed.
+/// ```rust
+/// # use ic_cdk::query;
+/// fn guard_function_1() -> Result<(), String> {
+///    // ...
+/// # unimplemented!()
+/// }
+/// fn guard_function_2() -> Result<(), String> {
+///   // ...
+/// # unimplemented!()
+/// }
+/// #[query(guards = ["guard_function_1", "guard_function_2"])]
+/// fn query_function() {
+///     // ...
+/// # unimplemented!()
+/// }   
 /// ```
+///
+/// In case the both `guard` and `guards` are specified, the `guard` will be executed first and the guard functions specified in the `guards` will be executed.
 ///
 /// To be able to make inter-canister calls from a query call, it must be a *composite* query (which cannot be executed in replicated mode).
 ///
@@ -140,6 +160,26 @@ pub use ic_cdk_macros::query;
 /// # unimplemented!()
 /// }
 /// ```
+///
+/// You can specify several guards and they will be executed in the order.
+/// When a guard function returns an error, the update function will not proceed.
+/// ```rust
+/// # use ic_cdk::update;
+/// fn guard_function_1() -> Result<(), String> {
+///    // ...
+/// # unimplemented!()
+/// }
+/// fn guard_function_2() -> Result<(), String> {
+///   // ...
+/// # unimplemented!()
+/// }
+/// #[update(guards = ["guard_function_1", "guard_function_2"])]
+/// fn update_function() {
+///     // ...
+/// # unimplemented!()
+/// }   
+///
+/// In case the both `guard` and `guards` are specified, the `guard` will be executed first and the guard functions specified in the `guards` will be executed.
 ///
 /// If you would rather call the [`reply()`](crate::api::call::reply) function than return a value,
 /// you will need to set `manual_reply` to `true` so that the canister does not trap.


### PR DESCRIPTION
# Description

Introduced multiple guards on `query` and `update` macros to protect them with several guards.

```rust
#[update(guards = ["only_admin", "non_reentrant"])]
fn do_something() {
...
}
```

Fixes https://github.com/dfinity/cdk-rs/issues/413

# How Has This Been Tested?

Added relevant unit test cases

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
