### PR TITLE
chore: bring back the canister_balance api and mark deprecated

### DIFF
--- a/ic-cdk/src/api.rs
+++ b/ic-cdk/src/api.rs
@@ -763,12 +763,25 @@ pub fn id() -> Principal {
 }
 
 /// Gets the amount of funds available in the canister.
+///
+/// # Panic
+///
+/// When the cycle balance is greater than `u64::MAX`, this function will panic.
+/// As this function is deprecated, it is recommended to use [`canister_cycle_balance`].
+#[deprecated(since = "0.18.0", note = "Use `canister_cycle_balance` instead")]
+pub fn canister_balance() -> u64 {
+    // ic0 no longer provides `ic0.canister_cycle_balance` which returns a u64,
+    // so we use the u128 version and convert it to u64.
+    // When the cycle balance is greater than `u64::MAX`, `ic0.canister_cycle_balance` also panics.
+    canister_cycle_balance()
+        .try_into()
+        .expect("the cycle balance is greater than u64::MAX, please use canister_cycle_balance which returns u128")
+}
+
+/// Gets the amount of funds available in the canister.
 #[deprecated(since = "0.18.0", note = "Use `canister_cycle_balance` instead")]
 pub fn canister_balance128() -> u128 {
-    let mut dst = 0u128;
-    // SAFETY: dst is writable and the size expected by ic0.canister_cycle_balance128.
-    unsafe { ic0::canister_cycle_balance128(&mut dst as *mut u128 as usize) }
-    dst
+    canister_cycle_balance()
 }
 
 /// Sets the certified data of this canister.


### PR DESCRIPTION
# Description

`api::canister_balance() -> u64` was removed during v0.18 development.
Such API deletion would cause compilation errors when migrate to the new ic-cdk version.

This PR brings it back and marks it deprecated. Then a deprecation warning will be shown and users can choose to use the replacement or just `#[allow(deprecated)]`.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
