### PR TITLE
docs: provide a link to bounded doc in V18 migration guide

### DIFF
--- a/ic-cdk/V18_GUIDE.md
+++ b/ic-cdk/V18_GUIDE.md
@@ -34,7 +34,7 @@ Please check the [docs](https://docs.rs/ic-cdk/0.18.0/ic_cdk/call/struct.Call.ht
 
 #### Migration
 
-The functions for inter-canister calls in the `ic_cdk::api::call` module are deprecated in favor of the new `Call` API. These functions were created before the introduction of the "Bounded-Wait Calls" feature. To maintain the same behavior, use the `Call::unbounded_wait()` constructor. You can later evaluate if a specific call should switch to `Call::bounded_wait()`.
+The functions for inter-canister calls in the `ic_cdk::api::call` module are deprecated in favor of the new `Call` API. These functions were created before the introduction of the [Bounded-Wait Calls](https://internetcomputer.org/docs/references/async-code#ic-call-types) feature. To maintain the same behavior, use the `Call::unbounded_wait()` constructor. You can later evaluate if a specific call should switch to `Call::bounded_wait()`.
 
 | Before                                             | After                                                                                    |
 | -------------------------------------------------- | ---------------------------------------------------------------------------------------- |


### PR DESCRIPTION
# Description

I was reading the [V18 migration guide](https://github.com/dfinity/cdk-rs/blob/main/ic-cdk/V18_GUIDE.md), and since I had no idea what "Bounded vs Unbounded calls" were, I ended up spending some time searching for resources that explain the difference. Even use the AI on the portal. That’s why, even though links to the portal often end up broken at some point, I think in this case it’s useful to include a link to the documentation.

# Changes

- Link term "Bounded-Wait Calls" to https://internetcomputer.org/docs/references/async-code#ic-call-types
