### PR TITLE
fix: updated `SnapshotSource` and release ic-management-canister-types 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.2" }
 ic-cdk-executor = { path = "ic-cdk-executor", version = "1.0.2" }
 ic-management-canister-types = { path = "ic-management-canister-types", version = "0.4.0" }
 
-candid = "0.10.17"      # sync with the doc comment in ic-cdk/README.md
+candid = "0.10.18"      # sync with the doc comment in ic-cdk/README.md
 candid_parser = "0.1.4"
 futures = "0.3"
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ ic0 = { path = "ic0", version = "1.0.0" }
 ic-cdk = { path = "ic-cdk", version = "0.18.7" }
 ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.2" }
 ic-cdk-executor = { path = "ic-cdk-executor", version = "1.0.2" }
-ic-management-canister-types = { path = "ic-management-canister-types", version = "0.4.0" }
+ic-management-canister-types = { path = "ic-management-canister-types", version = "0.4.1" }
 
 candid = "0.10.18"      # sync with the doc comment in ic-cdk/README.md
 candid_parser = "0.1.4"

--- a/ic-management-canister-types/CHANGELOG.md
+++ b/ic-management-canister-types/CHANGELOG.md
@@ -11,7 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The `TakenFromCanister` and `MetadataUpload` variants in `SnapshotSource` have been updated to use `candid:Reserved` inside.
+- Used `candid:Reserved` inside `TakenFromCanister` and `MetadataUpload` variants in `SnapshotSource`.
+- Renamed `MainMemory` to `WasmMemory` in `SnapshotDataKind` and `SnapshotDataOffset`.
+
+While this is technically a breaking change in the Rust type system, we are treating it as a patch fix.
+This is because the affected types and methods are for new, unreleased features (snapshot download/upload).
+Therefore, no existing services or canisters should be impacted by this change.
 
 ## [0.4.0] - 2025-08-25
 

--- a/ic-management-canister-types/CHANGELOG.md
+++ b/ic-management-canister-types/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Used `candid:Reserved` inside `TakenFromCanister` and `MetadataUpload` variants in `SnapshotSource`.
 - Renamed `MainMemory` to `WasmMemory` in `SnapshotDataKind` and `SnapshotDataOffset`.
+- Added `source` field to `LoadSnapshotRecord`.
 
 While this is technically a breaking change in the Rust type system, we are treating it as a patch fix.
 This is because the affected types and methods are for new, unreleased features (snapshot download/upload).

--- a/ic-management-canister-types/CHANGELOG.md
+++ b/ic-management-canister-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.4.1] - 2025-09-04
+
+### Fixed
+
+- The `TakenFromCanister` and `MetadataUpload` varaints in `SnapshotSource` have been updated to use `candid:Reserved` inside.
+
 ## [0.4.0] - 2025-08-25
 
 ### Changed

--- a/ic-management-canister-types/CHANGELOG.md
+++ b/ic-management-canister-types/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The `TakenFromCanister` and `MetadataUpload` varaints in `SnapshotSource` have been updated to use `candid:Reserved` inside.
+- The `TakenFromCanister` and `MetadataUpload` variants in `SnapshotSource` have been updated to use `candid:Reserved` inside.
 
 ## [0.4.0] - 2025-08-25
 

--- a/ic-management-canister-types/Cargo.toml
+++ b/ic-management-canister-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-management-canister-types"
-version = "0.4.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/ic-management-canister-types/src/lib.rs
+++ b/ic-management-canister-types/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-use candid::{CandidType, Nat, Principal};
+use candid::{CandidType, Nat, Principal, Reserved};
 use serde::{Deserialize, Serialize};
 
 /// # Canister ID.
@@ -1407,10 +1407,10 @@ pub struct ReadCanisterSnapshotMetadataResult {
 pub enum SnapshotSource {
     /// The snapshot was taken from a canister.
     #[serde(rename = "taken_from_canister")]
-    TakenFromCanister,
+    TakenFromCanister(Reserved),
     /// The snapshot was created by uploading metadata.
     #[serde(rename = "metadata_upload")]
-    MetadataUpload,
+    MetadataUpload(Reserved),
 }
 
 /// # An exported global variable.

--- a/ic-management-canister-types/src/lib.rs
+++ b/ic-management-canister-types/src/lib.rs
@@ -1480,9 +1480,9 @@ pub enum SnapshotDataKind {
         /// Size of the data in bytes.
         size: u64,
     },
-    /// Main memory.
-    #[serde(rename = "main_memory")]
-    MainMemory {
+    /// Wasm memory.
+    #[serde(rename = "wasm_memory")]
+    WasmMemory {
         /// Offset in bytes.
         offset: u64,
         /// Size of the data in bytes.
@@ -1567,9 +1567,9 @@ pub enum SnapshotDataOffset {
         /// Offset in bytes.
         offset: u64,
     },
-    /// Main memory.
-    #[serde(rename = "main_memory")]
-    MainMemory {
+    /// Wasm memory.
+    #[serde(rename = "wasm_memory")]
+    WasmMemory {
         /// Offset in bytes.
         offset: u64,
     },

--- a/ic-management-canister-types/src/lib.rs
+++ b/ic-management-canister-types/src/lib.rs
@@ -634,6 +634,8 @@ pub struct LoadSnapshotRecord {
     pub snapshot_id: SnapshotId,
     /// The timestamp at which the snapshot was taken.
     pub taken_at_timestamp: u64,
+    /// The source from which the snapshot was taken.
+    pub source: SnapshotSource,
 }
 
 /// # Controllers Change Record
@@ -1403,7 +1405,9 @@ pub struct ReadCanisterSnapshotMetadataResult {
 }
 
 /// # The source of a snapshot.
-#[derive(CandidType, Serialize, Deserialize, Debug, Clone)]
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
 pub enum SnapshotSource {
     /// The snapshot was taken from a canister.
     #[serde(rename = "taken_from_canister")]

--- a/ic-management-canister-types/tests/ic.did
+++ b/ic-management-canister-types/tests/ic.did
@@ -481,7 +481,7 @@ type read_canister_snapshot_data_args = record {
             offset : nat64;
             size : nat64;
         };
-        main_memory : record {
+        wasm_memory : record {
             offset : nat64;
             size : nat64;
         };
@@ -535,7 +535,7 @@ type upload_canister_snapshot_data_args = record {
         wasm_module : record {
             offset : nat64;
         };
-        main_memory : record {
+        wasm_memory : record {
             offset : nat64;
         };
         stable_memory : record {

--- a/ic-management-canister-types/tests/ic.did
+++ b/ic-management-canister-types/tests/ic.did
@@ -443,8 +443,8 @@ type read_canister_snapshot_metadata_args = record {
 
 type read_canister_snapshot_metadata_result = record {
     source : variant {
-        taken_from_canister;
-        metadata_upload;
+        taken_from_canister: reserved;
+        metadata_upload: reserved;
     };
     taken_at_timestamp : nat64;
     wasm_module_size : nat64;

--- a/ic-management-canister-types/tests/ic.did
+++ b/ic-management-canister-types/tests/ic.did
@@ -61,6 +61,10 @@ type change_details = variant {
         canister_version : nat64;
         snapshot_id : snapshot_id;
         taken_at_timestamp : nat64;
+        source : variant {
+            taken_from_canister : reserved;
+            metadata_upload : reserved;
+        };
     };
     // Deprecated: `settings_change` is used instead.
     controllers_change : record {


### PR DESCRIPTION
SDK-2307

# Description

- Added the `source` field in `LoadSnapshotRecord`.
- The `TakenFromCanister` and `MetadataUpload` variants in `SnapshotSource` have been updated to use `candid:Reserved` in [this pr](https://github.com/dfinity/ic/pull/6163).
- Followed up on the renaming from `main_memory` to `wasm_memory` in [this pr](https://github.com/dfinity/ic/pull/6420).
- Updated candid to `0.10.18`.
- Bumped `ic-management-canister-types` to `0.4.1`.

# How Has This Been Tested?

Updated the `ic.did` for `candid_equality_test`.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
