### PR TITLE
chore: release ic-management-canister-types v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ ic0 = { path = "ic0", version = "1.0.0" }
 ic-cdk = { path = "ic-cdk", version = "0.18.7" }
 ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.2" }
 ic-cdk-executor = { path = "ic-cdk-executor", version = "1.0.2" }
-ic-management-canister-types = { path = "ic-management-canister-types", version = "0.3.3" }
+ic-management-canister-types = { path = "ic-management-canister-types", version = "0.4.0" }
 
 candid = "0.10.17"      # sync with the doc comment in ic-cdk/README.md
 candid_parser = "0.1.4"

--- a/ic-cdk/CHANGELOG.md
+++ b/ic-cdk/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [BREAKING] Upgrade `ic-management-canister-types` which contains the changes for Canister Environment Variable.
+- [BREAKING] Upgrade `ic-management-canister-types` which contains the changes for:
+  - Canister Environment Variable.
+  - Non-replicated HTTP outcalls.
 
 ## [0.18.7] - 2025-08-20
 

--- a/ic-management-canister-types/CHANGELOG.md
+++ b/ic-management-canister-types/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.4.0] - 2025-08-25
+
 ### Changed
 
 - Added `environment_variable` field to `CanisterSettings` and `DefiniteCanisterSettings`.

--- a/ic-management-canister-types/Cargo.toml
+++ b/ic-management-canister-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-management-canister-types"
-version = "0.3.3"
+version = "0.4.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
# Description

We now release `ic-management-canister-types` v0.4.0 so that downstream projects can start supporting the IC environment variables.

`ic-cdk` is NOT released together in this PR.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
