### PR TITLE
feat: added types for canister snapshot download/upload.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ ic0 = { path = "ic0", version = "1.0.0" }
 ic-cdk = { path = "ic-cdk", version = "0.18.5" }
 ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.2" }
 ic-cdk-executor = { path = "ic-cdk-executor", version = "1.0.1" }
-ic-management-canister-types = { path = "ic-management-canister-types", version = "0.3.2-beta.1" }
+ic-management-canister-types = { path = "ic-management-canister-types", version = "0.3.2" }
 
 candid = "0.10.13"      # sync with the doc comment in ic-cdk/README.md
 candid_parser = "0.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ ic0 = { path = "ic0", version = "1.0.0" }
 ic-cdk = { path = "ic-cdk", version = "0.18.5" }
 ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.2" }
 ic-cdk-executor = { path = "ic-cdk-executor", version = "1.0.1" }
-ic-management-canister-types = { path = "ic-management-canister-types", version = "0.3.1" }
+ic-management-canister-types = { path = "ic-management-canister-types", version = "0.3.2-beta.1" }
 
 candid = "0.10.13"      # sync with the doc comment in ic-cdk/README.md
 candid_parser = "0.1.4"

--- a/ic-management-canister-types/CHANGELOG.md
+++ b/ic-management-canister-types/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-## [0.3.2-beta.1] - 2025-07-24
+## [0.3.2] - 2025-07-25
 
 ### Added
 - Types for canister snapshot download/upload.

--- a/ic-management-canister-types/CHANGELOG.md
+++ b/ic-management-canister-types/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.3.2-beta.1] - 2025-07-24
+
 ### Added
 - Types for canister snapshot download/upload.
 

--- a/ic-management-canister-types/CHANGELOG.md
+++ b/ic-management-canister-types/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+- Types for canister snapshot download/upload.
+
 ## [0.3.1] - 2025-05-09
 
 ### Added

--- a/ic-management-canister-types/Cargo.toml
+++ b/ic-management-canister-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-management-canister-types"
-version = "0.3.1"
+version = "0.3.2-beta.1"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/ic-management-canister-types/Cargo.toml
+++ b/ic-management-canister-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-management-canister-types"
-version = "0.3.2-beta.1"
+version = "0.3.2"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/ic-management-canister-types/src/lib.rs
+++ b/ic-management-canister-types/src/lib.rs
@@ -1319,6 +1319,168 @@ pub struct DeleteCanisterSnapshotArgs {
     pub snapshot_id: SnapshotId,
 }
 
+/// # The source of a snapshot.
+#[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
+pub enum SnapshotSource {
+    /// The snapshot was taken from a canister.
+    #[serde(rename = "taken_from_canister")]
+    TakenFromCanister,
+    /// The snapshot was created by uploading metadata.
+    #[serde(rename = "metadata_upload")]
+    MetadataUpload,
+}
+
+/// # An exported global variable.
+#[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
+pub enum ExportedGlobal {
+    /// A 32-bit integer.
+    #[serde(rename = "i32")]
+    I32(i32),
+    /// A 64-bit integer.
+    #[serde(rename = "i64")]
+    I64(i64),
+    /// A 32-bit floating point number.
+    #[serde(rename = "f32")]
+    F32(f32),
+    /// A 64-bit floating point number.
+    #[serde(rename = "f64")]
+    F64(f64),
+    /// A 128-bit integer.
+    #[serde(rename = "v128")]
+    V128(Nat),
+}
+
+/// # The status of a global timer.
+#[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
+pub enum CanisterTimer {
+    /// The global timer is inactive.
+    #[serde(rename = "inactive")]
+    Inactive,
+    /// The global timer is active.
+    #[serde(rename = "active")]
+    Active(u64),
+}
+
+/// # The status of a low wasm memory hook.
+#[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
+pub enum OnLowWasmMemoryHookStatus {
+    /// The condition for the  low wasm memory hook is not satisfied.
+    #[serde(rename = "condition_not_satisfied")]
+    ConditionNotSatisfied,
+    /// The low wasm memory hook is ready to be executed.
+    #[serde(rename = "ready")]
+    Ready,
+    /// The low wasm memory hook has been executed.
+    #[serde(rename = "executed")]
+    Executed,
+}
+
+/// # Canister snapshot metadata.
+#[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
+pub struct SnapshotMetadata {
+    /// The source of the snapshot.
+    pub source: SnapshotSource,
+    /// The Unix nanosecond timestamp the snapshot was taken at.
+    pub taken_at_timestamp: u64,
+    /// The size of the Wasm module.
+    pub wasm_module_size: u64,
+    /// The exported globals.
+    pub exported_globals: Vec<ExportedGlobal>,
+    /// The size of the Wasm memory.
+    pub wasm_memory_size: u64,
+    /// The size of the stable memory.
+    pub stable_memory_size: u64,
+    /// The chunk store of the Wasm module.
+    pub wasm_chunk_store: StoredChunksResult,
+    /// The version of the canister.
+    pub canister_version: u64,
+    /// The certified data.
+    #[serde(with = "serde_bytes")]
+    pub certified_data: Vec<u8>,
+    /// The status of the global timer.
+    pub global_timer: Option<CanisterTimer>,
+    /// The status of the low wasm memory hook.
+    pub on_low_wasm_memory_hook_status: Option<OnLowWasmMemoryHookStatus>,
+}
+
+/// # Snapshot data kind.
+#[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
+pub enum SnapshotDataKind {
+    /// Wasm module.
+    #[serde(rename = "wasm_module")]
+    WasmModule {
+        /// Offset in bytes.
+        offset: u64,
+        /// Size of the data in bytes.
+        size: u64,
+    },
+    /// Main memory.
+    #[serde(rename = "main_memory")]
+    MainMemory {
+        /// Offset in bytes.
+        offset: u64,
+        /// Size of the data in bytes.
+        size: u64,
+    },
+    /// Stable memory.
+    #[serde(rename = "stable_memory")]
+    StableMemory {
+        /// Offset in bytes.
+        offset: u64,
+        /// Size of the data in bytes.
+        size: u64,
+    },
+    /// Chunk hash.
+    #[serde(rename = "wasm_chunk")]
+    WasmChunk {
+        /// The hash of the chunk.
+        #[serde(with = "serde_bytes")]
+        hash: Vec<u8>,
+    },
+}
+
+/// # Snapshot reading result.
+#[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
+pub struct SnapshotDataResult {
+    /// The returned chunk of data.
+    #[serde(with = "serde_bytes")]
+    pub chunk: Vec<u8>,
+}
+
+/// # The ID of a snapshot.
+#[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
+pub struct CanisterSnapshotId {
+    /// The ID of the snapshot.
+    #[serde(with = "serde_bytes")]
+    pub snapshot_id: Vec<u8>,
+}
+
+/// # Snapshot data offset.
+#[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
+pub enum SnapshotDataOffset {
+    /// Wasm module.
+    #[serde(rename = "wasm_module")]
+    WasmModule {
+        /// Offset in bytes.
+        offset: u64,
+    },
+    /// Main memory.
+    #[serde(rename = "main_memory")]
+    MainMemory {
+        /// Offset in bytes.
+        offset: u64,
+    },
+    /// Stable memory.
+    #[serde(rename = "stable_memory")]
+    StableMemory {
+        /// Offset in bytes.
+        offset: u64,
+    },
+    /// Wasm chunk.
+    #[serde(rename = "wasm_chunk")]
+    WasmChunk,
+}
+
 /// # Fetch Canister Logs Args.
 ///
 /// Argument type of [`fetch_canister_logs`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-fetch_canister_logs).
@@ -1331,8 +1493,12 @@ pub type FetchCanisterLogsArgs = CanisterIdRecord;
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
 pub struct CanisterLogRecord {
+    /// The index of the log record.
     pub idx: u64,
+    /// The timestamp of the log record.
     pub timestamp_nanos: u64,
+    /// The content of the log record.
+    #[serde(with = "serde_bytes")]
     pub content: Vec<u8>,
 }
 
@@ -1343,5 +1509,6 @@ pub struct CanisterLogRecord {
     CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
 )]
 pub struct FetchCanisterLogsResult {
+    /// The logs of the canister.
     pub canister_log_records: Vec<CanisterLogRecord>,
 }

--- a/ic-management-canister-types/src/lib.rs
+++ b/ic-management-canister-types/src/lib.rs
@@ -1508,6 +1508,8 @@ pub struct UploadCanisterSnapshotDataArgs {
     pub snapshot_id: SnapshotId,
     /// The kind of data to be read.
     pub kind: SnapshotDataOffset,
+    /// The chunk of data to be uploaded.
+    pub chunk: Vec<u8>,
 }
 
 /// # Snapshot data offset.

--- a/ic-management-canister-types/src/lib.rs
+++ b/ic-management-canister-types/src/lib.rs
@@ -1319,6 +1319,43 @@ pub struct DeleteCanisterSnapshotArgs {
     pub snapshot_id: SnapshotId,
 }
 
+/// # Read Canister Snapshot Metadata Args.
+#[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
+pub struct ReadCanisterSnapshotMetadataArgs {
+    /// Canister ID.
+    pub canister_id: CanisterId,
+    /// ID of the snapshot to be read.
+    pub snapshot_id: SnapshotId,
+}
+
+/// # Read Canister Snapshot Metadata Result.
+#[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
+pub struct ReadCanisterSnapshotMetadataResult {
+    /// The source of the snapshot.
+    pub source: SnapshotSource,
+    /// The Unix nanosecond timestamp the snapshot was taken at.
+    pub taken_at_timestamp: u64,
+    /// The size of the Wasm module.
+    pub wasm_module_size: u64,
+    /// The exported globals.
+    pub exported_globals: Vec<ExportedGlobal>,
+    /// The size of the Wasm memory.
+    pub wasm_memory_size: u64,
+    /// The size of the stable memory.
+    pub stable_memory_size: u64,
+    /// The chunk store of the Wasm module.
+    pub wasm_chunk_store: StoredChunksResult,
+    /// The version of the canister.
+    pub canister_version: u64,
+    /// The certified data.
+    #[serde(with = "serde_bytes")]
+    pub certified_data: Vec<u8>,
+    /// The status of the global timer.
+    pub global_timer: Option<CanisterTimer>,
+    /// The status of the low wasm memory hook.
+    pub on_low_wasm_memory_hook_status: Option<OnLowWasmMemoryHookStatus>,
+}
+
 /// # The source of a snapshot.
 #[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
 pub enum SnapshotSource {
@@ -1375,32 +1412,15 @@ pub enum OnLowWasmMemoryHookStatus {
     Executed,
 }
 
-/// # Canister snapshot metadata.
+/// # Read Canister Snapshot Data Args.
 #[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
-pub struct SnapshotMetadata {
-    /// The source of the snapshot.
-    pub source: SnapshotSource,
-    /// The Unix nanosecond timestamp the snapshot was taken at.
-    pub taken_at_timestamp: u64,
-    /// The size of the Wasm module.
-    pub wasm_module_size: u64,
-    /// The exported globals.
-    pub exported_globals: Vec<ExportedGlobal>,
-    /// The size of the Wasm memory.
-    pub wasm_memory_size: u64,
-    /// The size of the stable memory.
-    pub stable_memory_size: u64,
-    /// The chunk store of the Wasm module.
-    pub wasm_chunk_store: StoredChunksResult,
-    /// The version of the canister.
-    pub canister_version: u64,
-    /// The certified data.
-    #[serde(with = "serde_bytes")]
-    pub certified_data: Vec<u8>,
-    /// The status of the global timer.
-    pub global_timer: Option<CanisterTimer>,
-    /// The status of the low wasm memory hook.
-    pub on_low_wasm_memory_hook_status: Option<OnLowWasmMemoryHookStatus>,
+pub struct ReadCanisterSnapshotDataArgs {
+    /// Canister ID.
+    pub canister_id: CanisterId,
+    /// ID of the snapshot to be read.
+    pub snapshot_id: SnapshotId,
+    /// The kind of data to be read.
+    pub kind: SnapshotDataKind,
 }
 
 /// # Snapshot data kind.
@@ -1441,18 +1461,53 @@ pub enum SnapshotDataKind {
 
 /// # Snapshot reading result.
 #[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
-pub struct SnapshotDataResult {
+pub struct ReadCanisterSnapshotDataResult {
     /// The returned chunk of data.
     #[serde(with = "serde_bytes")]
     pub chunk: Vec<u8>,
 }
 
-/// # The ID of a snapshot.
+/// # Upload Canister Snapshot Metadata Args.
 #[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
-pub struct CanisterSnapshotId {
+pub struct UploadCanisterSnapshotMetadataArgs {
+    /// Canister ID.
+    pub canister_id: CanisterId,
+    /// An optional snapshot ID to be replaced by the new snapshot.
+    ///
+    /// The snapshot identified by the specified ID will be deleted once a new snapshot has been successfully created.
+    pub replace_snapshot: Option<SnapshotId>,
+    /// The size of the Wasm module.
+    pub wasm_module_size: u64,
+    /// The exported globals.
+    pub exported_globals: Vec<ExportedGlobal>,
+    /// The size of the Wasm memory.
+    pub wasm_memory_size: u64,
+    /// The size of the stable memory.
+    pub stable_memory_size: u64,
+    /// The certified data.
+    pub certified_data: Vec<u8>,
+    /// The status of the global timer.
+    pub global_timer: Option<CanisterTimer>,
+    /// The status of the low wasm memory hook.
+    pub on_low_wasm_memory_hook_status: Option<OnLowWasmMemoryHookStatus>,
+}
+
+/// # Upload Canister Snapshot Metadata Result.
+#[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
+pub struct UploadCanisterSnapshotMetadataResult {
     /// The ID of the snapshot.
-    #[serde(with = "serde_bytes")]
-    pub snapshot_id: Vec<u8>,
+    pub snapshot_id: SnapshotId,
+}
+
+/// # Upload Canister Snapshot Data Args.
+#[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
+pub struct UploadCanisterSnapshotDataArgs {
+    /// Canister ID.
+    pub canister_id: CanisterId,
+    /// ID of the snapshot to be read.
+    pub snapshot_id: SnapshotId,
+    /// The kind of data to be read.
+    pub kind: SnapshotDataOffset,
 }
 
 /// # Snapshot data offset.

--- a/ic-management-canister-types/src/lib.rs
+++ b/ic-management-canister-types/src/lib.rs
@@ -1459,7 +1459,7 @@ pub enum SnapshotDataKind {
     },
 }
 
-/// # Snapshot reading result.
+/// # Read Canister Snapshot Data Result.
 #[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
 pub struct ReadCanisterSnapshotDataResult {
     /// The returned chunk of data.

--- a/ic-management-canister-types/tests/candid_equality.rs
+++ b/ic-management-canister-types/tests/candid_equality.rs
@@ -145,7 +145,9 @@ fn delete_canister_snapshot(_: DeleteCanisterSnapshotArgs) {
 }
 
 #[candid_method(update)]
-fn read_canister_snapshot_metadata(_: ReadCanisterSnapshotMetadataArgs) -> ReadCanisterSnapshotMetadataResult {
+fn read_canister_snapshot_metadata(
+    _: ReadCanisterSnapshotMetadataArgs,
+) -> ReadCanisterSnapshotMetadataResult {
     unimplemented!()
 }
 
@@ -155,7 +157,9 @@ fn read_canister_snapshot_data(_: ReadCanisterSnapshotDataArgs) -> ReadCanisterS
 }
 
 #[candid_method(update)]
-fn upload_canister_snapshot_metadata(_: UploadCanisterSnapshotMetadataArgs) -> UploadCanisterSnapshotMetadataResult {
+fn upload_canister_snapshot_metadata(
+    _: UploadCanisterSnapshotMetadataArgs,
+) -> UploadCanisterSnapshotMetadataResult {
     unimplemented!()
 }
 

--- a/ic-management-canister-types/tests/candid_equality.rs
+++ b/ic-management-canister-types/tests/candid_equality.rs
@@ -144,6 +144,26 @@ fn delete_canister_snapshot(_: DeleteCanisterSnapshotArgs) {
     unimplemented!()
 }
 
+#[candid_method(update)]
+fn read_canister_snapshot_metadata(_: ReadCanisterSnapshotMetadataArgs) -> ReadCanisterSnapshotMetadataResult {
+    unimplemented!()
+}
+
+#[candid_method(update)]
+fn read_canister_snapshot_data(_: ReadCanisterSnapshotDataArgs) -> ReadCanisterSnapshotDataResult {
+    unimplemented!()
+}
+
+#[candid_method(update)]
+fn upload_canister_snapshot_metadata(_: UploadCanisterSnapshotMetadataArgs) -> UploadCanisterSnapshotMetadataResult {
+    unimplemented!()
+}
+
+#[candid_method(update)]
+fn upload_canister_snapshot_data(_: UploadCanisterSnapshotDataArgs) {
+    unimplemented!()
+}
+
 #[candid_method(query)]
 fn fetch_canister_logs(_: FetchCanisterLogsArgs) -> FetchCanisterLogsResult {
     unimplemented!()

--- a/ic-management-canister-types/tests/ic.did
+++ b/ic-management-canister-types/tests/ic.did
@@ -422,6 +422,116 @@ type delete_canister_snapshot_args = record {
     snapshot_id : snapshot_id;
 };
 
+type read_canister_snapshot_metadata_args = record {
+    canister_id : canister_id;
+    snapshot_id : snapshot_id;
+};
+
+type read_canister_snapshot_metadata_result = record {
+    source : variant {
+        taken_from_canister;
+        metadata_upload;
+    };
+    taken_at_timestamp : nat64;
+    wasm_module_size : nat64;
+    exported_globals : vec variant {
+        i32 : int32;
+        i64 : int64;
+        f32 : float32;
+        f64 : float64;
+        v128 : nat;
+    };
+    wasm_memory_size : nat64;
+    stable_memory_size : nat64;
+    wasm_chunk_store : vec record {
+        hash : blob;
+    };
+    canister_version : nat64;
+    certified_data : blob;
+    global_timer : opt variant {
+        inactive;
+        active : nat64;
+    };
+    on_low_wasm_memory_hook_status : opt variant {
+        condition_not_satisfied;
+        ready;
+        executed;
+    };
+};
+
+type read_canister_snapshot_data_args = record {
+    canister_id : canister_id;
+    snapshot_id : snapshot_id;
+    kind : variant {
+        wasm_module : record {
+            offset : nat64;
+            size : nat64;
+        };
+        main_memory : record {
+            offset : nat64;
+            size : nat64;
+        };
+        stable_memory : record {
+            offset : nat64;
+            size : nat64;
+        };
+        wasm_chunk : record {
+            hash : blob;
+        };
+    };
+};
+
+type read_canister_snapshot_data_result = record {
+    chunk : blob;
+};
+
+type upload_canister_snapshot_metadata_args = record {
+    canister_id : canister_id;
+    replace_snapshot : opt snapshot_id;
+    wasm_module_size : nat64;
+    exported_globals : vec variant {
+        i32 : int32;
+        i64 : int64;
+        f32 : float32;
+        f64 : float64;
+        v128 : nat;
+    };
+    wasm_memory_size : nat64;
+    stable_memory_size : nat64;
+    certified_data : blob;
+    global_timer : opt variant {
+        inactive;
+        active : nat64;
+    };
+    on_low_wasm_memory_hook_status : opt variant {
+        condition_not_satisfied;
+        ready;
+        executed;
+    };
+};
+
+type upload_canister_snapshot_metadata_result = record {
+    snapshot_id : snapshot_id;
+};
+
+type upload_canister_snapshot_data_args = record {
+    canister_id : canister_id;
+    snapshot_id : snapshot_id;
+    kind : variant {
+        wasm_module : record {
+            offset : nat64;
+        };
+        main_memory : record {
+            offset : nat64;
+        };
+        stable_memory : record {
+            offset : nat64;
+        };
+        wasm_chunk;
+    };
+    chunk : blob;
+};
+
 type fetch_canister_logs_args = record {
     canister_id : canister_id;
 };
@@ -484,6 +594,10 @@ service ic : {
     load_canister_snapshot : (load_canister_snapshot_args) -> ();
     list_canister_snapshots : (list_canister_snapshots_args) -> (list_canister_snapshots_result);
     delete_canister_snapshot : (delete_canister_snapshot_args) -> ();
+    read_canister_snapshot_metadata : (read_canister_snapshot_metadata_args) -> (read_canister_snapshot_metadata_result);
+    read_canister_snapshot_data : (read_canister_snapshot_data_args) -> (read_canister_snapshot_data_result);
+    upload_canister_snapshot_metadata : (upload_canister_snapshot_metadata_args) -> (upload_canister_snapshot_metadata_result);
+    upload_canister_snapshot_data : (upload_canister_snapshot_data_args) -> ();
 
     // canister logging
     fetch_canister_logs : (fetch_canister_logs_args) -> (fetch_canister_logs_result) query;


### PR DESCRIPTION
# Description

Follow-up pr to https://github.com/dfinity/cdk-rs/pull/639. 

Moved the canister snapshot related types from ic-utils to ic-management-canister-types, please refer to [PR](https://github.com/dfinity/agent-rs/pull/654) on the agent-rs side.

Fixes # (issue)

[SDK-2237](https://dfinity.atlassian.net/browse/SDK-2237)

# How Has This Been Tested?

Extended the candid_equality test to cover the new methods and types.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.


[SDK-2237]: https://dfinity.atlassian.net/browse/SDK-2237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ