### PR TITLE
feat: set default skipping quota

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.2" }
 ic-cdk-executor = { path = "ic-cdk-executor", version = "1.0.2" }
 ic-management-canister-types = { path = "ic-management-canister-types", version = "0.3.2" }
 
-candid = "0.10.13"      # sync with the doc comment in ic-cdk/README.md
+candid = "0.10.17"      # sync with the doc comment in ic-cdk/README.md
 candid_parser = "0.1.4"
 futures = "0.3"
 hex = "0.4"

--- a/e2e-tests/src/bin/macros/main.rs
+++ b/e2e-tests/src/bin/macros/main.rs
@@ -139,6 +139,12 @@ fn guard2() -> Result<(), String> {
     }
 }
 
+// This method will be called with "malicious" payloads.
+// We expected that a default skipping_quota (10_000) is set in the update/query macros.
+// This will trigger a decoding error when the payload exceeds the quota.
+#[update]
+fn default_skipping_quota(_arg: Option<u32>) {}
+
 export_candid! {}
 
 fn main() {
@@ -165,6 +171,7 @@ mod tests {
             generic : (blob) -> (blob);
             manual_reply : () -> (nat32);
             with_guards : () -> ();
+            default_skipping_quota : (opt nat32) -> ();
           }";
         let expected_candid = CandidSource::Text(expected);
 

--- a/e2e-tests/tests/macros.rs
+++ b/e2e-tests/tests/macros.rs
@@ -75,4 +75,27 @@ fn call_macros() {
     let _res = pic
         .update_call(canister_id, sender, "with_guards", vec![15])
         .unwrap();
+
+    // The entry-point expects an `opt nat32` value.
+    // Here we send some blob that decoder need to skip.
+    // The call is expected to:
+    // * succeed: when the blob is relatively small
+    // * fail: when the blob is too large
+    let _: () = update(
+        &pic,
+        canister_id,
+        "default_skipping_quota",
+        (vec![42; 1400],),
+    )
+    .unwrap();
+    let res: Result<(), _> = update(
+        &pic,
+        canister_id,
+        "default_skipping_quota",
+        (vec![42; 1500],),
+    );
+    assert!(res
+        .unwrap_err()
+        .reject_message
+        .contains("Skipping cost exceeds the limit"));
 }

--- a/ic-cdk-macros/src/export.rs
+++ b/ic-cdk-macros/src/export.rs
@@ -251,7 +251,9 @@ fn dfn_macro(
     } else {
         quote! {
             let arg_bytes = ::ic_cdk::api::msg_arg_data();
-            let ( #( #arg_tuple, )* ) = ::candid::utils::decode_args(&arg_bytes).unwrap();
+            let mut decoder_config = ::candid::DecoderConfig::new();
+            decoder_config.set_skipping_quota(10000);
+            let ( #( #arg_tuple, )* ) = ::candid::utils::decode_args_with_config(&arg_bytes, &decoder_config).unwrap();
         }
     };
 
@@ -570,7 +572,9 @@ mod test {
             fn #fn_name() {
                 ::ic_cdk::futures::in_query_executor_context(|| {
                     let arg_bytes = ::ic_cdk::api::msg_arg_data();
-                    let (a,) = ::candid::utils::decode_args(&arg_bytes).unwrap();
+                    let mut decoder_config = ::candid::DecoderConfig::new();
+                    decoder_config.set_skipping_quota(10000);
+                    let (a,) = ::candid::utils::decode_args_with_config(&arg_bytes, &decoder_config).unwrap();
                     let result = query(a);
                     let bytes: Vec<u8> = ::candid::utils::encode_one(()).unwrap();
                     ::ic_cdk::api::msg_reply(bytes);
@@ -607,7 +611,9 @@ mod test {
             fn #fn_name() {
                 ::ic_cdk::futures::in_query_executor_context(|| {
                     let arg_bytes = ::ic_cdk::api::msg_arg_data();
-                    let (a, b,) = ::candid::utils::decode_args(&arg_bytes).unwrap();
+                    let mut decoder_config = ::candid::DecoderConfig::new();
+                    decoder_config.set_skipping_quota(10000);
+                    let (a, b,) = ::candid::utils::decode_args_with_config(&arg_bytes, &decoder_config).unwrap();
                     let result = query(a, b);
                     let bytes: Vec<u8> = ::candid::utils::encode_one(()).unwrap();
                     ::ic_cdk::api::msg_reply(bytes);
@@ -644,7 +650,9 @@ mod test {
             fn #fn_name() {
                 ::ic_cdk::futures::in_query_executor_context(|| {
                     let arg_bytes = ::ic_cdk::api::msg_arg_data();
-                    let (a, b,) = ::candid::utils::decode_args(&arg_bytes).unwrap();
+                    let mut decoder_config = ::candid::DecoderConfig::new();
+                    decoder_config.set_skipping_quota(10000);
+                    let (a, b,) = ::candid::utils::decode_args_with_config(&arg_bytes, &decoder_config).unwrap();
                     let result = query(a, b);
                     let bytes: Vec<u8> = ::candid::utils::encode_one(result).unwrap();
                     ::ic_cdk::api::msg_reply(bytes);

--- a/ic-cdk/CHANGELOG.md
+++ b/ic-cdk/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+- Restored the default `skipping_quota` to match the behavior of previous versions of the macros.
+
 ### Fixed
 
 - The macros now support 2024 edition.


### PR DESCRIPTION
# Description

The `skipping_quota` macro option was removed in `ic-cdk` v0.18.
A default 10_000 `skipping_quota` was set in the macros. See [here](https://github.com/dfinity/cdk-rs/commit/bbd63393f40c5af4abbfbcc4592c39735a168e8f#diff-512c30fae8883899d66bca2b49ddc68da3a167d3329eabad931e7603ed2269f3R65-R68).

Canisters migrating from v0.17 to v0.18 would silently lost the protection against DoS attack.
This PR brings back the default `skipping_quota`. 

There should be no public `ic-cdk` API that directly exposes configuration of  `skipping_quota` or `DecoderConfig`.
Users will need to use `#[update(decode_with = "...")]` if they need any customized decoding.

# How Has This Been Tested?

Added `default_skipping_quota` in the `macros` e2e test.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
