### PR TITLE
chore: Factor out v2 executor into separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,6 +1164,7 @@ version = "0.17.1"
 dependencies = [
  "anyhow",
  "candid",
+ "ic-cdk-executor",
  "ic-cdk-macros",
  "ic0",
  "rstest",
@@ -1199,6 +1200,10 @@ dependencies = [
  "serde_bytes",
  "sha2",
 ]
+
+[[package]]
+name = "ic-cdk-executor"
+version = "0.1.0"
 
 [[package]]
 name = "ic-cdk-macros"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ opt-level = 'z'
 [workspace.dependencies]
 ic0 = { path = "src/ic0", version = "0.23.0" }
 ic-cdk = { path = "src/ic-cdk", version = "0.17.1" }
+ic-cdk-executor = { path = "src/ic-cdk-executor", version = "0.1.0" }
 ic-cdk-timers = { path = "src/ic-cdk-timers", version = "0.11.0" }
 
 candid = "0.10.4"

--- a/src/ic-cdk-executor/Cargo.toml
+++ b/src/ic-cdk-executor/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ic-cdk-executor"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Async executor for `ic-cdk`"
+categories = ["asynchronous", "rust-patterns"]
+keywords = ["internet-computer", "dfinity", "canister", "cdk"]
+# DO NOT change this field, not even to update the link, unless you are updating every existing version of the package.
+# Update the link by updating the links-pin tag.
+links = "ic-cdk async executor, see https://github.com/dfinity/cdk-rs/blob/links-pin/ic-cdk-executor/TROUBLESHOOTING.md"
+
+[dependencies]

--- a/src/ic-cdk-executor/Cargo.toml
+++ b/src/ic-cdk-executor/Cargo.toml
@@ -11,6 +11,6 @@ categories = ["asynchronous", "rust-patterns"]
 keywords = ["internet-computer", "dfinity", "canister", "cdk"]
 # DO NOT change this field, not even to update the link, unless you are updating every existing version of the package.
 # Update the link by updating the links-pin tag.
-links = "ic-cdk async executor, see https://github.com/dfinity/cdk-rs/blob/links-pin/ic-cdk-executor/TROUBLESHOOTING.md"
+links = "ic-cdk async executor, see https://github.com/dfinity/cdk-rs/blob/links-pin/TROUBLESHOOTING.md"
 
 [dependencies]

--- a/src/ic-cdk-executor/build.rs
+++ b/src/ic-cdk-executor/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    // dummy build script, required by `package.links`
+}

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -22,6 +22,7 @@ include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 [dependencies]
 candid.workspace = true
 ic0.workspace = true
+ic-cdk-executor.workspace = true
 # Pin ic-cdk-macros to a specific version.
 # This actually create a 1-to-1 mapping between ic-cdk and ic-cdk-macros.
 # Dependents won't accidentaly upgrading ic-cdk-macros only but not ic-cdk.

--- a/src/ic-cdk/src/api/call.rs
+++ b/src/ic-cdk/src/api/call.rs
@@ -182,9 +182,9 @@ unsafe extern "C" fn cleanup<T: AsRef<[u8]>>(state_ptr: *const RwLock<CallFuture
         if let Some(waker) = w {
             // Flag that we do not want to actually wake the task - we
             // want to drop it *without* executing it.
-            crate::futures::CLEANUP.store(true, Ordering::Relaxed);
+            ic_cdk_executor::CLEANUP.store(true, Ordering::Relaxed);
             waker.wake();
-            crate::futures::CLEANUP.store(false, Ordering::Relaxed);
+            ic_cdk_executor::CLEANUP.store(false, Ordering::Relaxed);
         }
     }
 }
@@ -873,5 +873,5 @@ where
 /// [std::thread::panicking] - it tells you whether the destructor is executing *because* of a trap,
 /// as opposed to just because the scope was exited, so you could e.g. implement mutex poisoning.
 pub fn is_recovering_from_trap() -> bool {
-    crate::futures::CLEANUP.load(Ordering::Relaxed)
+    ic_cdk_executor::CLEANUP.load(Ordering::Relaxed)
 }

--- a/src/ic-cdk/src/lib.rs
+++ b/src/ic-cdk/src/lib.rs
@@ -13,7 +13,6 @@
 compile_error!("This version of the CDK does not support multithreading.");
 
 pub mod api;
-mod futures;
 mod macros;
 mod printer;
 pub mod storage;
@@ -45,13 +44,13 @@ pub fn setup() {
     note = "Use the spawn() function instead, it does the same thing but is more appropriately named."
 )]
 pub fn block_on<F: 'static + std::future::Future<Output = ()>>(future: F) {
-    futures::spawn(future);
+    ic_cdk_executor::spawn(future);
 }
 
 /// Spawn an asynchronous task that drives the provided future to
 /// completion.
 pub fn spawn<F: 'static + std::future::Future<Output = ()>>(future: F) {
-    futures::spawn(future);
+    ic_cdk_executor::spawn(future);
 }
 
 /// Format and then print the formatted message


### PR DESCRIPTION
This PR targets a feature branch because it is for ic-cdk@0.17, not 0.18.