### PR TITLE
feat: macros attrs can take a Path

### DIFF
--- a/e2e-tests/tests/macros.rs
+++ b/e2e-tests/tests/macros.rs
@@ -61,6 +61,9 @@ fn call_macros() {
         .encode_to_vec()
     );
     let _: (u32,) = update(&pic, canister_id, "manual_reply", ()).unwrap();
+    let (res,): (u32,) = update(&pic, canister_id, "generic", (1u32,)).unwrap();
+    assert_eq!(res, 2);
+
     let rej = pic
         .update_call(canister_id, sender, "with_guards", vec![1])
         .unwrap_err();


### PR DESCRIPTION
SDK-2110

# Description

The macros attributes `guard`, `decode_with` and `encode_with` accept function names. They were restricted to take `syn::Ident` only.

This PR extended the attributes to take `syn::Path` instead which allows:
- Functions defined in other modules: `other_mod::guard`;
- Functions with generic parameters: `candid_decode_with_quota::<1000,_>`;

# How Has This Been Tested?

Added e2e tests.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
