### PR TITLE
chore: release bindgen v0.2.0-alpha.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ opt-level = 'z'
 [workspace.dependencies]
 ic0 = { path = "ic0", version = "1.0.1" }
 ic-cdk = { path = "ic-cdk", version = "0.19.0-beta.2" }
-ic-cdk-bindgen = { path = "ic-cdk-bindgen", version = "0.2.0-alpha.1" }
+ic-cdk-bindgen = { path = "ic-cdk-bindgen", version = "0.2.0-alpha.2" }
 ic-cdk-timers = { path = "ic-cdk-timers", version = "0.12.2" }
 ic-cdk-executor = { path = "ic-cdk-executor", version = "1.0.2" }
 ic-management-canister-types = { path = "ic-management-canister-types", version = "0.4.1" }

--- a/ic-cdk-bindgen/CHANGELOG.md
+++ b/ic-cdk-bindgen/CHANGELOG.md
@@ -13,6 +13,7 @@ The `ic-cdk-bindgen` crate introduces a completely redesigned API to integrate s
 - The bindgen now supports two modes:
   - `static_callee`: The canister ID is known at compile time.
   - `dynamic_callee`: The canister ID will be fetched via ICP environment variables at runtime.
+- The "Type Selector" config can be set to customize how Candid types are translated to Rust types.
 - Removed implicit handling of `dfx` environment variables. See the "Use with `dfx`" section in the crate documentation for more info.
 
 ## [0.1.3] - 2024-02-27

--- a/ic-cdk-bindgen/Cargo.toml
+++ b/ic-cdk-bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-bindgen"
-version = "0.2.0-alpha.1"
+version = "0.2.0-alpha.2"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
This PR is for cutting the release to ship the "Type Selector config" feature (merged in #663).