### PR TITLE
feat!: non replicated http outcalls

### DIFF
--- a/e2e-tests/src/bin/http_request.rs
+++ b/e2e-tests/src/bin/http_request.rs
@@ -17,6 +17,7 @@ async fn get_without_transform() {
         body: Some(vec![1]),
         max_response_bytes: Some(100_000),
         transform: None,
+        is_replicated: Some(true),
     };
 
     let res = http_request(&args).await.unwrap();
@@ -124,6 +125,19 @@ async fn get_with_transform_closure() {
     );
     // The first 42 is from the response body, the second 42 is from the transform closure.
     assert_eq!(res.body, vec![42, 42]);
+}
+
+/// Non replicated HTTP request.
+#[update]
+async fn non_replicated() {
+    let args = HttpRequestArgs {
+        url: "https://example.com".to_string(),
+        method: HttpMethod::GET,
+        is_replicated: Some(false),
+        ..Default::default()
+    };
+
+    http_request(&args).await.unwrap();
 }
 
 fn main() {}

--- a/e2e-tests/tests/http_request.rs
+++ b/e2e-tests/tests/http_request.rs
@@ -22,6 +22,7 @@ fn test_http_request() {
     test_one_http_request(&pic, canister_id, "head");
     test_one_http_request(&pic, canister_id, "get_with_transform");
     test_one_http_request(&pic, canister_id, "get_with_transform_closure");
+    test_one_http_request(&pic, canister_id, "non_replicated");
 }
 
 fn test_one_http_request(pic: &PocketIc, canister_id: Principal, method: &str) {

--- a/ic-management-canister-types/CHANGELOG.md
+++ b/ic-management-canister-types/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added the type `EnvironmentVariable`.
 - Added `settings_change` variant to `ChangeDetails`.
 - Added `environment_variables_hash` field to `CreationRecord`.
+- Added `is_replicated` field to `HttpRequestArgs`.
 
 ## [0.3.3] - 2025-08-20
 

--- a/ic-management-canister-types/src/lib.rs
+++ b/ic-management-canister-types/src/lib.rs
@@ -750,6 +750,8 @@ pub struct HttpRequestArgs {
     pub body: Option<Vec<u8>>,
     /// Name of the transform function which is `func (transform_args) -> (http_response) query`.
     pub transform: Option<TransformContext>,
+    /// If `Some(false)`, the HTTP request will be made by single replica instead of all nodes in the subnet.
+    pub is_replicated: Option<bool>,
 }
 
 /// # HTTP Request Result

--- a/ic-management-canister-types/tests/ic.did
+++ b/ic-management-canister-types/tests/ic.did
@@ -314,6 +314,7 @@ type http_request_args = record {
         function : func(record { response : http_request_result; context : blob }) -> (http_request_result) query;
         context : blob;
     };
+    is_replicated : opt bool;
 };
 
 type ecdsa_public_key_args = record {


### PR DESCRIPTION
# Description

The "non replicated http outcalls" has been enabled on the mainnet.

This PR updates the `HttpRequestArgs` in `ic-management-canister-types` to support the feature.

Since this change introduces a new field to an existing struct, it's technically a breaking change. Consequently, ic-cdk, which re-exports this type, will also require a major version bump.

# How Has This Been Tested?

Added `non_replicated` in http_request.rs e2e test.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
