### PR TITLE
fix: Add executor edge case checks

### DIFF
--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -26,7 +26,7 @@ candid_parser.workspace = true
 cargo_metadata = "0.19"
 futures = "0.3"
 hex.workspace = true
-ic-vetkd-utils = { git = "https://github.com/dfinity/ic" }
+ic-vetkd-utils = { git = "https://github.com/dfinity/ic", rev = "95231520" }
 pocket-ic = { git = "https://github.com/dfinity/ic", tag = "release-2025-04-11_13-20-base" }
 reqwest = "0.12"
 

--- a/e2e-tests/tests/async.rs
+++ b/e2e-tests/tests/async.rs
@@ -44,14 +44,33 @@ fn panic_after_async_frees_resources() {
 }
 
 #[test]
-fn panic_after_async_destructors_can_schedule_tasks() {
+fn panic_after_async_destructors_cannot_schedule_tasks() {
     let pic = pic_base().build();
     let wasm = cargo_build_canister("async");
     let canister_id = pic.create_canister();
     pic.add_cycles(canister_id, 2_000_000_000_000);
     pic.install_canister(canister_id, wasm, vec![], None);
     let err = update::<_, ()>(&pic, canister_id, "schedule_on_panic", ()).unwrap_err();
+    assert!(err.reject_message.contains("recovery"));
+    let (pre_bg_notifs,): (u64,) =
+        query_candid(&pic, canister_id, "notifications_received", ()).unwrap();
+    assert_eq!(pre_bg_notifs, 1);
+    update::<_, ()>(&pic, canister_id, "on_notify", ()).unwrap();
+    let (post_bg_notifs,): (u64,) =
+        query_candid(&pic, canister_id, "notifications_received", ()).unwrap();
+    assert_eq!(post_bg_notifs, 2);
+}
+
+#[test]
+fn panic_after_async_destructors_can_schedule_timers() {
+    let pic = pic_base().build();
+    let wasm = cargo_build_canister("async");
+    let canister_id = pic.create_canister();
+    pic.add_cycles(canister_id, 2_000_000_000_000);
+    pic.install_canister(canister_id, wasm, vec![], None);
+    let err = update::<_, ()>(&pic, canister_id, "timer_on_panic", ()).unwrap_err();
     assert!(err.reject_message.contains("testing"));
+    assert!(!err.reject_message.contains("recovery"));
     let (pre_bg_notifs,): (u64,) =
         query_candid(&pic, canister_id, "notifications_received", ()).unwrap();
     assert_eq!(pre_bg_notifs, 1);

--- a/ic-cdk-executor/src/lib.rs
+++ b/ic-cdk-executor/src/lib.rs
@@ -15,7 +15,8 @@ pub fn spawn<F: 'static + Future<Output = ()>>(future: F) {
     let in_query = match CONTEXT.get() {
         AsyncContext::None => panic!("`spawn` can only be called from an executor context"),
         AsyncContext::Query => true,
-        AsyncContext::Update | AsyncContext::Cancel => false,
+        AsyncContext::Update => false,
+        AsyncContext::Cancel => panic!("`spawn` cannot be called during panic recovery"),
         AsyncContext::FromTask => unreachable!("FromTask"),
     };
     let pinned_future = Box::pin(future);


### PR DESCRIPTION
* Disallows calling `spawn` inside the cleanup handler
* Disallows calling `wake` outside an executor context