### PR TITLE
chore: release v0.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ lto = true
 opt-level = 'z'
 
 [workspace.dependencies]
-ic0 = { path = "ic0", version = "0.24.0-alpha.3" }
-ic-cdk = { path = "ic-cdk", version = "0.18.0-alpha.2" }
-ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.0-alpha.2" }
+ic0 = { path = "ic0", version = "0.24.0" }
+ic-cdk = { path = "ic-cdk", version = "0.18.0" }
+ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.0" }
 ic-management-canister-types = { path = "ic-management-canister-types", version = "0.3.0" }
 
 candid = "0.10.13"      # sync with the doc comment in ic-cdk/README.md

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -26,7 +26,7 @@ candid_parser.workspace = true
 cargo_metadata = "0.19"
 futures = "0.3"
 hex.workspace = true
-pocket-ic = { git = "https://github.com/dfinity/ic", tag = "release-2025-04-03_03-15-base" }
+pocket-ic = { git = "https://github.com/dfinity/ic", tag = "release-2025-04-11_13-20-base" }
 reqwest = "0.12"
 
 [build-dependencies]

--- a/e2e-tests/tests/test_utilities.rs
+++ b/e2e-tests/tests/test_utilities.rs
@@ -96,7 +96,6 @@ pub fn pic_base() -> PocketIcBuilder {
     PocketIcBuilder::new()
         .with_server_binary(pocket_ic_server)
         .with_application_subnet()
-        .with_nonmainnet_features(true)
 }
 
 fn check_pocket_ic_server() -> PathBuf {

--- a/ic-cdk-macros/Cargo.toml
+++ b/ic-cdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-macros"
-version = "0.18.0-alpha.2" # sync with ic-cdk
+version = "0.18.0" # sync with ic-cdk
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ic-cdk-timers/CHANGELOG.md
+++ b/ic-cdk-timers/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.12.0] - 2025-04-22
+
+- Upgrade `ic-cdk` to v0.18.
+
 ## [0.11.0] - 2024-11-04
 
 ### Changed

--- a/ic-cdk-timers/Cargo.toml
+++ b/ic-cdk-timers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-timers"
-version = "0.12.0-alpha.2"
+version = "0.12.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ic-cdk/CHANGELOG.md
+++ b/ic-cdk/CHANGELOG.md
@@ -6,26 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-## [0.18.0-alpha.2] - 2025-03-19
-
-### Changes since [0.18.0-alpha.1]
-
-- Implemented the `bitcoin_canister.rs` module.
-- `Call::bounded_wait` default with 300s timeout.
-- Added System API in `ic0` and bindings in `api.rs`.
-  - `cost_*`
-  - `subnet_self`
-  - `canister_liquid_cycle_balance`
-- Removed the `_with_cycles` suffix from some Management canister methods
-  - They no longer takes `cycles` as an argument.
-  - The cycles cost is calculated using the new `cost_*` API.
-- Upgrade `ic-management-canister-types` to 0.3.0.
-- Switch `RejectCode` to `ic-error-types`.
-- `CallReject` provides `reject_code()` and `raw_reject_code()` methods.
-- `update`/`query` macros now support custom result encoders via `encode_with`.
-- Downgrade MSRV to 1.75.0 which is the same as `ic-cdk` v0.17.
-
-## [0.18.0-alpha.1] - 2025-02-25
+## [0.18.0] - 2025-04-22
 
 Please check [Version 0.18 Guide](V18_GUIDE.md) for more details.
 

--- a/ic-cdk/Cargo.toml
+++ b/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.18.0-alpha.2" # sync with ic-cdk-macros and the doc comment in README.md
+version = "0.18.0" # sync with ic-cdk-macros and the doc comment in README.md
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -27,7 +27,7 @@ ic0.workspace = true
 # Dependents won't accidentaly upgrading ic-cdk-macros only but not ic-cdk.
 # ic-cdk-macros is a hidden dependency, re-exported by ic-cdk.
 # It should not be included by users direcly.
-ic-cdk-macros = { path = "../ic-cdk-macros", version = "=0.18.0-alpha.2" }
+ic-cdk-macros = { path = "../ic-cdk-macros", version = "=0.18.0" }
 ic-error-types = "0.1.0"
 ic-management-canister-types.workspace = true
 serde.workspace = true

--- a/ic-cdk/V18_GUIDE.md
+++ b/ic-cdk/V18_GUIDE.md
@@ -1,25 +1,17 @@
 # Version 0.18 Guide
 
 ## Introduction
+
 `ic-cdk` v0.18 introduces many new features and changes that improve the developer experience.
 This guide covers the major features and changes and provides migration guidance for code written with version 0.17 or earlier.
 
 ### How to Upgrade
 
-Update the `Cargo.toml` to use the alpha version of the library:
+Update `Cargo.toml`:
 ```toml
 [dependencies]
-ic-cdk = "0.18.0-alpha.2"
+ic-cdk = "0.18.0"
 ```
-
-> [!NOTE]
-> The new version relies on the “Bounded-Wait Calls” feature that is not yet fully enabled on the mainnet.
-> To allow users to start experimenting with the new features and provide feedback, we are releasing this version as an alpha.
-> A stable release will follow once the “Bounded-Wait Calls” feature is fully enabled on the mainnet.
->
-> The Canister module built with the new Rust CDK is compatible with:
-> - `dfx start`: defaults to enable the “Bounded-Wait Calls” feature.
-> - `PocketIC`: enable the feature with `PocketIcBuilder::with_nonmainnet_features(true)`.
 
 ## Features
 
@@ -38,7 +30,7 @@ let res: u32 = Call::bounded_wait(id, method) // Choose the "bounded-wait" const
     .candid()?;                               // Decode the response bytes as Candid value
 ```
 
-Please check the [docs](https://docs.rs/ic-cdk/0.18.0-alpha.1/ic_cdk/call/struct.Call.html) for more details.
+Please check the [docs](https://docs.rs/ic-cdk/0.18.0/ic_cdk/call/struct.Call.html) for more details.
 
 #### Migration
 

--- a/ic0/Cargo.toml
+++ b/ic0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic0"
-version = "0.24.0-alpha.3"
+version = "0.24.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/library/ic-ledger-types/CHANGELOG.md
+++ b/library/ic-ledger-types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.15.0] - 2025-04-22
+
+### Changed
+
+- Upgrade `ic-cdk` to v0.18.
+
 ## [0.14.0] - 2024-11-08
 
 ### Changed

--- a/library/ic-ledger-types/Cargo.toml
+++ b/library/ic-ledger-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-ledger-types"
-version = "0.15.0-alpha.2"
+version = "0.15.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
SDK-2086

# Description

Cut the stable v0.18.0 release as the "Bounded-Wait Calls" feature is enabled on all the mainnet subnets.

# How Has This Been Tested?

CI

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
