### PR TITLE
feat: add Call::take_raw_args which owns the bytes

### DIFF
--- a/e2e-tests/src/bin/call.rs
+++ b/e2e-tests/src/bin/call.rs
@@ -93,6 +93,11 @@ async fn call_echo() {
         .await
         .unwrap();
     assert_eq!(res, bytes);
+    let res = Call::unbounded_wait(canister_self(), "echo")
+        .take_raw_args(bytes.clone())
+        .await
+        .unwrap();
+    assert_eq!(res, bytes);
     let res: u32 = Call::unbounded_wait(canister_self(), "echo")
         .with_arg(n)
         .await
@@ -131,6 +136,11 @@ async fn call_echo() {
     assert_eq!(res, bytes);
     let res = Call::bounded_wait(canister_self(), "echo")
         .with_raw_args(&bytes)
+        .await
+        .unwrap();
+    assert_eq!(res, bytes);
+    let res = Call::bounded_wait(canister_self(), "echo")
+        .take_raw_args(bytes.clone())
         .await
         .unwrap();
     assert_eq!(res, bytes);

--- a/ic-cdk/CHANGELOG.md
+++ b/ic-cdk/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support VetKD management canister API. (#597)
+- Add `Call::take_raw_args` which owns the bytes. (#601)
 
 ## [0.18.0] - 2025-04-22
 

--- a/ic-cdk/src/call.rs
+++ b/ic-cdk/src/call.rs
@@ -215,9 +215,35 @@ impl<'a> Call<'_, 'a> {
     }
 
     /// Sets the arguments for the call as raw bytes.
+    ///
+    /// # Note
+    ///
+    /// This method just borrows the bytes, so it is useful when making multiple calls with the same argument data.
+    ///
+    /// The `Call` object will be tied to the lifetime of the argument bytes,
+    /// which may prevent storing the call in collections or returning it from functions
+    /// if the arguments don't live long enough.
+    ///
+    /// For cases where you need to transfer ownership of the arguments bytes consider using [`Self::take_raw_args`] instead.
     pub fn with_raw_args(self, raw_args: &'a [u8]) -> Self {
         Self {
             encoded_args: Cow::Borrowed(raw_args),
+            ..self
+        }
+    }
+
+    /// Sets the arguments for the call as raw bytes and consumes the bytes.
+    ///
+    /// # Note
+    ///
+    /// This method takes ownership of the arguments bytes, so it is useful
+    /// when you want to store the call in collections or return a `Call` from functions.
+    ///
+    /// For cases where you want to make multiple calls with the same argument data,
+    /// consider using [`Self::with_raw_args`] instead to avoid unnecessary cloning.
+    pub fn take_raw_args(self, raw_args: Vec<u8>) -> Self {
+        Self {
+            encoded_args: Cow::Owned(raw_args),
             ..self
         }
     }


### PR DESCRIPTION
SDK-2129

# Description

The existing `Call::with_raw_args` method takes a reference of the bytes which may prevent storing the call in collections or returning it from functions if the arguments don't live long enough.

This PR added another method which takes the ownership of the bytes.

# How Has This Been Tested?

Added in e2e tests.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
