### PR TITLE
chore: bump MSRV to 1.78.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.75.0 # MSRV, should sync with `rust-toolchain` in `Cargo.toml`
+          toolchain: 1.78.0 # MSRV, should sync with `rust-toolchain` in `Cargo.toml`
           target: wasm32-unknown-unknown
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ repository = "https://github.com/dfinity/cdk-rs"
 # MSRV
 # Avoid updating this field unless we use new Rust features.
 # Sync with the `toolchain` field when setting up Rust toolchain in ci.yml msrv job.
-rust-version = "1.75.0"
+rust-version = "1.78.0"
 license = "Apache-2.0"
 
 [profile.canister-release]


### PR DESCRIPTION
# Description

MSRV Bump: 1.75.0 -> 1.78.0

This PR updates our Minimum Supported Rust Version (MSRV) to 1.78.0 to align with the recent `candid` and `candid_derive` releases.

We have chosen not to treat an MSRV upgrade as a breaking change. While it requires developers to update their Rust toolchain, it does not change our public API.

We will continue to keep our MSRV at least a few minor versions behind the latest stable release to avoid forcing our users to upgrade their toolchain too frequently.

# How Has This Been Tested?

CI

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
