### PR TITLE
chore: Release ic-cdk-executor v1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ opt-level = 'z'
 ic0 = { path = "ic0", version = "0.25.0" }
 ic-cdk = { path = "ic-cdk", version = "0.18.1" }
 ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.0" }
-ic-cdk-executor = { path = "ic-cdk-executor", version = "0.1.0" }
+ic-cdk-executor = { path = "ic-cdk-executor", version = "1.0.0" }
 ic-management-canister-types = { path = "ic-management-canister-types", version = "0.3.1" }
 
 candid = "0.10.13"      # sync with the doc comment in ic-cdk/README.md

--- a/ic-cdk-executor/Cargo.toml
+++ b/ic-cdk-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-executor"
-version = "0.1.0"
+version = "1.0.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
The ic-cdk release is deferred for now.