### PR TITLE
chore: update bitcoin regtest configuration to be same as the bitcoin mainnet.

### DIFF
--- a/ic-cdk/src/bitcoin_canister.rs
+++ b/ic-cdk/src/bitcoin_canister.rs
@@ -230,7 +230,7 @@ pub fn cost_get_utxos(arg: &GetUtxosRequest) -> u128 {
     match arg.network {
         Network::Mainnet => GET_UTXO_MAINNET,
         Network::Testnet => GET_UTXO_TESTNET,
-        Network::Regtest => 0,
+        Network::Regtest => GET_UTXO_MAINNET,
     }
 }
 
@@ -274,7 +274,7 @@ pub fn cost_get_balance(arg: &GetBalanceRequest) -> u128 {
     match arg.network {
         Network::Mainnet => GET_BALANCE_MAINNET,
         Network::Testnet => GET_BALANCE_TESTNET,
-        Network::Regtest => 0,
+        Network::Regtest => GET_BALANCE_MAINNET,
     }
 }
 
@@ -334,7 +334,7 @@ pub fn cost_get_current_fee_percentiles(arg: &GetCurrentFeePercentilesRequest) -
     match arg.network {
         Network::Mainnet => GET_CURRENT_FEE_PERCENTILES_MAINNET,
         Network::Testnet => GET_CURRENT_FEE_PERCENTILES_TESTNET,
-        Network::Regtest => 0,
+        Network::Regtest => GET_CURRENT_FEE_PERCENTILES_MAINNET,
     }
 }
 
@@ -392,7 +392,7 @@ pub fn cost_get_block_headers(arg: &GetBlockHeadersRequest) -> u128 {
     match arg.network {
         Network::Mainnet => GET_BLOCK_HEADERS_MAINNET,
         Network::Testnet => GET_BLOCK_HEADERS_TESTNET,
-        Network::Regtest => 0,
+        Network::Regtest => GET_BLOCK_HEADERS_MAINNET,
     }
 }
 
@@ -440,7 +440,10 @@ pub fn cost_send_transaction(arg: &SendTransactionRequest) -> u128 {
             SEND_TRANSACTION_SUBMISSION_TESTNET,
             SEND_TRANSACTION_PAYLOAD_TESTNET,
         ),
-        Network::Regtest => (0, 0),
+        Network::Regtest => (
+            SEND_TRANSACTION_SUBMISSION_MAINNET,
+            SEND_TRANSACTION_PAYLOAD_MAINNET,
+        ),
     };
     submission + payload * arg.transaction.len() as u128
 }


### PR DESCRIPTION
# Description

Update bitcoin `regtest` configuration to be same as the bitcoin `mainnet`.

```
fees = record {
      get_current_fee_percentiles = 10_000_000 : nat;
      get_utxos_maximum = 10_000_000_000 : nat;
      get_block_headers_cycles_per_ten_instructions = 10 : nat;
      get_current_fee_percentiles_maximum = 100_000_000 : nat;
      send_transaction_per_byte = 20_000_000 : nat;
      get_balance = 10_000_000 : nat;
      get_utxos_cycles_per_ten_instructions = 10 : nat;
      get_block_headers_base = 50_000_000 : nat;
      get_utxos_base = 50_000_000 : nat;
      get_balance_maximum = 100_000_000 : nat;
      send_transaction_base = 5_000_000_000 : nat;
      get_block_headers_maximum = 10_000_000_000 : nat;
    };
```
You can get the fees by `get_config` API on the [BTC Mainnet Canister](https://dashboard.internetcomputer.org/canister/ghsi2-tqaaa-aaaan-aaaca-cai)

Fixes # (issue)
[SDK-2141](https://dfinity.atlassian.net/browse/SDK-2141)

# How Has This Been Tested?

Manually tested locally.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.


[SDK-2141]: https://dfinity.atlassian.net/browse/SDK-2141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ