### PR TITLE
feat: ic-cdk and ic-cdk-macros v0.20.2 — interpret empty vector as candid encoding of ()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 # Crates of this workspace
-ic-cdk = { path = "ic-cdk", version = "0.20.1" }
+ic-cdk = { path = "ic-cdk", version = "0.20.2" }
 ic-cdk-bindgen = { path = "ic-cdk-bindgen", version = "0.2.0" }
 ic-cdk-bitcoin-canister = { path = "ic-cdk-bitcoin-canister", version = "0.2.0" }
 ic-cdk-executor = { path = "ic-cdk-executor", version = "2.0.0" }
-ic-cdk-macros = { path = "ic-cdk-macros", version = "=0.20.1" }
+ic-cdk-macros = { path = "ic-cdk-macros", version = "=0.20.2" }
 ic-cdk-management-canister = { path = "ic-cdk-management-canister", version = "0.1.1" }
 ic-cdk-timers = { path = "ic-cdk-timers", version = "1.0.0" }
 ic-management-canister-types = "0.7.1"

--- a/e2e-tests/src/bin/macros/main.rs
+++ b/e2e-tests/src/bin/macros/main.rs
@@ -1,4 +1,4 @@
-use ic_cdk::{export_candid, update};
+use ic_cdk::{export_candid, query, update};
 use prost::Message;
 use std::marker::PhantomData;
 
@@ -145,6 +145,12 @@ fn guard2() -> Result<(), String> {
 #[update]
 fn default_skipping_quota(_arg: Option<u32>) {}
 
+#[update]
+fn foo_update(_x: Option<u64>) {}
+
+#[query]
+fn foo_query(_x: Option<u64>) {}
+
 export_candid! {}
 
 fn main() {
@@ -172,6 +178,8 @@ mod tests {
             manual_reply : () -> (nat32);
             with_guards : () -> ();
             default_skipping_quota : (opt nat32) -> ();
+            foo_update : (opt nat64) -> ();
+            foo_query : (opt nat64) -> () query;
           }";
         let expected_candid = CandidSource::Text(expected);
 

--- a/e2e-tests/tests/macros.rs
+++ b/e2e-tests/tests/macros.rs
@@ -9,6 +9,7 @@ use canister::*;
 mod test_utilities;
 use test_utilities::{cargo_build_canister, pic_base, update};
 
+
 #[test]
 fn call_macros() {
     let wasm = cargo_build_canister("macros");
@@ -99,4 +100,11 @@ fn call_macros() {
             .reject_message
             .contains("Skipping cost exceeds the limit")
     );
+
+    // vec![] (empty binary) must be accepted as if it were the Candid encoding of ()
+    // for any input args list, not just for methods with no arguments.
+    pic.update_call(canister_id, sender, "foo_update", vec![])
+        .unwrap();
+    pic.query_call(canister_id, sender, "foo_query", vec![])
+        .unwrap();
 }

--- a/e2e-tests/tests/macros.rs
+++ b/e2e-tests/tests/macros.rs
@@ -9,7 +9,6 @@ use canister::*;
 mod test_utilities;
 use test_utilities::{cargo_build_canister, pic_base, update};
 
-
 #[test]
 fn call_macros() {
     let wasm = cargo_build_canister("macros");

--- a/ic-cdk-macros/Cargo.toml
+++ b/ic-cdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk-macros"
-version = "0.20.1" # sync with ic-cdk
+version = "0.20.2" # sync with ic-cdk
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ic-cdk-macros/src/export.rs
+++ b/ic-cdk-macros/src/export.rs
@@ -254,6 +254,7 @@ fn dfn_macro(
     } else {
         quote! {
             let arg_bytes = #cratename::api::msg_arg_data();
+            let arg_bytes = if arg_bytes.is_empty() { b"DIDL\x00\x00".to_vec() } else { arg_bytes };
             let mut decoder_config = ::candid::DecoderConfig::new();
             decoder_config.set_skipping_quota(10000);
             let ( #( #arg_tuple, )* ) = ::candid::utils::decode_args_with_config(&arg_bytes, &decoder_config).unwrap();
@@ -576,6 +577,7 @@ mod test {
             fn #fn_name() {
                 ::ic_cdk::futures::internals::in_query_executor_context(|| {
                     let arg_bytes = ::ic_cdk::api::msg_arg_data();
+                    let arg_bytes = if arg_bytes.is_empty() { b"DIDL\x00\x00".to_vec() } else { arg_bytes };
                     let mut decoder_config = ::candid::DecoderConfig::new();
                     decoder_config.set_skipping_quota(10000);
                     let (a,) = ::candid::utils::decode_args_with_config(&arg_bytes, &decoder_config).unwrap();
@@ -615,6 +617,7 @@ mod test {
             fn #fn_name() {
                 ::ic_cdk::futures::internals::in_query_executor_context(|| {
                     let arg_bytes = ::ic_cdk::api::msg_arg_data();
+                    let arg_bytes = if arg_bytes.is_empty() { b"DIDL\x00\x00".to_vec() } else { arg_bytes };
                     let mut decoder_config = ::candid::DecoderConfig::new();
                     decoder_config.set_skipping_quota(10000);
                     let (a, b,) = ::candid::utils::decode_args_with_config(&arg_bytes, &decoder_config).unwrap();
@@ -654,6 +657,7 @@ mod test {
             fn #fn_name() {
                 ::ic_cdk::futures::internals::in_query_executor_context(|| {
                     let arg_bytes = ::ic_cdk::api::msg_arg_data();
+                    let arg_bytes = if arg_bytes.is_empty() { b"DIDL\x00\x00".to_vec() } else { arg_bytes };
                     let mut decoder_config = ::candid::DecoderConfig::new();
                     decoder_config.set_skipping_quota(10000);
                     let (a, b,) = ::candid::utils::decode_args_with_config(&arg_bytes, &decoder_config).unwrap();

--- a/ic-cdk-macros/src/export.rs
+++ b/ic-cdk-macros/src/export.rs
@@ -254,10 +254,10 @@ fn dfn_macro(
     } else {
         quote! {
             let arg_bytes = #cratename::api::msg_arg_data();
-            let arg_bytes = if arg_bytes.is_empty() { b"DIDL\x00\x00".to_vec() } else { arg_bytes };
+            let arg_bytes: &[u8] = if arg_bytes.is_empty() { b"DIDL\x00\x00" } else { &arg_bytes };
             let mut decoder_config = ::candid::DecoderConfig::new();
             decoder_config.set_skipping_quota(10000);
-            let ( #( #arg_tuple, )* ) = ::candid::utils::decode_args_with_config(&arg_bytes, &decoder_config).unwrap();
+            let ( #( #arg_tuple, )* ) = ::candid::utils::decode_args_with_config(arg_bytes, &decoder_config).unwrap();
         }
     };
 
@@ -577,10 +577,10 @@ mod test {
             fn #fn_name() {
                 ::ic_cdk::futures::internals::in_query_executor_context(|| {
                     let arg_bytes = ::ic_cdk::api::msg_arg_data();
-                    let arg_bytes = if arg_bytes.is_empty() { b"DIDL\x00\x00".to_vec() } else { arg_bytes };
+                    let arg_bytes: &[u8] = if arg_bytes.is_empty() { b"DIDL\x00\x00" } else { &arg_bytes };
                     let mut decoder_config = ::candid::DecoderConfig::new();
                     decoder_config.set_skipping_quota(10000);
-                    let (a,) = ::candid::utils::decode_args_with_config(&arg_bytes, &decoder_config).unwrap();
+                    let (a,) = ::candid::utils::decode_args_with_config(arg_bytes, &decoder_config).unwrap();
                     let result = query(a);
                     let bytes: Vec<u8> = ::candid::utils::encode_one(()).unwrap();
                     ::ic_cdk::api::msg_reply(bytes);
@@ -617,10 +617,10 @@ mod test {
             fn #fn_name() {
                 ::ic_cdk::futures::internals::in_query_executor_context(|| {
                     let arg_bytes = ::ic_cdk::api::msg_arg_data();
-                    let arg_bytes = if arg_bytes.is_empty() { b"DIDL\x00\x00".to_vec() } else { arg_bytes };
+                    let arg_bytes: &[u8] = if arg_bytes.is_empty() { b"DIDL\x00\x00" } else { &arg_bytes };
                     let mut decoder_config = ::candid::DecoderConfig::new();
                     decoder_config.set_skipping_quota(10000);
-                    let (a, b,) = ::candid::utils::decode_args_with_config(&arg_bytes, &decoder_config).unwrap();
+                    let (a, b,) = ::candid::utils::decode_args_with_config(arg_bytes, &decoder_config).unwrap();
                     let result = query(a, b);
                     let bytes: Vec<u8> = ::candid::utils::encode_one(()).unwrap();
                     ::ic_cdk::api::msg_reply(bytes);
@@ -657,10 +657,10 @@ mod test {
             fn #fn_name() {
                 ::ic_cdk::futures::internals::in_query_executor_context(|| {
                     let arg_bytes = ::ic_cdk::api::msg_arg_data();
-                    let arg_bytes = if arg_bytes.is_empty() { b"DIDL\x00\x00".to_vec() } else { arg_bytes };
+                    let arg_bytes: &[u8] = if arg_bytes.is_empty() { b"DIDL\x00\x00" } else { &arg_bytes };
                     let mut decoder_config = ::candid::DecoderConfig::new();
                     decoder_config.set_skipping_quota(10000);
-                    let (a, b,) = ::candid::utils::decode_args_with_config(&arg_bytes, &decoder_config).unwrap();
+                    let (a, b,) = ::candid::utils::decode_args_with_config(arg_bytes, &decoder_config).unwrap();
                     let result = query(a, b);
                     let bytes: Vec<u8> = ::candid::utils::encode_one(result).unwrap();
                     ::ic_cdk::api::msg_reply(bytes);

--- a/ic-cdk/CHANGELOG.md
+++ b/ic-cdk/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-### Fixed
+### Changed
 
-- Update, query, `init`, and `post_upgrade` canister entry points now interpret an empty input vector as a Candid encoding of `()`, making them more lenient when no arguments are provided.
+- Update, query, `init`, and `post_upgrade` canister entry points now interpret an empty input vector as the Candid encoding of `()`, making them more lenient when no arguments are provided. This does not apply to methods using `decode_with`, which still receive the raw (empty) bytes.
 
 ## [0.20.1] - 2026-04-20
 

--- a/ic-cdk/CHANGELOG.md
+++ b/ic-cdk/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+
+- Update, query, `init`, and `post_upgrade` canister entry points now interpret an empty input vector as a Candid encoding of `()`, making them more lenient when no arguments are provided.
+
 ## [0.20.1] - 2026-04-20
 
 ### Added

--- a/ic-cdk/CHANGELOG.md
+++ b/ic-cdk/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.20.2] - 2026-06-08
+
 ### Changed
 
 - Update, query, `init`, and `post_upgrade` canister entry points now interpret an empty input vector as the Candid encoding of `()`, making them more lenient when no arguments are provided. This does not apply to methods using `decode_with`, which still receive the raw (empty) bytes.

--- a/ic-cdk/Cargo.toml
+++ b/ic-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-cdk"
-version = "0.20.1" # sync with ic-cdk-macros
+version = "0.20.2" # sync with ic-cdk-macros
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
# Description

This PR fixes the CDK macros for update, query, `init`, and `post_upgrade` methods to interpret an empty input vector as the Candid encoding of `()` even if the method has a non-empty argument list. The motivation is to allow passing an empty input vector to method taking optional arguments and have them be decoded to `None` by default.

This PR also releases **ic-cdk** and **ic-cdk-macros** **v0.20.2** (version bumps in the workspace + crate manifests and the corresponding `ic-cdk` CHANGELOG entry).

# How Has This Been Tested?

New integration tests have been introduced.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.