### PR TITLE
fix: Add `spawn` order compatibility adapter

### DIFF
--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -26,7 +26,7 @@ candid_parser.workspace = true
 cargo_metadata = "0.19"
 futures = "0.3"
 hex.workspace = true
-ic-vetkd-utils = { git = "https://github.com/dfinity/ic" }
+ic-vetkd-utils = { git = "https://github.com/dfinity/ic", rev = "95231520" }
 pocket-ic = { git = "https://github.com/dfinity/ic", tag = "release-2025-04-11_13-20-base" }
 reqwest = "0.12"
 

--- a/ic-cdk/V18_GUIDE.md
+++ b/ic-cdk/V18_GUIDE.md
@@ -77,7 +77,7 @@ spawn(async {
 runs_third();
 ```
 
-Please check all the places you call `spawn` to ensure that you do not depend on the code in the spawned future running before the code below the `spawn` call. Note that most `spawn` calls are the entire body of timers - if there is no code after `spawn`, the behavior has not changed.
+Please check all the places you call `spawn` to ensure that you do not depend on the code in the spawned future running before the code below the `spawn` call. Note that most `spawn` calls are the entire body of timers - if there is no code after `spawn` in the timer, the behavior has not changed.
 
 ### Wasm64 Compilation
 

--- a/ic-cdk/src/lib.rs
+++ b/ic-cdk/src/lib.rs
@@ -94,6 +94,11 @@ pub fn spawn<F: 'static + Future<Output = ()>>(fut: F) {
                 Notice: Code execution order will change, see https://github.com/dfinity/cdk-rs/blob/0.18.3/ic-cdk/V18_GUIDE.md#futures-ordering-changes")
         }
     }
+    // Emulated behavior: A spawned future is polled once immediately, then backgrounded and run at a normal pace.
+    // We poll it once with an unimplemented waker, then spawn it, which will poll it again with the real waker.
+    // In a correctly implemented future, this second poll should overwrite the fake waker with the real one.
+    // The only way to hit the fake waker's wake function is if the first poll calls wake.
+    // A more complex compat adapter will be needed to handle this case.
     let mut pin = Box::pin(fut);
     let poll = pin
         .as_mut()


### PR DESCRIPTION
This adds a deprecated `spawn` function where it was removed from in 0.17, which works like the old one most of the time but panics in complicated cases. To be replaced with a perfect solution in 0.19.