### PR TITLE
feat!: [DO NOT MERGE] non replicated http outcalls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,10 @@ opt-level = 'z'
 
 [workspace.dependencies]
 ic0 = { path = "ic0", version = "1.0.0" }
-ic-cdk = { path = "ic-cdk", version = "0.18.5" }
-ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.2" }
+ic-cdk = { path = "ic-cdk", version = "0.19.0-beta.1" }
+ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.1" }
 ic-cdk-executor = { path = "ic-cdk-executor", version = "1.0.0" }
-ic-management-canister-types = { path = "ic-management-canister-types", version = "0.3.1" }
+ic-management-canister-types = { path = "ic-management-canister-types", version = "0.4.0-beta.1" }
 
 candid = "0.10.13"      # sync with the doc comment in ic-cdk/README.md
 candid_parser = "0.1.4"

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -19,7 +19,7 @@ ic-cdk-timers.workspace = true
 lazy_static = "1.4.0"
 serde_bytes.workspace = true
 sha2.workspace = true
-prost = "0.13.5"
+prost = "0.14"
 
 [dev-dependencies]
 candid_parser.workspace = true
@@ -27,8 +27,8 @@ cargo_metadata = "0.19"
 futures = "0.3"
 hex.workspace = true
 ic-vetkd-utils = { git = "https://github.com/dfinity/ic", rev = "95231520" }
-pocket-ic = { git = "https://github.com/dfinity/ic", tag = "release-2025-05-30_03-21-base" }
+pocket-ic = { git = "https://github.com/dfinity/ic", tag = "release-2025-06-26_03-25-base" }
 reqwest = "0.12"
 
 [build-dependencies]
-prost-build = "0.13.5"
+prost-build = "0.14"

--- a/e2e-tests/src/bin/http_request.rs
+++ b/e2e-tests/src/bin/http_request.rs
@@ -17,6 +17,7 @@ async fn get_without_transform() {
         body: Some(vec![1]),
         max_response_bytes: Some(100_000),
         transform: None,
+        is_replicated: Some(true),
     };
 
     let res = http_request(&args).await.unwrap();

--- a/e2e-tests/src/bin/http_request.rs
+++ b/e2e-tests/src/bin/http_request.rs
@@ -32,6 +32,20 @@ async fn get_without_transform() {
     assert_eq!(res.body, vec![42]);
 }
 
+#[update]
+async fn is_replicated_false() {
+    let args = HttpRequestArgs {
+        url: "https://example.com".to_string(),
+        method: HttpMethod::GET,
+        is_replicated: Some(false),
+        ..Default::default()
+    };
+    // As of 2025-06-26, the Pocket IC does not support non-replicated HTTP requests.
+    // The following line is expected to panic with "Canister HTTP requests with is_replicated=false are not supported".
+    // Though panic, it proves that the `is_replicated` field has correct type and the IC can handle it.
+    http_request(&args).await.unwrap();
+}
+
 /// Method is POST.
 #[update]
 async fn post() {

--- a/e2e-tests/src/bin/management_canister.rs
+++ b/e2e-tests/src/bin/management_canister.rs
@@ -224,12 +224,12 @@ async fn provisional() {
         log_visibility: Some(LogVisibility::Controllers),
         ..Default::default()
     };
+    // Using NNS Root Canister ID as specified_id.
+    let specified_id = Principal::from_text("r7inp-6aaaa-aaaaa-aaabq-cai").unwrap();
     let arg = ProvisionalCreateCanisterWithCyclesArgs {
         amount: Some(10_000_000_000_000u64.into()),
         settings: Some(settings),
-        specified_id: Some(Principal::from_slice(&[
-            255, 255, 255, 255, 255, 209, 0, 0, 1, 1,
-        ])),
+        specified_id: Some(specified_id),
     };
     let canister_id = provisional_create_canister_with_cycles(&arg)
         .await

--- a/e2e-tests/src/bin/management_canister.rs
+++ b/e2e-tests/src/bin/management_canister.rs
@@ -224,8 +224,9 @@ async fn provisional() {
         log_visibility: Some(LogVisibility::Controllers),
         ..Default::default()
     };
-    // Using NNS Root Canister ID as specified_id.
-    let specified_id = Principal::from_text("r7inp-6aaaa-aaaaa-aaabq-cai").unwrap();
+    // Using Cycles Ledger (on the II subnet) Canister ID as specified_id.
+    // The test canister is deployed on the II subnet, it can provisional create a canister on the same subnet.
+    let specified_id = Principal::from_text("um5iw-rqaaa-aaaaq-qaaba-cai").unwrap();
     let arg = ProvisionalCreateCanisterWithCyclesArgs {
         amount: Some(10_000_000_000_000u64.into()),
         settings: Some(settings),

--- a/e2e-tests/tests/http_request.rs
+++ b/e2e-tests/tests/http_request.rs
@@ -6,7 +6,7 @@ use pocket_ic::common::rest::{
 use pocket_ic::PocketIc;
 
 mod test_utilities;
-use test_utilities::{cargo_build_canister, pic_base};
+use test_utilities::{cargo_build_canister, pic_base, update};
 
 #[test]
 fn test_http_request() {
@@ -22,6 +22,20 @@ fn test_http_request() {
     test_one_http_request(&pic, canister_id, "head");
     test_one_http_request(&pic, canister_id, "get_with_transform");
     test_one_http_request(&pic, canister_id, "get_with_transform_closure");
+}
+
+// Remove this test when Pocket IC supports non-replicated HTTP requests.
+#[test]
+fn test_http_request_is_replicated_false() {
+    let pic = pic_base().build();
+    let wasm = cargo_build_canister("http_request");
+    let canister_id = pic.create_canister();
+    pic.add_cycles(canister_id, 3_000_000_000_000u128);
+    pic.install_canister(canister_id, wasm, vec![], None);
+    let err = update::<(), ()>(&pic, canister_id, "is_replicated_false", ()).unwrap_err();
+    assert!(err
+        .reject_message
+        .contains("Canister HTTP requests with is_replicated=false are not supported"));
 }
 
 fn test_one_http_request(pic: &PocketIc, canister_id: Principal, method: &str) {

--- a/e2e-tests/tests/management_canister.rs
+++ b/e2e-tests/tests/management_canister.rs
@@ -9,14 +9,20 @@ fn test_management_canister() {
     let canister_id = pic.create_canister();
     let subnet_id = pic.get_subnet(canister_id).unwrap();
     pic.add_cycles(canister_id, 10_000_000_000_000u128); // 10 T
-    pic.install_canister(canister_id, wasm, vec![], None);
+    pic.install_canister(canister_id, wasm.clone(), vec![], None);
     let () = update(&pic, canister_id, "basic", ()).unwrap();
     let () = update(&pic, canister_id, "ecdsa", ()).unwrap();
     let () = update(&pic, canister_id, "schnorr", ()).unwrap();
     let () = update(&pic, canister_id, "metrics", (subnet_id,)).unwrap();
     let () = update(&pic, canister_id, "subnet", (subnet_id,)).unwrap();
-    let () = update(&pic, canister_id, "provisional", ()).unwrap();
     let () = update(&pic, canister_id, "snapshots", ()).unwrap();
+
+    // Install the test canister on the II subnet, so that it can provisional create canisters on the same subnet.
+    let ii_subnet_id = pic.topology().get_ii().unwrap();
+    let canister_id_on_ii = pic.create_canister_on_subnet(None, None, ii_subnet_id);
+    pic.add_cycles(canister_id_on_ii, 10_000_000_000_000u128); // 10 T
+    pic.install_canister(canister_id_on_ii, wasm, vec![], None);
+    let () = update(&pic, canister_id_on_ii, "provisional", ()).unwrap();
 }
 
 #[test]

--- a/ic-cdk-macros/Cargo.toml
+++ b/ic-cdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-macros"
-version = "0.18.5" # sync with ic-cdk
+version = "0.19.0-beta.1" # sync with ic-cdk
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ic-cdk/CHANGELOG.md
+++ b/ic-cdk/CHANGELOG.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.19.0-beta.1] - 2025-06-25
+
 ### Changed
 
-- [BREAKING] Upgrade `ic-management-canister-types` dependency to v0.4.0 which added `is_replicated` field to `HttpRequestArgs`.
+- [BREAKING] Upgrade `ic-management-canister-types` dependency to v0.4.0:
+  - Added `is_replicated` field to `HttpRequestArgs`.
 
 ## [0.18.5] - 2025-06-25
 

--- a/ic-cdk/CHANGELOG.md
+++ b/ic-cdk/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changed
+
+- [BREAKING] Upgrade `ic-management-canister-types` dependency to v0.4.0 which added `is_replicated` field to `HttpRequestArgs`.
+
 ## [0.18.5] - 2025-06-25
 
 ### Fixed

--- a/ic-cdk/Cargo.toml
+++ b/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.18.5" # sync with ic-cdk-macros and the doc comment in README.md
+version = "0.19.0-beta.1" # sync with ic-cdk-macros and the doc comment in README.md
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -28,7 +28,7 @@ ic-cdk-executor.workspace = true
 # Dependents won't accidentaly upgrading ic-cdk-macros only but not ic-cdk.
 # ic-cdk-macros is a hidden dependency, re-exported by ic-cdk.
 # It should not be included by users direcly.
-ic-cdk-macros = { path = "../ic-cdk-macros", version = "=0.18.5" }
+ic-cdk-macros = { path = "../ic-cdk-macros", version = "=0.19.0-beta.1" }
 ic-error-types = "0.2.0"
 ic-management-canister-types.workspace = true
 serde.workspace = true

--- a/ic-management-canister-types/CHANGELOG.md
+++ b/ic-management-canister-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.4.0-beta.1] - 2025-06-25
+
+### Changed
+
+- Added `is_replicated` field to `HttpRequestArgs`.
+
 ## [0.3.1] - 2025-05-09
 
 ### Added

--- a/ic-management-canister-types/Cargo.toml
+++ b/ic-management-canister-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-management-canister-types"
-version = "0.3.1"
+version = "0.4.0-beta.1"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/ic-management-canister-types/src/lib.rs
+++ b/ic-management-canister-types/src/lib.rs
@@ -706,6 +706,8 @@ pub struct HttpRequestArgs {
     pub body: Option<Vec<u8>>,
     /// Name of the transform function which is `func (transform_args) -> (http_response) query`.
     pub transform: Option<TransformContext>,
+    /// If `Some(false)`, the HTTP request will be made by single replica instead of all nodes in the subnet.
+    pub is_replicated: Option<bool>,
 }
 
 /// # HTTP Request Result

--- a/ic-management-canister-types/tests/ic.did
+++ b/ic-management-canister-types/tests/ic.did
@@ -301,6 +301,7 @@ type http_request_args = record {
         function : func(record { response : http_request_result; context : blob }) -> (http_request_result) query;
         context : blob;
     };
+    is_replicated : opt bool;
 };
 
 type ecdsa_public_key_args = record {

--- a/library/ic-ledger-types/CHANGELOG.md
+++ b/library/ic-ledger-types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.16.0-beta.1] - 2025-06-25
+
+### Changed
+
+- Upgrade `ic-cdk` to v0.19.0-beta.1.
+
 ## [0.15.0] - 2025-04-22
 
 ### Changed

--- a/library/ic-ledger-types/Cargo.toml
+++ b/library/ic-ledger-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-ledger-types"
-version = "0.15.0"
+version = "0.16.0-beta.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
DO NOT MERGE!

SDK-2191

# Description

This PR updates the `HttpRequestArgs` in `ic-management-canister-types` to support the upcoming "non-replicated HTTP outcalls" feature.

Since this change introduces a new field to an existing struct, it's technically a breaking change. Consequently, ic-cdk, which re-exports this type, will also require a major version bump.

To facilitate early adoption and testing by developers, ic-cdk v0.19.0-beta.1 is released.

# How Has This Been Tested?

`pocket-ic` is upgraded to tag `release-2025-06-26_03-25-base`. The added `test_http_request_is_replicated_false` verified that the new field is correctly recognized by the system and triggered the "not support" error as expected.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
