### PR TITLE
chore: Release 0.17.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "candid",
@@ -1207,7 +1207,7 @@ version = "0.1.0"
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "candid",
  "proc-macro2",

--- a/src/ic-cdk-macros/Cargo.toml
+++ b/src/ic-cdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-macros"
-version = "0.17.1" # sync with ic-cdk
+version = "0.17.2" # sync with ic-cdk
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/src/ic-cdk/Cargo.toml
+++ b/src/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.17.1" # sync with ic-cdk-macros
+version = "0.17.2" # sync with ic-cdk-macros
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -28,7 +28,7 @@ ic-cdk-executor.workspace = true
 # Dependents won't accidentaly upgrading ic-cdk-macros only but not ic-cdk.
 # ic-cdk-macros is a hidden dependency, re-exported by ic-cdk.
 # It should not be included by users direcly.
-ic-cdk-macros = { path = "../ic-cdk-macros", version = "=0.17.1" }
+ic-cdk-macros = { path = "../ic-cdk-macros", version = "=0.17.2" }
 serde.workspace = true
 serde_bytes.workspace = true
 slotmap = { workspace = true, optional = true }


### PR DESCRIPTION
Includes publishing new crate `ic-cdk-executor`.