### PR TITLE
chore: Release ic-cdk@0.18.5, ic0@1.0.0, ic-cdk-timers@0.12.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ lto = true
 opt-level = 'z'
 
 [workspace.dependencies]
-ic0 = { path = "ic0", version = "0.25.1" }
-ic-cdk = { path = "ic-cdk", version = "0.18.4" }
-ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.1" }
+ic0 = { path = "ic0", version = "1.0.0" }
+ic-cdk = { path = "ic-cdk", version = "0.18.5" }
+ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.2" }
 ic-cdk-executor = { path = "ic-cdk-executor", version = "1.0.0" }
 ic-management-canister-types = { path = "ic-management-canister-types", version = "0.3.1" }
 

--- a/ic-cdk-macros/Cargo.toml
+++ b/ic-cdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-macros"
-version = "0.18.4" # sync with ic-cdk
+version = "0.18.5" # sync with ic-cdk
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ic-cdk-timers/CHANGELOG.md
+++ b/ic-cdk-timers/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.12.2] - 2025-06-25
+
+- Upgrade `ic0` to v1.0.
+
 ## [0.12.1] - 2025-06-17
 
 - Upgrade `ic0` to v0.25.

--- a/ic-cdk-timers/Cargo.toml
+++ b/ic-cdk-timers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-timers"
-version = "0.12.1"
+version = "0.12.2"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ic-cdk/CHANGELOG.md
+++ b/ic-cdk/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.18.5] - 2025-06-25
+
+### Fixed
+
+- Tasks which return after canceling futures are no longer marked as trapped
+
+### Changed
+
+- Updated to `ic0` v1.0.0
+
 ## [0.18.4] - 2025-06-17
 
 ### Added

--- a/ic-cdk/Cargo.toml
+++ b/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.18.4" # sync with ic-cdk-macros and the doc comment in README.md
+version = "0.18.5" # sync with ic-cdk-macros and the doc comment in README.md
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -28,7 +28,7 @@ ic-cdk-executor.workspace = true
 # Dependents won't accidentaly upgrading ic-cdk-macros only but not ic-cdk.
 # ic-cdk-macros is a hidden dependency, re-exported by ic-cdk.
 # It should not be included by users direcly.
-ic-cdk-macros = { path = "../ic-cdk-macros", version = "=0.18.4" }
+ic-cdk-macros = { path = "../ic-cdk-macros", version = "=0.18.5" }
 ic-error-types = "0.2.0"
 ic-management-canister-types.workspace = true
 serde.workspace = true

--- a/ic0/CHANGELOG.md
+++ b/ic0/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [1.0.0] - 2025-06-25
 
 ### Changed
 

--- a/ic0/Cargo.toml
+++ b/ic0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic0"
-version = "0.25.1"
+version = "1.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Note that major ic0 updates are not major updates to ic-cdk-timers.