### PR TITLE
feat(bindgen): set type selector config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-13-large]
+        os: [ubuntu-24.04, macos-14-large]
       fail-fast: false
     steps:
       - name: Install Rust toolchain
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-13-large]
+        os: [ubuntu-24.04, macos-14-large]
       fail-fast: false
     steps:
       - name: Install Rust toolchain
@@ -93,7 +93,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-13-large]
+        os: [ubuntu-24.04, macos-14-large]
       fail-fast: false
     steps:
       - name: Install Rust toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14-large]
+        os: [ubuntu-24.04, macos-13-large]
       fail-fast: false
     steps:
       - name: Install Rust toolchain
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14-large]
+        os: [ubuntu-24.04, macos-13-large]
       fail-fast: false
     steps:
       - name: Install Rust toolchain
@@ -93,7 +93,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14-large]
+        os: [ubuntu-24.04, macos-13-large]
       fail-fast: false
     steps:
       - name: Install Rust toolchain

--- a/e2e-tests/build.rs
+++ b/e2e-tests/build.rs
@@ -9,6 +9,7 @@ fn main() {
         "management_canister",
         "../ic-management-canister-types/tests/ic.did",
     )
+    .set_type_selector_config("src/bin/bindgen_callee/management.toml")
     .static_callee(candid::Principal::management_canister())
     .generate();
     // Dynamic Callee mode bindgen for the bindgen_callee

--- a/e2e-tests/src/bin/bindgen_callee/management.toml
+++ b/e2e-tests/src/bin/bindgen_callee/management.toml
@@ -1,0 +1,2 @@
+[rust]
+blob.use_type = "Vec<u8>"

--- a/e2e-tests/src/bin/bindgen_callee/management.toml
+++ b/e2e-tests/src/bin/bindgen_callee/management.toml
@@ -1,2 +1,5 @@
 [rust]
+visibility = "pub(crate)"
+attributes = "#[derive(CandidType, Deserialize, Clone, Debug)]"
 blob.use_type = "Vec<u8>"
+change_details.variant.creation.name = "CreationRecord"

--- a/ic-cdk-bindgen/README.md
+++ b/ic-cdk-bindgen/README.md
@@ -92,7 +92,6 @@ Then, add the type selector configuration to your build script using `set_type_s
 // build.rs
 fn main() {
     ic_cdk_bindgen::Config::new("callee", "candid/callee.did")
-        .static_callee(CALLEE_CANISTER_ID)
         .set_type_selector_config("path/to/callee.toml")
         .dynamic_callee("ICP_CANISTER_ID:callee")
         .generate();

--- a/ic-cdk-bindgen/README.md
+++ b/ic-cdk-bindgen/README.md
@@ -38,7 +38,9 @@ mod callee {
 
 #[ic_cdk::update]
 async fn invoke_callee() {
-    let _result = callee::invoke().await;
+    // In modern IDE/editors like VSCode, you can often use "Go to Definition" or similar features
+    // to quickly navigate to the generated bindings.
+    let _result = callee::some_method().await;
 }
 ```
 
@@ -67,6 +69,40 @@ fn main() {
 ```
 
 Then the generated code will use the canister ID from the environment variable at runtime.
+
+## Type Selector Config
+
+The `candid` project specifies a "Type Selector" configuration language that controls the details of Rust code generation.
+You can use type selectors to customize how Candid types are translated to Rust types.
+
+First, add a `toml` file which has a `rust` map at the top level.
+
+```toml
+# callee.toml
+[rust]
+visibility = "pub(crate)"
+attributes = "#[derive(CandidType, Deserialize, Clone, Debug)]"
+blob.use_type = "Vec<u8>"
+change_details.variant.creation.name = "CreationRecord"
+```
+
+Next, invoke the `set_type_selector_config` method to set the path.
+
+```rust,no_run
+// build.rs
+fn main() {
+    ic_cdk_bindgen::Config::new("callee", "candid/callee.did")
+        .static_callee(CALLEE_CANISTER_ID)
+        .set_type_selector_config("path/to/callee.toml")
+        .dynamic_callee("ICP_CANISTER_ID:callee")
+        .generate();
+}
+```
+
+The updated bindings can be seen by using the "Go to definition" or similar features from your IDE/editors.
+
+For more details on type selector syntax and capabilities, refer to the [specification](https://github.com/dfinity/candid/blob/master/spec/Type-selector.md#rust-binding-configuration).
+
 
 ## Use with `dfx`
 

--- a/ic-cdk-bindgen/src/lib.rs
+++ b/ic-cdk-bindgen/src/lib.rs
@@ -129,13 +129,16 @@ impl Config {
     pub fn generate(&self) {
         // 0. Load type selector config if provided
         let type_selector_configs_str = match &self.type_selector_config_path {
-            Some(p) => fs::read_to_string(p).unwrap_or_else(|e| {
-                panic!(
-                    "failed to read the type selector config file ({}): {}",
-                    p.display(),
-                    e
-                )
-            }),
+            Some(p) => {
+                println!("cargo:rerun-if-changed={}", p.display());
+                fs::read_to_string(p).unwrap_or_else(|e| {
+                    panic!(
+                        "failed to read the type selector config file ({}): {}",
+                        p.display(),
+                        e
+                    )
+                })
+            }
             None => "".to_string(),
         };
         let type_selector_configs = Configs::from_str(&type_selector_configs_str)


### PR DESCRIPTION
SDK-2322

# Description

Use "type selector" config to customize how Candid types are translated to Rust types.

# How Has This Been Tested?

Added `management.toml` for the management canister bindgen in e2e.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
